### PR TITLE
Return mvn status code at the end in submodule sync script [skip ci]

### DIFF
--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -69,11 +69,11 @@ mvn verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=ON -Dtest=*,!CuFileTest
-ret="$?"
+verify_status=$?
 set -e
 
 test_pass="False"
-if [[ "${ret}" == "0" ]]; then
+if [[ "${verify_status}" == "0" ]]; then
   echo "Test passed, will try merge the change"
   test_pass="True"
 else
@@ -95,3 +95,5 @@ $WORKSPACE/.github/workflows/action-helper/python/submodule-sync \
   --token=${GIT_TOKEN} \
   --passed=${test_pass} \
   --delete_head=True
+
+exit $verify_status # always exit return code of mvn verify at the end


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

To only put the mvn test status of submodule sync in PR may not be enough.
Let's also reflect the actual test run status in the internal slack channel for corresponding pipeline, 
so people could get notified from more sources.