### PR TITLE
[auto-merge] bot-auto-merge-branch-22.04 to branch-22.06 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,12 +18,12 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-      - branch-22.02
+      - branch-22.04
     types: [closed]
 
 env:
-  HEAD: branch-22.02
-  BASE: branch-22.04
+  HEAD: branch-22.04
+  BASE: branch-22.06
 
 jobs:
   auto-merge:


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.04` to create a PR keeping `branch-22.06` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.