### PR TITLE
moving rapids cmake include to pull from rapids version

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -14,11 +14,7 @@
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake
-)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-
+include(../../../thirdparty/cudf/fetch_rapids.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)


### PR DESCRIPTION
I noticed today that the cmake file was pulling an out of date RAPIDS.cmake and upon some investigation I found that cudf had moved this functionality into a file in the root directory. Changing this to pull the cmake file from cudf instead of trying to roll the version as cudf changes.

I wanted to use `${CUDF_DIR}`, but I couldn't get it to work as I believe `${PROJECT_BINARY_DIR}` is not initialized this early.