### PR TITLE
Add spark-rapids-jni-version-info.properties

### DIFF
--- a/build/build-info
+++ b/build/build-info
@@ -28,10 +28,10 @@ echo_build_properties() {
   shift 2
   echo version=$version
   echo user=$USER
-  echo revision=$(git -C "$git_path" rev-parse HEAD)
-  echo branch=$(git -C "$git_path" rev-parse --abbrev-ref HEAD)
+  echo revision=$(cd "$git_path" && git rev-parse HEAD)
+  echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo url=$(git -C "$git_path" config --get remote.origin.url)
+  echo url=$(cd "$git_path" && git config --get remote.origin.url)
   for arg in "$@"; do
     echo $arg
   done

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,13 @@
                   <arg value="${project.version}"/>
                   <arg value="${cudf.path}"/>
                 </exec>
+                <exec executable="bash"
+                      output="${project.build.directory}/extra-resources/spark-rapids-jni-version-info.properties"
+                      failonerror="true">
+                  <arg value="${project.basedir}/build/build-info"/>
+                  <arg value="${project.version}"/>
+                  <arg value="${project.basedir}"/>
+                </exec>
               </target>
             </configuration>
             <goals>


### PR DESCRIPTION
This adds a spark-rapids-jni-version-info.properties file to the jar to capture the git information of the repository separate from the cudf version info, which is kept for backwards-compatibility.

In addition the build-info script was updated to handle older git versions that do not support the `-C` flag.