### PR TITLE
Disable cufile test in build

### DIFF
--- a/build-libcudf.xml
+++ b/build-libcudf.xml
@@ -46,8 +46,6 @@
       <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}" />
       <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
       <arg value="-DUSE_GDS=${USE_GDS}" />
-      <!-- build GDS only but exclude CuFileTest which requires specific devices -->
-      <arg value="-Dtest=*,!CuFileTest" />
     </exec>
 
     <exec dir="${libcudf.build.path}"

--- a/build-libcudf.xml
+++ b/build-libcudf.xml
@@ -45,7 +45,7 @@
       <arg value="-DCUDF_USE_ARROW_STATIC=ON"/>
       <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}" />
       <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
-      <arg value="-DUSE_GDS=${USE_GDS}" />
+      <arg value="-DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest" />
     </exec>
 
     <exec dir="${libcudf.build.path}"

--- a/build-libcudf.xml
+++ b/build-libcudf.xml
@@ -45,7 +45,9 @@
       <arg value="-DCUDF_USE_ARROW_STATIC=ON"/>
       <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}" />
       <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
-      <arg value="-DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest" />
+      <arg value="-DUSE_GDS=${USE_GDS}" />
+      <!-- build GDS only but exclude CuFileTest which requires specific devices -->
+      <arg value="-Dtest=*,!CuFileTest" />
     </exec>
 
     <exec dir="${libcudf.build.path}"

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,8 @@
                   <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}"/>
                   <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}"/>
                   <arg value="-DUSE_GDS=${USE_GDS}"/>
+                  <!-- build GDS only but exclude CuFileTest which requires specific devices -->
+                  <arg value="-Dtest=*,!CuFileTest" />
                 </exec>
                 <exec dir="${libcudfjni.build.path}"
                       failonerror="true"


### PR DESCRIPTION
Enable USE_GDS for cudfjni build will introduce cufile test which required specific devices.

Temp workaround to not run CuFileTest