### PR TITLE
[auto-merge] bot-auto-merge-branch-22.06 to branch-22.08 [skip ci] [bot]

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -14,11 +14,7 @@
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake
-)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-
+include(../../../thirdparty/cudf/fetch_rapids.cmake)
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.06` to create a PR keeping `branch-22.08` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.