### PR TITLE
Fix invalid yum repo in ci/Dockerfile [skip ci]

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -27,6 +27,7 @@ FROM gpuci/cuda:$CUDA_VERSION-devel-centos7
 RUN yum install -y centos-release-scl
 RUN yum install -y devtoolset-9 rh-python38 epel-release
 RUN yum install -y zlib-devel maven tar wget patch ninja-build
+# require git 2.18+ to keep consistent submodule operations
 RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && yum install -y git
 RUN scl enable rh-python38 "pip install requests"
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -27,7 +27,7 @@ FROM gpuci/cuda:$CUDA_VERSION-devel-centos7
 RUN yum install -y centos-release-scl
 RUN yum install -y devtoolset-9 rh-python38 epel-release
 RUN yum install -y zlib-devel maven tar wget patch ninja-build
-RUN yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && yum install -y git
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && yum install -y git
 RUN scl enable rh-python38 "pip install requests"
 
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

we require git 2.18+ for CI submodule operations,
The previous yum repo in dockerfile become invalid, updated it to latest one.

Verified working locally.