### PR TITLE
Add source-javadoc profile

### DIFF
--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -23,6 +23,7 @@ git submodule update --init --recursive
 
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 mvn clean package ${MVN_MIRROR}  \
+  -Psource-javadoc \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=ON -Dtest=*,!CuFileTest

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,45 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>source-javadoc</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>attach-source</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadoc</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <doclint>none</doclint>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Part of https://github.com/NVIDIA/spark-rapids-jni/issues/16

Add source-javadoc profile, also deploy javadoc and source artifacts in nightly build. Verified internally