### PR TITLE
Add CUDA::cudart_static to the link line for libcufilejni

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -218,5 +218,6 @@ if(USE_GDS)
     -Wl,--no-whole-archive
     spark_rapids_jni
     ${cuFile_LIBRARIES}
+    CUDA::cudart_static
   )
 endif()


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

When compiling with nvcomp libraries that link with the static cudart, the ai.rapids.cudf.CuFileTest started to fail with the following dump:

`/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64/jre/bin/java: symbol lookup error: /tmp/cufilejni2743598080003698811.so: undefined symbol: cudaGetLastError`

 Robert Maynard suggested the fix.