### PR TITLE
Use ccache in build-in-docker by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ Due to the lengthy build of libcudf, it is **not cleaned** during a normal Maven
 unless built using `build/build-in-docker`. `build/build-in-docker` uses `ccache` by default
 unless CCACHE_DISABLE=1 is set in the environment.
 
-Boolean property `-Dlibcudf.clean.skip=false` can also be set manually to clean libcudf
-build area in addition to the normal clean of `target/` directories.
+`-Dlibcudf.clean.skip=false` can also be specified on the Maven command-line to force
+libcudf to be cleaned during the Maven clean phase.
 
 Currently libcudf is only configured once and the build relies on cmake to re-configure as needed.
 This is because libcudf currently is rebuilding almost entirely when it is configured with the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,12 @@ so it should be invoked as one would invoke Maven, e.g.: `build/build-in-docker 
 ### cudf Submodule and Build
 
 [RAPIDS cuDF](https://github.com/rapidsai/cudf) is being used as a submodule in this project.
-Due to the lengthy build of libcudf, it is **not cleaned** during a normal Maven clean phase.
-Use `-Dlibcudf.clean.skip=true` to clean the libcudf build area in addition to the normal clean
-of `target/` directories.
+Due to the lengthy build of libcudf, it is **not cleaned** during a normal Maven clean phase
+unless built using `build/build-in-docker`. `build/build-in-docker` uses `ccache` by default
+unless CCACHE_DISABLE=1 is set in the environment.
+
+Boolean property `-Dlibcudf.clean.skip=false` can also be set manually to clean libcudf
+build area in addition to the normal clean of `target/` directories.
 
 Currently libcudf is only configured once and the build relies on cmake to re-configure as needed.
 This is because libcudf currently is rebuilding almost entirely when it is configured with the same

--- a/build-libcudf.xml
+++ b/build-libcudf.xml
@@ -36,6 +36,7 @@
           executable="cmake"
           if:true="${needConfigure}">
       <arg value="${cudf.path}/cpp"/>
+      <arg line="${cmake.ccache.opts}"/>
       <arg value="-DBUILD_SHARED_LIBS=OFF"/>
       <arg value="-DBUILD_TESTS=OFF"/>
       <arg value="-DCMAKE_CUDA_ARCHITECTURES=${GPU_ARCHS}"/>

--- a/build/build-in-docker
+++ b/build/build-in-docker
@@ -46,6 +46,25 @@ $DOCKER_CMD build -f $REPODIR/thirdparty/cudf/java/ci/Dockerfile.centos7 \
   -t $IMAGE_NAME \
   $REPODIR/thirdparty/cudf/java/ci
 
+CCACHE_OPTS=(
+  "-DCMAKE_C_COMPILER_LAUNCHER=ccache"
+  "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  "-DCMAKE_CUDA_COMPILER_LAUNCHER=ccache"
+  "-DCMAKE_CXX_LINKER_LAUNCHER=ccache"
+)
+
+_CUDF_CLEAN_SKIP=""
+# if ccache is enabled and libcudf.clean.skip not provided
+# by the user remove the cpp build directory
+#
+if [[ "$CCACHE_DISABLE" != "1" ]]; then
+  if [[ ! "$*" =~ " -Dlibcudf.clean.skip=" ]]; then
+    # Don't skip clean if ccache is enabled
+    # unless the user overrides
+    _CUDF_CLEAN_SKIP="-Dlibcudf.clean.skip=false"
+  fi
+fi
+
 $DOCKER_CMD run -it -u $(id -u):$(id -g) --rm \
   -v "/etc/group:/etc/group:ro" \
   -v "/etc/passwd:/etc/passwd:ro" \
@@ -53,14 +72,18 @@ $DOCKER_CMD run -it -u $(id -u):$(id -g) --rm \
   -v "/etc/sudoers.d:/etc/sudoers.d:ro" \
   -v "$REPODIR:$WORKSPACE_REPODIR:rw" \
   -v "$LOCAL_MAVEN_REPO:$WORKSPACE_MAVEN_REPODIR:rw" \
+  -v "$HOME/.ccache:$HOME/.ccache:rw" \
   --workdir "$WORKSPACE_REPODIR" \
   -e CMAKE_GENERATOR="$CMAKE_GENERATOR" \
   -e CUDA_VISIBLE_DEVICES \
   -e PARALLEL_LEVEL \
   -e VERBOSE \
+  -e CCACHE_DISABLE \
   $IMAGE_NAME \
   scl enable devtoolset-9 "mvn \
     -Dmaven.repo.local=$WORKSPACE_MAVEN_REPODIR \
     -DPER_THREAD_DEFAULT_STREAM=$PER_THREAD_DEFAULT_STREAM \
     -DUSE_GDS=$USE_GDS \
+    -Dcmake.ccache.opts=\"${CCACHE_OPTS[*]}\" \
+    "$_CUDF_CLEAN_SKIP" \
     $*"

--- a/build/build-in-docker
+++ b/build/build-in-docker
@@ -85,5 +85,5 @@ $DOCKER_CMD run -it -u $(id -u):$(id -g) --rm \
     -DPER_THREAD_DEFAULT_STREAM=$PER_THREAD_DEFAULT_STREAM \
     -DUSE_GDS=$USE_GDS \
     -Dcmake.ccache.opts=\"${CCACHE_OPTS[*]}\" \
-    "$_CUDF_CLEAN_SKIP" \
+    $_CUDF_CLEAN_SKIP \
     $*"

--- a/build/build-in-docker
+++ b/build/build-in-docker
@@ -74,11 +74,11 @@ $DOCKER_CMD run -it -u $(id -u):$(id -g) --rm \
   -v "$LOCAL_MAVEN_REPO:$WORKSPACE_MAVEN_REPODIR:rw" \
   -v "$HOME/.ccache:$HOME/.ccache:rw" \
   --workdir "$WORKSPACE_REPODIR" \
+  -e CCACHE_DISABLE \
   -e CMAKE_GENERATOR="$CMAKE_GENERATOR" \
   -e CUDA_VISIBLE_DEVICES \
   -e PARALLEL_LEVEL \
   -e VERBOSE \
-  -e CCACHE_DISABLE \
   $IMAGE_NAME \
   scl enable devtoolset-9 "mvn \
     -Dmaven.repo.local=$WORKSPACE_MAVEN_REPODIR \

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.30</slf4j.version>
     <submodule.check.skip>false</submodule.check.skip>
+    <cmake.ccache.opts/>
   </properties>
 
   <dependencies>
@@ -260,6 +261,7 @@
                   <env key="CUDF_CPP_BUILD_DIR" value="${libcudf.build.path}"/>
                   <env key="CUDF_ROOT" value="${cudf.path}"/>
                   <arg value="${cudf.path}/java/src/main/native"/>
+                  <arg line="${cmake.ccache.opts}"/>
                   <arg value="-DBUILD_SHARED_LIBS=OFF"/>
                   <arg value="-DCUDA_STATIC_RUNTIME=ON"/>
                   <arg value="-DCUDF_JNI_LIBCUDF_STATIC=ON"/>


### PR DESCRIPTION
This PR enables `ccache` in build-in-docker script by default, closes #222. 

A repeated no-change build with the native build dir cleaned is ~90 seconds
A repeated no-change build without removing the native build dir is ~30 seconds

The PR proposes to change the default to not skipping the clean of libcudf build unless CCACHE_DISABLE=1 is set.

Manual override of `libcudf.clean.skip` is honored.
 
Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
