### PR TITLE
Use release build for spark-rapids-jni by default

### DIFF
--- a/spark-rapids-jni/src/main/cpp/CMakeLists.txt
+++ b/spark-rapids-jni/src/main/cpp/CMakeLists.txt
@@ -65,6 +65,9 @@ set(CUDF_DIR
   CACHE STRING "path to cudf repository"
 )
 
+# Set a default build type if none was specified
+rapids_cmake_build_type("Release")
+
 # ##################################################################################################
 # * compiler options ------------------------------------------------------------------------------
 rapids_find_package(CUDAToolkit REQUIRED)


### PR DESCRIPTION
The spark-rapids-jni build was not specifying a default build type, so it could build in Debug mode.  This changes the default build mode for spark-rapids-jni to be a Release build.