### PR TITLE
Run CudaFatalTest as a separate forked test

### DIFF
--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -26,4 +26,4 @@ mvn clean package ${MVN_MIRROR}  \
   -Psource-javadoc \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -25,4 +25,4 @@ PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 mvn verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -68,7 +68,7 @@ set +e
 mvn verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest
 verify_status=$?
 set -e
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,11 +166,20 @@
         <plugins>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>**/CuFileTest.java</exclude>
-              </excludes>
-            </configuration>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <excludes>
+                    <exclude>**/CuFileTest.java</exclude>
+                    <exclude>**/CudaFatalTest.java</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
@@ -448,7 +457,36 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
           </dependency>
+          <dependency>
+            <!-- workaround for bug https://github.com/junit-team/junit5/issues/1367 -->
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-logger-api</artifactId>
+            <version>2.21.0</version>
+          </dependency>
         </dependencies>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/CudaFatalTest.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>fatal-cuda-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <reuseForks>false</reuseForks>
+              <test>CudaFatalTest</test>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Fixes #319.

Adds a separate test execution for CudaFatalTest so it runs without reusing the JVM in a separate execution.  This prevents the fatal CUDA exception generated in that test from spreading into subsequent tests.