### PR TITLE
Add lib to HINTS for libparquet

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -105,6 +105,7 @@ find_library(CUDFJNI_LIB "libcudfjni.a" REQUIRED NO_DEFAULT_PATH
 # parquet
 find_library(PARQUET_LIB "libparquet.a" REQUIRED NO_DEFAULT_PATH
   HINTS "${PROJECT_BINARY_DIR}/../libcudf-install/lib64"
+  HINTS "${PROJECT_BINARY_DIR}/../libcudf-install/lib"
 )
 
 # Internal parquet headers


### PR DESCRIPTION
Add hints for 32bit system to find libparquet. 

I tried to build spark-rapids-jni on my local machine. I got the a CMake error: could not find `libparquet.a`. Then, I checked the build directionary `./target/libcudf-install` and found `libparquet.a` is in the folder `./target/libcudf-install/lib` instead of `./target/libcudf-install/lib64` along with other static libs.

Signed-off-by: sperlingxx <lovedreamf@gmail.com>