### PR TITLE
Exclude CuFileTest unless user specifies -DUSE_GDS=ON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,27 @@
 
   <profiles>
     <profile>
+      <id>no-cufile-tests</id>
+      <activation>
+        <property>
+          <name>USE_GDS</name>
+          <value>!ON</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/CuFileTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>source-javadoc</id>
       <build>
         <plugins>


### PR DESCRIPTION
This updates the spark-rapids-jni pom to exclude CuFileTest unless the `USE_GDS` property is `ON`.  The cudf pom has the same logic, and this updates the spark-rapids-jni pom to match that behavior.