### PR TITLE
Copy nvcomp-2.3 shared libs from the cudfjni build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,14 @@
                     <include>libcufilejni.so</include>
                   </includes>
                 </resource>
+                <resource>
+                  <directory>${libcudfjni.build.path}</directory>
+                  <includes>
+                    <include>libnvcomp.so</include>
+                    <include>libnvcomp_gdeflate.so</include>
+                    <include>libnvcomp_bitcomp.so</include>
+                  </includes>
+                </resource>
               </resources>
             </configuration>
           </execution>


### PR DESCRIPTION
Add support for building with the nvcomp-2.3 shared libraries release.
Most of the work for supporting nvcomp-2.3 is in related cudf PR: [10837](https://github.com/rapidsai/cudf/pull/10837).  For spark-rapids-jni, all we have to do is copy the shared libraries from that build so they can be included in the resulting jar file.

NOTE: we should not merge this until the CUDF support is finalized.  It is possible that changes on the CUDF side might require changes here as well.  For this reason, I am filing this as a draft PR.