### PR TITLE
Update JNI version 22.04.0-SNAPSHOT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "thirdparty/cudf"]
 	path = thirdparty/cudf
 	url = https://github.com/rapidsai/cudf.git
-	branch = branch-22.02
+	branch = branch-22.04

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.nvidia</groupId>
   <artifactId>spark-rapids-jni-parent</artifactId>
-  <version>22.02.0-SNAPSHOT</version>
+  <version>22.04.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>RAPIDS Accelerator JNI for Apache Spark Root Project</name>
   <description>

--- a/spark-rapids-cudf/pom.xml
+++ b/spark-rapids-cudf/pom.xml
@@ -22,10 +22,10 @@
   <parent>
     <groupId>com.nvidia</groupId>
     <artifactId>spark-rapids-jni-parent</artifactId>
-    <version>22.02.0-SNAPSHOT</version>
+    <version>22.04.0-SNAPSHOT</version>
   </parent>
   <artifactId>spark-rapids-cudf</artifactId>
-  <version>22.02.0-SNAPSHOT</version>
+  <version>22.04.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>RAPIDS Accelerator cudf</name>
   <description>RAPIDS cuDF customized for the RAPIDS Accelerator for Apache Spark</description>

--- a/spark-rapids-jni/pom.xml
+++ b/spark-rapids-jni/pom.xml
@@ -22,10 +22,10 @@
   <parent>
     <groupId>com.nvidia</groupId>
     <artifactId>spark-rapids-jni-parent</artifactId>
-    <version>22.02.0-SNAPSHOT</version>
+    <version>22.04.0-SNAPSHOT</version>
   </parent>
   <artifactId>rapids-4-spark-jni</artifactId>
-  <version>22.02.0-SNAPSHOT</version>
+  <version>22.04.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>RAPIDS Accelerator JNI for Apache Spark</name>
   <description>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Update jni version to 22.04.0-SNAPSHOT,
also update submodule remote and commit to HEAD of cudf 22.04

since we will not release jni 22.02, all nightly pipelines will be directly targeted to 22.04 after merged