### PR TITLE
Compile benchmarks without building cudf benchmarks

### DIFF
--- a/build-libcudf.xml
+++ b/build-libcudf.xml
@@ -41,7 +41,6 @@
       <!-- benchmarks in cudf have to be built in order to get the library used
            for data generation to build in cudf so that benchmarks in
            spark-rapids-jni can link to it. -->
-      <arg value="-DBUILD_BENCHMARKS=${BUILD_BENCHMARKS}"/>
       <arg value="-DCMAKE_CUDA_ARCHITECTURES=${GPU_ARCHS}"/>
       <arg value="-DCMAKE_INSTALL_PREFIX=${libcudf.install.path}"/>
       <arg value="-DCUDA_STATIC_RUNTIME=ON"/>

--- a/build-libcudf.xml
+++ b/build-libcudf.xml
@@ -38,9 +38,6 @@
       <arg value="${cudf.path}/cpp"/>
       <arg value="-DBUILD_SHARED_LIBS=OFF"/>
       <arg value="-DBUILD_TESTS=OFF"/>
-      <!-- benchmarks in cudf have to be built in order to get the library used
-           for data generation to build in cudf so that benchmarks in
-           spark-rapids-jni can link to it. -->
       <arg value="-DCMAKE_CUDA_ARCHITECTURES=${GPU_ARCHS}"/>
       <arg value="-DCMAKE_INSTALL_PREFIX=${libcudf.install.path}"/>
       <arg value="-DCUDA_STATIC_RUNTIME=ON"/>

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -14,20 +14,20 @@
 # limitations under the License.
 #=============================================================================
 
-add_library(CUDF_DATAGEN STATIC common/generate_input.cu)
-target_compile_features(CUDF_DATAGEN PUBLIC cxx_std_17 cuda_std_17)
+add_library(DATAGEN_LIB STATIC common/generate_input.cu)
+target_compile_features(DATAGEN_LIB PUBLIC cxx_std_17 cuda_std_17)
 
 target_compile_options(
-  CUDF_DATAGEN PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${SPARK_RAPIDS_JNI_CXX_FLAGS}>"
+  DATAGEN_LIB PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${SPARK_RAPIDS_JNI_CXX_FLAGS}>"
                       "$<$<COMPILE_LANGUAGE:CUDA>:${SPARK_RAPIDS_JNI_CUDA_FLAGS}>"
 )
 
 target_link_libraries(
-  CUDF_DATAGEN PUBLIC cudf::cudf 
+  DATAGEN_LIB PUBLIC cudf::cudf 
 )
 
 target_include_directories(
-  CUDF_DATAGEN
+  DATAGEN_LIB
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" "$<BUILD_INTERFACE:${CUDF_DIR}/cpp>"
          "$<BUILD_INTERFACE:${CUDF_DIR}/cpp/include>"
 )
@@ -55,7 +55,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
                    CUDA_STANDARD 17
                    CUDA_STANDARD_REQUIRED ON
         )
-    target_link_libraries(${CMAKE_BENCH_NAME} nvbench::main CUDF_DATAGEN ${CUDF_BENCHMARK_COMMON}
+    target_link_libraries(${CMAKE_BENCH_NAME} nvbench::main DATAGEN_LIB ${CUDF_BENCHMARK_COMMON}
                                               cudf::cudf spark_rapids_jni Threads::Threads)
     install(
         TARGETS ${CMAKE_BENCH_NAME}

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -14,9 +14,22 @@
 # limitations under the License.
 #=============================================================================
 
-# this library isn't exposed by cudf, so we have to grab it this way
-find_library(CUDF_DATAGEN "libcudf_datagen.a" REQUIRED NO_DEFAULT_PATH
-    HINTS "${CUDF_DIR}/cpp/build/benchmarks"
+add_library(CUDF_DATAGEN STATIC common/generate_input.cu)
+target_compile_features(CUDF_DATAGEN PUBLIC cxx_std_17 cuda_std_17)
+
+target_compile_options(
+  CUDF_DATAGEN PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${SPARK_RAPIDS_JNI_CXX_FLAGS}>"
+                      "$<$<COMPILE_LANGUAGE:CUDA>:${SPARK_RAPIDS_JNI_CUDA_FLAGS}>"
+)
+
+target_link_libraries(
+  CUDF_DATAGEN PUBLIC cudf::cudf 
+)
+
+target_include_directories(
+  CUDF_DATAGEN
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" "$<BUILD_INTERFACE:${CUDF_DIR}/cpp>"
+         "$<BUILD_INTERFACE:${CUDF_DIR}/cpp/include>"
 )
 
 ###################################################################################################
@@ -42,7 +55,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
                    CUDA_STANDARD 17
                    CUDA_STANDARD_REQUIRED ON
         )
-    target_link_libraries(${CMAKE_BENCH_NAME} nvbench::main ${CUDF_DATAGEN} ${CUDF_BENCHMARK_COMMON}
+    target_link_libraries(${CMAKE_BENCH_NAME} nvbench::main CUDF_DATAGEN ${CUDF_BENCHMARK_COMMON}
                                               cudf::cudf spark_rapids_jni Threads::Threads)
     install(
         TARGETS ${CMAKE_BENCH_NAME}

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -14,20 +14,20 @@
 # limitations under the License.
 #=============================================================================
 
-add_library(DATAGEN_LIB STATIC common/generate_input.cu)
-target_compile_features(DATAGEN_LIB PUBLIC cxx_std_17 cuda_std_17)
+add_library(spark_rapids_jni_datagen STATIC common/generate_input.cu)
+target_compile_features(spark_rapids_jni_datagen PUBLIC cxx_std_17 cuda_std_17)
 
 target_compile_options(
-  DATAGEN_LIB PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${SPARK_RAPIDS_JNI_CXX_FLAGS}>"
+  spark_rapids_jni_datagen PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${SPARK_RAPIDS_JNI_CXX_FLAGS}>"
                       "$<$<COMPILE_LANGUAGE:CUDA>:${SPARK_RAPIDS_JNI_CUDA_FLAGS}>"
 )
 
 target_link_libraries(
-  DATAGEN_LIB PUBLIC cudf::cudf 
+  spark_rapids_jni_datagen PUBLIC cudf::cudf 
 )
 
 target_include_directories(
-  DATAGEN_LIB
+  spark_rapids_jni_datagen
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" "$<BUILD_INTERFACE:${CUDF_DIR}/cpp>"
          "$<BUILD_INTERFACE:${CUDF_DIR}/cpp/include>"
 )
@@ -55,7 +55,7 @@ function(ConfigureBench CMAKE_BENCH_NAME)
                    CUDA_STANDARD 17
                    CUDA_STANDARD_REQUIRED ON
         )
-    target_link_libraries(${CMAKE_BENCH_NAME} nvbench::main DATAGEN_LIB ${CUDF_BENCHMARK_COMMON}
+    target_link_libraries(${CMAKE_BENCH_NAME} nvbench::main spark_rapids_jni_datagen ${CUDF_BENCHMARK_COMMON}
                                               cudf::cudf spark_rapids_jni Threads::Threads)
     install(
         TARGETS ${CMAKE_BENCH_NAME}

--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -1,0 +1,877 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "generate_input.hpp"
+#include "random_distribution_factory.cuh"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/valid_if.cuh>
+#include <cudf/filling.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <thrust/binary_search.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/for_each.h>
+#include <thrust/functional.h>
+#include <thrust/gather.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/random/linear_congruential_engine.h>
+#include <thrust/random/uniform_int_distribution.h>
+#include <thrust/random/uniform_real_distribution.h>
+#include <thrust/scan.h>
+#include <thrust/tabulate.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <random>
+#include <utility>
+#include <vector>
+
+/**
+ * @brief Mersenne Twister pseudo-random engine.
+ */
+auto deterministic_engine(unsigned seed) { return thrust::minstd_rand{seed}; }
+
+/**
+ *  Computes the mean value for a distribution of given type and value bounds.
+ */
+template <typename T>
+T get_distribution_mean(distribution_params<T> const& dist)
+{
+  switch (dist.id) {
+    case distribution_id::NORMAL:
+    case distribution_id::UNIFORM: return (dist.lower_bound / 2.) + (dist.upper_bound / 2.);
+    case distribution_id::GEOMETRIC: {
+      auto const range_size = dist.lower_bound < dist.upper_bound
+                                ? dist.upper_bound - dist.lower_bound
+                                : dist.lower_bound - dist.upper_bound;
+      auto const p          = geometric_dist_p(range_size);
+      if (dist.lower_bound < dist.upper_bound)
+        return dist.lower_bound + (1. / p);
+      else
+        return dist.lower_bound - (1. / p);
+    }
+    default: CUDF_FAIL("Unsupported distribution type.");
+  }
+}
+
+/**
+ * @brief Computes the average element size in a column, given the data profile.
+ *
+ * Random distribution parameters like average string length and maximum list nesting level affect
+ * the element size of non-fixed-width columns. For lists and structs, `avg_element_size` is called
+ * recursively to determine the size of nested columns.
+ */
+size_t avg_element_size(data_profile const& profile, cudf::data_type dtype);
+
+// Utilities to determine the mean size of an element, given the data profile
+template <typename T, CUDF_ENABLE_IF(cudf::is_fixed_width<T>())>
+size_t non_fixed_width_size(data_profile const& profile)
+{
+  CUDF_FAIL("Should not be called, use `size_of` for this type instead");
+}
+
+template <typename T, CUDF_ENABLE_IF(!cudf::is_fixed_width<T>())>
+size_t non_fixed_width_size(data_profile const& profile)
+{
+  CUDF_FAIL("not implemented!");
+}
+
+template <>
+size_t non_fixed_width_size<cudf::string_view>(data_profile const& profile)
+{
+  auto const dist = profile.get_distribution_params<cudf::string_view>().length_params;
+  return get_distribution_mean(dist);
+}
+
+template <>
+size_t non_fixed_width_size<cudf::list_view>(data_profile const& profile)
+{
+  auto const dist_params       = profile.get_distribution_params<cudf::list_view>();
+  auto const single_level_mean = get_distribution_mean(dist_params.length_params);
+  auto const element_size = avg_element_size(profile, cudf::data_type{dist_params.element_type});
+  return element_size * pow(single_level_mean, dist_params.max_depth);
+}
+
+template <>
+size_t non_fixed_width_size<cudf::struct_view>(data_profile const& profile)
+{
+  auto const dist_params = profile.get_distribution_params<cudf::struct_view>();
+  return std::accumulate(dist_params.leaf_types.cbegin(),
+                         dist_params.leaf_types.cend(),
+                         0ul,
+                         [&](auto& sum, auto type_id) {
+                           return sum + avg_element_size(profile, cudf::data_type{type_id});
+                         });
+}
+
+struct non_fixed_width_size_fn {
+  template <typename T>
+  size_t operator()(data_profile const& profile)
+  {
+    return non_fixed_width_size<T>(profile);
+  }
+};
+
+size_t avg_element_size(data_profile const& profile, cudf::data_type dtype)
+{
+  if (cudf::is_fixed_width(dtype)) { return cudf::size_of(dtype); }
+  return cudf::type_dispatcher(dtype, non_fixed_width_size_fn{}, profile);
+}
+
+/**
+ * @brief bool generator with given probability [0.0 - 1.0] of returning true.
+ */
+struct bool_generator {
+  thrust::minstd_rand engine;
+  thrust::uniform_real_distribution<float> dist;
+  double probability_true;
+  bool_generator(thrust::minstd_rand engine, double probability_true)
+    : engine(engine), dist{0, 1}, probability_true{probability_true}
+  {
+  }
+  bool_generator(unsigned seed, double probability_true)
+    : engine(seed), dist{0, 1}, probability_true{probability_true}
+  {
+  }
+
+  __device__ bool operator()(size_t n)
+  {
+    engine.discard(n);
+    return dist(engine) < probability_true;
+  }
+};
+
+/**
+ * @brief Functor that computes a random column element with the given data profile.
+ *
+ * The implementation is SFINAEd for different type groups. Currently only used for fixed-width
+ * types.
+ */
+template <typename T, typename Enable = void>
+struct random_value_fn;
+
+/**
+ * @brief Creates an random timestamp/duration value
+ */
+template <typename T>
+struct random_value_fn<T, std::enable_if_t<cudf::is_chrono<T>()>> {
+  distribution_fn<int64_t> seconds_gen;
+  distribution_fn<int64_t> nanoseconds_gen;
+
+  random_value_fn(distribution_params<T> params)
+  {
+    using cuda::std::chrono::duration_cast;
+
+    std::pair<cudf::duration_s, cudf::duration_s> const range_s = {
+      duration_cast<cuda::std::chrono::seconds>(typename T::duration{params.lower_bound}),
+      duration_cast<cuda::std::chrono::seconds>(typename T::duration{params.upper_bound})};
+    if (range_s.first != range_s.second) {
+      seconds_gen =
+        make_distribution<int64_t>(params.id, range_s.first.count(), range_s.second.count());
+
+      nanoseconds_gen = make_distribution<int64_t>(distribution_id::UNIFORM, 0l, 1000000000l);
+    } else {
+      // Don't need a random seconds generator for sub-second intervals
+      seconds_gen = [range_s](thrust::minstd_rand&, size_t size) {
+        rmm::device_uvector<int64_t> result(size, cudf::default_stream_value);
+        thrust::fill(thrust::device, result.begin(), result.end(), range_s.second.count());
+        return result;
+      };
+
+      std::pair<cudf::duration_ns, cudf::duration_ns> const range_ns = {
+        duration_cast<cudf::duration_ns>(typename T::duration{params.lower_bound}),
+        duration_cast<cudf::duration_ns>(typename T::duration{params.upper_bound})};
+      nanoseconds_gen = make_distribution<int64_t>(distribution_id::UNIFORM,
+                                                   std::min(range_ns.first.count(), 0l),
+                                                   std::max(range_ns.second.count(), 0l));
+    }
+  }
+
+  rmm::device_uvector<T> operator()(thrust::minstd_rand& engine, unsigned size)
+  {
+    auto const sec = seconds_gen(engine, size);
+    auto const ns  = nanoseconds_gen(engine, size);
+    rmm::device_uvector<T> result(size, cudf::default_stream_value);
+    thrust::transform(
+      thrust::device,
+      sec.begin(),
+      sec.end(),
+      ns.begin(),
+      result.begin(),
+      [] __device__(int64_t sec_value, int64_t nanoseconds_value) {
+        auto const timestamp_ns =
+          cudf::duration_s{sec_value} + cudf::duration_ns{nanoseconds_value};
+        // Return value in the type's precision
+        return T(cuda::std::chrono::duration_cast<typename T::duration>(timestamp_ns));
+      });
+    return result;
+  }
+};
+
+/**
+ * @brief Creates an random fixed_point value.
+ */
+template <typename T>
+struct random_value_fn<T, std::enable_if_t<cudf::is_fixed_point<T>()>> {
+  using rep = typename T::rep;
+  rep const lower_bound;
+  rep const upper_bound;
+  distribution_fn<rep> dist;
+  std::optional<numeric::scale_type> scale;
+
+  random_value_fn(distribution_params<rep> const& desc)
+    : lower_bound{desc.lower_bound},
+      upper_bound{desc.upper_bound},
+      dist{make_distribution<rep>(desc.id, desc.lower_bound, desc.upper_bound)}
+  {
+  }
+
+  rmm::device_uvector<T> operator()(thrust::minstd_rand& engine, unsigned size)
+  {
+    if (not scale.has_value()) {
+      int const max_scale = std::numeric_limits<rep>::digits10;
+      std::uniform_int_distribution<int> scale_dist{-max_scale, max_scale};
+      std::mt19937 engine_scale(engine());
+      scale = numeric::scale_type{scale_dist(engine_scale)};
+    }
+    auto const ints = dist(engine, size);
+    rmm::device_uvector<T> result(size, cudf::default_stream_value);
+    // Clamp the generated random value to the specified range
+    thrust::transform(thrust::device,
+                      ints.begin(),
+                      ints.end(),
+                      result.begin(),
+                      [scale       = *(this->scale),
+                       upper_bound = this->upper_bound,
+                       lower_bound = this->lower_bound] __device__(auto int_value) {
+                        return T{std::clamp(int_value, lower_bound, upper_bound), scale};
+                      });
+    return result;
+  }
+};
+
+/**
+ * @brief Creates an random numeric value with the given distribution.
+ */
+template <typename T>
+struct random_value_fn<T, std::enable_if_t<!std::is_same_v<T, bool> && cudf::is_numeric<T>()>> {
+  T const lower_bound;
+  T const upper_bound;
+  distribution_fn<T> dist;
+
+  random_value_fn(distribution_params<T> const& desc)
+    : lower_bound{desc.lower_bound},
+      upper_bound{desc.upper_bound},
+      dist{make_distribution<T>(desc.id, desc.lower_bound, desc.upper_bound)}
+  {
+  }
+
+  auto operator()(thrust::minstd_rand& engine, unsigned size) { return dist(engine, size); }
+};
+
+/**
+ * @brief Creates an boolean value with given probability of returning `true`.
+ */
+template <typename T>
+struct random_value_fn<T, typename std::enable_if_t<std::is_same_v<T, bool>>> {
+  // Bernoulli distribution
+  distribution_fn<bool> dist;
+
+  random_value_fn(distribution_params<bool> const& desc)
+    : dist{[valid_prob = desc.probability_true](thrust::minstd_rand& engine,
+                                                size_t size) -> rmm::device_uvector<bool> {
+        rmm::device_uvector<bool> result(size, cudf::default_stream_value);
+        thrust::tabulate(
+          thrust::device, result.begin(), result.end(), bool_generator(engine, valid_prob));
+        return result;
+      }}
+  {
+  }
+  auto operator()(thrust::minstd_rand& engine, unsigned size) { return dist(engine, size); }
+};
+
+auto create_run_length_dist(cudf::size_type avg_run_len)
+{
+  // Distribution with low probability of generating 0-1 even with a low `avg_run_len` value
+  static constexpr float alpha = 4.f;
+  return std::gamma_distribution<float>{alpha, avg_run_len / alpha};
+}
+
+/**
+ * @brief Generate indices within range [0 , cardinality) repeating with average run length
+ * `avg_run_len`
+ *
+ * @param avg_run_len  Average run length of the generated indices
+ * @param cardinality  Number of unique values in the output vector
+ * @param num_rows     Number of indices to generate
+ * @param engine       Random engine
+ * @return Generated indices of type `cudf::size_type`
+ */
+rmm::device_uvector<cudf::size_type> sample_indices_with_run_length(cudf::size_type avg_run_len,
+                                                                    cudf::size_type cardinality,
+                                                                    cudf::size_type num_rows,
+                                                                    thrust::minstd_rand& engine)
+{
+  auto sample_dist = random_value_fn<cudf::size_type>{
+    distribution_params<cudf::size_type>{distribution_id::UNIFORM, 0, cardinality - 1}};
+  if (avg_run_len > 1) {
+    auto avglen_dist =
+      random_value_fn<int>{distribution_params<int>{distribution_id::UNIFORM, 1, 2 * avg_run_len}};
+    auto const approx_run_len = num_rows / avg_run_len + 1;
+    auto run_lens             = avglen_dist(engine, approx_run_len);
+    thrust::inclusive_scan(
+      thrust::device, run_lens.begin(), run_lens.end(), run_lens.begin(), std::plus<int>{});
+    auto const samples_indices = sample_dist(engine, approx_run_len + 1);
+    // This is gather.
+    auto avg_repeated_sample_indices_iterator = thrust::make_transform_iterator(
+      thrust::make_counting_iterator(0),
+      [rb              = run_lens.begin(),
+       re              = run_lens.end(),
+       samples_indices = samples_indices.begin()] __device__(cudf::size_type i) {
+        auto sample_idx = thrust::upper_bound(thrust::seq, rb, re, i) - rb;
+        return samples_indices[sample_idx];
+      });
+    rmm::device_uvector<cudf::size_type> repeated_sample_indices(num_rows,
+                                                                 cudf::default_stream_value);
+    thrust::copy(thrust::device,
+                 avg_repeated_sample_indices_iterator,
+                 avg_repeated_sample_indices_iterator + num_rows,
+                 repeated_sample_indices.begin());
+    return repeated_sample_indices;
+  } else {
+    // generate n samples.
+    return sample_dist(engine, num_rows);
+  }
+}
+
+/**
+ * @brief Creates a column with random content of type @ref T.
+ *
+ * @param profile Parameters for the random generator
+ * @param engine Pseudo-random engine
+ * @param num_rows Size of the output column
+ *
+ * @tparam T Data type of the output column
+ * @return Column filled with random data
+ */
+template <typename T>
+std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
+                                                   thrust::minstd_rand& engine,
+                                                   cudf::size_type num_rows)
+{
+  // Bernoulli distribution
+  auto valid_dist =
+    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+  auto value_dist = random_value_fn<T>{profile.get_distribution_params<T>()};
+
+  // Distribution for picking elements from the array of samples
+  auto const avg_run_len = profile.get_avg_run_length();
+  rmm::device_uvector<T> data(0, cudf::default_stream_value);
+  rmm::device_uvector<bool> null_mask(0, cudf::default_stream_value);
+
+  if (profile.get_cardinality() == 0 and avg_run_len == 1) {
+    data      = value_dist(engine, num_rows);
+    null_mask = valid_dist(engine, num_rows);
+  } else {
+    auto const cardinality = [profile_cardinality = profile.get_cardinality(), num_rows] {
+      return (profile_cardinality == 0 or profile_cardinality > num_rows) ? num_rows
+                                                                          : profile_cardinality;
+    }();
+    rmm::device_uvector<bool> samples_null_mask = valid_dist(engine, cardinality);
+    rmm::device_uvector<T> samples              = value_dist(engine, cardinality);
+    // generate n samples and gather.
+    auto const sample_indices =
+      sample_indices_with_run_length(avg_run_len, cardinality, num_rows, engine);
+    data      = rmm::device_uvector<T>(num_rows, cudf::default_stream_value);
+    null_mask = rmm::device_uvector<bool>(num_rows, cudf::default_stream_value);
+    thrust::gather(
+      thrust::device, sample_indices.begin(), sample_indices.end(), samples.begin(), data.begin());
+    thrust::gather(thrust::device,
+                   sample_indices.begin(),
+                   sample_indices.end(),
+                   samples_null_mask.begin(),
+                   null_mask.begin());
+  }
+
+  auto [result_bitmask, null_count] =
+    cudf::detail::valid_if(null_mask.begin(), null_mask.end(), thrust::identity<bool>{});
+
+  return std::make_unique<cudf::column>(
+    cudf::data_type{cudf::type_to_id<T>()},
+    num_rows,
+    data.release(),
+    profile.get_null_frequency().has_value() ? std::move(result_bitmask) : rmm::device_buffer{});
+}
+
+struct valid_or_zero {
+  template <typename T>
+  __device__ T operator()(thrust::tuple<T, bool> len_valid) const
+  {
+    return thrust::get<1>(len_valid) ? thrust::get<0>(len_valid) : T{0};
+  }
+};
+
+struct string_generator {
+  char* chars;
+  thrust::minstd_rand engine;
+  thrust::uniform_int_distribution<unsigned char> char_dist;
+  string_generator(char* c, thrust::minstd_rand& engine)
+    : chars(c), engine(engine), char_dist(32, 137)
+  // ~90% ASCII, ~10% UTF-8.
+  // ~80% not-space, ~20% space.
+  // range 32-127 is ASCII; 127-136 will be multi-byte UTF-8
+  {
+  }
+  __device__ void operator()(thrust::tuple<cudf::size_type, cudf::size_type> str_begin_end)
+  {
+    auto begin = thrust::get<0>(str_begin_end);
+    auto end   = thrust::get<1>(str_begin_end);
+    engine.discard(begin);
+    for (auto i = begin; i < end; ++i) {
+      auto ch = char_dist(engine);
+      if (i == end - 1 && ch >= '\x7F') ch = ' ';  // last element ASCII only.
+      if (ch >= '\x7F')                            // x7F is at the top edge of ASCII
+        chars[i++] = '\xC4';                       // these characters are assigned two bytes
+      chars[i] = static_cast<char>(ch + (ch >= '\x7F'));
+    }
+  }
+};
+
+/**
+ * @brief Create a UTF-8 string column with the average length.
+ *
+ */
+std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile const& profile,
+                                                               thrust::minstd_rand& engine,
+                                                               cudf::size_type num_rows)
+{
+  auto len_dist =
+    random_value_fn<uint32_t>{profile.get_distribution_params<cudf::string_view>().length_params};
+  auto valid_dist =
+    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+  auto lengths   = len_dist(engine, num_rows + 1);
+  auto null_mask = valid_dist(engine, num_rows + 1);
+  thrust::transform_if(
+    thrust::device,
+    lengths.begin(),
+    lengths.end(),
+    null_mask.begin(),
+    lengths.begin(),
+    [] __device__(auto) { return 0; },
+    thrust::logical_not<bool>{});
+  auto valid_lengths = thrust::make_transform_iterator(
+    thrust::make_zip_iterator(thrust::make_tuple(lengths.begin(), null_mask.begin())),
+    valid_or_zero{});
+  rmm::device_uvector<cudf::size_type> offsets(num_rows + 1, cudf::default_stream_value);
+  thrust::exclusive_scan(
+    thrust::device, valid_lengths, valid_lengths + lengths.size(), offsets.begin());
+  // offfsets are ready.
+  auto chars_length = *thrust::device_pointer_cast(offsets.end() - 1);
+  rmm::device_uvector<char> chars(chars_length, cudf::default_stream_value);
+  thrust::for_each_n(thrust::device,
+                     thrust::make_zip_iterator(offsets.begin(), offsets.begin() + 1),
+                     num_rows,
+                     string_generator{chars.data(), engine});
+  auto [result_bitmask, null_count] =
+    cudf::detail::valid_if(null_mask.begin(), null_mask.end() - 1, thrust::identity<bool>{});
+  return cudf::make_strings_column(
+    num_rows,
+    std::move(offsets),
+    std::move(chars),
+    profile.get_null_frequency().has_value() ? std::move(result_bitmask) : rmm::device_buffer{});
+}
+
+/**
+ * @brief Creates a string column with random content.
+ *
+ * @param profile Parameters for the random generator
+ * @param engine Pseudo-random engine
+ * @param num_rows Size of the output column
+ *
+ * @return Column filled with random strings
+ */
+template <>
+std::unique_ptr<cudf::column> create_random_column<cudf::string_view>(data_profile const& profile,
+                                                                      thrust::minstd_rand& engine,
+                                                                      cudf::size_type num_rows)
+{
+  auto const cardinality = std::min(profile.get_cardinality(), num_rows);
+  auto const avg_run_len = profile.get_avg_run_length();
+
+  auto sample_strings =
+    create_random_utf8_string_column(profile, engine, cardinality == 0 ? num_rows : cardinality);
+  if (cardinality == 0) { return sample_strings; }
+  auto sample_indices = sample_indices_with_run_length(avg_run_len, cardinality, num_rows, engine);
+  auto str_table      = cudf::detail::gather(cudf::table_view{{sample_strings->view()}},
+                                        sample_indices,
+                                        cudf::out_of_bounds_policy::DONT_CHECK,
+                                        cudf::detail::negative_index_policy::NOT_ALLOWED);
+  return std::move(str_table->release()[0]);
+}
+
+template <>
+std::unique_ptr<cudf::column> create_random_column<cudf::dictionary32>(data_profile const& profile,
+                                                                       thrust::minstd_rand& engine,
+                                                                       cudf::size_type num_rows)
+{
+  CUDF_FAIL("not implemented yet");
+}
+
+/**
+ * @brief Functor to dispatch create_random_column calls.
+ */
+struct create_rand_col_fn {
+ public:
+  template <typename T>
+  std::unique_ptr<cudf::column> operator()(data_profile const& profile,
+                                           thrust::minstd_rand& engine,
+                                           cudf::size_type num_rows)
+  {
+    return create_random_column<T>(profile, engine, num_rows);
+  }
+};
+
+/**
+ * @brief Calculates the number of direct parents needed to generate a struct column hierarchy with
+ * lowest maximum number of children in any nested column.
+ *
+ * Used to generate an "evenly distributed" struct column hierarchy with the given number of leaf
+ * columns and nesting levels. The column tree is considered evenly distributed if all columns have
+ * nearly the same number of child columns (difference not larger than one).
+ */
+int num_direct_parents(int num_lvls, int num_leaf_columns)
+{
+  // Estimated average number of children in the hierarchy;
+  auto const num_children_avg = std::pow(num_leaf_columns, 1. / num_lvls);
+  // Minimum number of children columns for any column in the hierarchy
+  int const num_children_min = std::floor(num_children_avg);
+  // Maximum number of children columns for any column in the hierarchy
+  int const num_children_max = num_children_min + 1;
+
+  // Minimum number of columns needed so that their number of children does not exceed the maximum
+  int const min_for_current_nesting = std::ceil((double)num_leaf_columns / num_children_max);
+  // Minimum number of columns needed so that columns at the higher levels have at least the minimum
+  // number of children
+  int const min_for_upper_nesting = std::pow(num_children_min, num_lvls - 1);
+  // Both conditions need to be satisfied
+  return std::max(min_for_current_nesting, min_for_upper_nesting);
+}
+
+template <>
+std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profile const& profile,
+                                                                      thrust::minstd_rand& engine,
+                                                                      cudf::size_type num_rows)
+{
+  auto const dist_params = profile.get_distribution_params<cudf::struct_view>();
+
+  // Generate leaf columns
+  std::vector<std::unique_ptr<cudf::column>> children;
+  children.reserve(dist_params.leaf_types.size());
+  std::transform(dist_params.leaf_types.cbegin(),
+                 dist_params.leaf_types.cend(),
+                 std::back_inserter(children),
+                 [&](auto& type_id) {
+                   return cudf::type_dispatcher(
+                     cudf::data_type(type_id), create_rand_col_fn{}, profile, engine, num_rows);
+                 });
+
+  auto valid_dist =
+    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+
+  // Generate the column bottom-up
+  for (int lvl = dist_params.max_depth; lvl > 0; --lvl) {
+    // Generating the next level
+    std::vector<std::unique_ptr<cudf::column>> parents;
+    parents.resize(num_direct_parents(lvl, children.size()));
+
+    auto current_child = children.begin();
+    for (auto current_parent = parents.begin(); current_parent != parents.end(); ++current_parent) {
+      auto [null_mask, null_count] = [&]() {
+        if (profile.get_null_frequency().has_value()) {
+          auto valids = valid_dist(engine, num_rows);
+          return cudf::detail::valid_if(valids.begin(), valids.end(), thrust::identity<bool>{});
+        }
+        return std::pair<rmm::device_buffer, cudf::size_type>{};
+      }();
+
+      // Adopt remaining children as evenly as possible
+      auto const num_to_adopt = cudf::util::div_rounding_up_unsafe(
+        std::distance(current_child, children.end()), std::distance(current_parent, parents.end()));
+      CUDF_EXPECTS(num_to_adopt > 0, "No children columns left to adopt");
+
+      std::vector<std::unique_ptr<cudf::column>> children_to_adopt;
+      children_to_adopt.insert(children_to_adopt.end(),
+                               std::make_move_iterator(current_child),
+                               std::make_move_iterator(current_child + num_to_adopt));
+      current_child += children_to_adopt.size();
+
+      *current_parent = cudf::make_structs_column(
+        num_rows, std::move(children_to_adopt), null_count, std::move(null_mask));
+    }
+
+    if (lvl == 1) {
+      CUDF_EXPECTS(parents.size() == 1, "There should be one top-level column");
+      return std::move(parents.front());
+    }
+    children = std::move(parents);
+  }
+  CUDF_FAIL("Reached unreachable code in struct column creation");
+}
+
+template <typename T>
+struct clamp_down : public thrust::unary_function<T, T> {
+  T max;
+  clamp_down(T max) : max(max) {}
+  __host__ __device__ T operator()(T x) const { return min(x, max); }
+};
+/**
+ * @brief Creates a list column with random content.
+ *
+ * The data profile determines the list length distribution, number of nested level, and the data
+ * type of the bottom level.
+ *
+ * @param profile Parameters for the random generator
+ * @param engine Pseudo-random engine
+ * @param num_rows Size of the output column
+ *
+ * @return Column filled with random lists
+ */
+template <>
+std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile const& profile,
+                                                                    thrust::minstd_rand& engine,
+                                                                    cudf::size_type num_rows)
+{
+  auto const dist_params       = profile.get_distribution_params<cudf::list_view>();
+  auto const single_level_mean = get_distribution_mean(dist_params.length_params);
+  auto const num_elements      = num_rows * pow(single_level_mean, dist_params.max_depth);
+
+  auto leaf_column = cudf::type_dispatcher(
+    cudf::data_type(dist_params.element_type), create_rand_col_fn{}, profile, engine, num_elements);
+  auto len_dist =
+    random_value_fn<uint32_t>{profile.get_distribution_params<cudf::list_view>().length_params};
+  auto valid_dist =
+    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+
+  // Generate the list column bottom-up
+  auto list_column = std::move(leaf_column);
+  for (int lvl = 0; lvl < dist_params.max_depth; ++lvl) {
+    // Generating the next level - offsets point into the current list column
+    auto current_child_column      = std::move(list_column);
+    cudf::size_type const num_rows = current_child_column->size() / single_level_mean;
+
+    auto offsets = len_dist(engine, num_rows + 1);
+    auto valids  = valid_dist(engine, num_rows);
+    // to ensure these values <= current_child_column->size()
+    auto output_offsets = thrust::make_transform_output_iterator(
+      offsets.begin(), clamp_down{current_child_column->size()});
+
+    thrust::exclusive_scan(thrust::device, offsets.begin(), offsets.end(), output_offsets);
+    thrust::device_pointer_cast(offsets.end())[-1] =
+      current_child_column->size();  // Always include all elements
+
+    auto offsets_column = std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT32}, num_rows + 1, offsets.release());
+
+    auto [null_mask, null_count] =
+      cudf::detail::valid_if(valids.begin(), valids.end(), thrust::identity<bool>{});
+    list_column = cudf::make_lists_column(
+      num_rows,
+      std::move(offsets_column),
+      std::move(current_child_column),
+      profile.get_null_frequency().has_value() ? null_count : 0,  // cudf::UNKNOWN_NULL_COUNT,
+      profile.get_null_frequency().has_value() ? std::move(null_mask) : rmm::device_buffer{});
+  }
+  return list_column;  // return the top-level column
+}
+
+using columns_vector = std::vector<std::unique_ptr<cudf::column>>;
+
+/**
+ * @brief Creates a vector of columns with random content.
+ *
+ * @param profile Parameters for the random generator
+ * @param dtype_ids vector of data type ids, one for each output column
+ * @param engine Pseudo-random engine
+ * @param num_rows Size of the output columns
+ *
+ * @return Column filled with random lists
+ */
+columns_vector create_random_columns(data_profile const& profile,
+                                     std::vector<cudf::type_id> dtype_ids,
+                                     thrust::minstd_rand engine,
+                                     cudf::size_type num_rows)
+{
+  columns_vector output_columns;
+  std::transform(
+    dtype_ids.begin(), dtype_ids.end(), std::back_inserter(output_columns), [&](auto tid) {
+      engine.discard(num_rows);
+      return cudf::type_dispatcher(
+        cudf::data_type(tid), create_rand_col_fn{}, profile, engine, num_rows);
+    });
+  return output_columns;
+}
+
+/**
+ * @brief Repeats the input data types cyclically order to fill a vector of @ref num_cols
+ * elements.
+ */
+std::vector<cudf::type_id> cycle_dtypes(std::vector<cudf::type_id> const& dtype_ids,
+                                        cudf::size_type num_cols)
+{
+  if (dtype_ids.size() == static_cast<std::size_t>(num_cols)) { return dtype_ids; }
+  std::vector<cudf::type_id> out_dtypes;
+  out_dtypes.reserve(num_cols);
+  for (cudf::size_type col = 0; col < num_cols; ++col)
+    out_dtypes.push_back(dtype_ids[col % dtype_ids.size()]);
+  return out_dtypes;
+}
+
+std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
+                                                 table_size_bytes table_bytes,
+                                                 data_profile const& profile,
+                                                 unsigned seed)
+{
+  size_t const avg_row_bytes =
+    std::accumulate(dtype_ids.begin(), dtype_ids.end(), 0ul, [&](size_t sum, auto tid) {
+      return sum + avg_element_size(profile, cudf::data_type(tid));
+    });
+  cudf::size_type const num_rows = table_bytes.size / avg_row_bytes;
+
+  return create_random_table(dtype_ids, row_count{num_rows}, profile, seed);
+}
+
+std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
+                                                 row_count num_rows,
+                                                 data_profile const& profile,
+                                                 unsigned seed)
+{
+  auto seed_engine = deterministic_engine(seed);
+  thrust::uniform_int_distribution<unsigned> seed_dist;
+
+  columns_vector output_columns;
+  std::transform(
+    dtype_ids.begin(), dtype_ids.end(), std::back_inserter(output_columns), [&](auto tid) mutable {
+      auto engine = deterministic_engine(seed_dist(seed_engine));
+      return cudf::type_dispatcher(
+        cudf::data_type(tid), create_rand_col_fn{}, profile, engine, num_rows.count);
+    });
+  return std::make_unique<cudf::table>(std::move(output_columns));
+}
+
+std::unique_ptr<cudf::table> create_sequence_table(std::vector<cudf::type_id> const& dtype_ids,
+                                                   row_count num_rows,
+                                                   std::optional<double> null_probability,
+                                                   unsigned seed)
+{
+  auto seed_engine = deterministic_engine(seed);
+  thrust::uniform_int_distribution<unsigned> seed_dist;
+
+  auto columns = std::vector<std::unique_ptr<cudf::column>>(dtype_ids.size());
+  std::transform(dtype_ids.begin(), dtype_ids.end(), columns.begin(), [&](auto dtype) mutable {
+    auto init = cudf::make_default_constructed_scalar(cudf::data_type{dtype});
+    auto col  = cudf::sequence(num_rows.count, *init);
+    auto [mask, count] =
+      create_random_null_mask(num_rows.count, null_probability, seed_dist(seed_engine));
+    col->set_null_mask(std::move(mask), count);
+    return col;
+  });
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
+  cudf::size_type size, std::optional<double> null_probability, unsigned seed)
+{
+  if (not null_probability.has_value()) { return {rmm::device_buffer{}, 0}; }
+  CUDF_EXPECTS(*null_probability >= 0.0 and *null_probability <= 1.0,
+               "Null probability must be within the range [0.0, 1.0]");
+  if (*null_probability == 0.0f) {
+    return {cudf::create_null_mask(size, cudf::mask_state::ALL_VALID), 0};
+  } else if (*null_probability == 1.0) {
+    return {cudf::create_null_mask(size, cudf::mask_state::ALL_NULL), size};
+  } else {
+    return cudf::detail::valid_if(thrust::make_counting_iterator<cudf::size_type>(0),
+                                  thrust::make_counting_iterator<cudf::size_type>(size),
+                                  bool_generator{seed, 1.0 - *null_probability});
+  }
+}
+
+std::vector<cudf::type_id> get_type_or_group(int32_t id)
+{
+  // identity transformation when passing a concrete type_id
+  if (id < static_cast<int32_t>(cudf::type_id::NUM_TYPE_IDS))
+    return {static_cast<cudf::type_id>(id)};
+
+  // if the value is larger that type_id::NUM_TYPE_IDS, it's a group id
+  type_group_id const group_id = static_cast<type_group_id>(id);
+
+  using trait_fn       = bool (*)(cudf::data_type);
+  trait_fn is_integral = [](cudf::data_type type) {
+    return cudf::is_numeric(type) && !cudf::is_floating_point(type);
+  };
+  trait_fn is_integral_signed = [](cudf::data_type type) {
+    return cudf::is_numeric(type) && !cudf::is_floating_point(type) && !cudf::is_unsigned(type);
+  };
+  auto fn = [&]() -> trait_fn {
+    switch (group_id) {
+      case type_group_id::FLOATING_POINT: return cudf::is_floating_point;
+      case type_group_id::INTEGRAL: return is_integral;
+      case type_group_id::INTEGRAL_SIGNED: return is_integral_signed;
+      case type_group_id::NUMERIC: return cudf::is_numeric;
+      case type_group_id::TIMESTAMP: return cudf::is_timestamp;
+      case type_group_id::DURATION: return cudf::is_duration;
+      case type_group_id::FIXED_POINT: return cudf::is_fixed_point;
+      case type_group_id::COMPOUND: return cudf::is_compound;
+      case type_group_id::NESTED: return cudf::is_nested;
+      default: CUDF_FAIL("Invalid data type group");
+    }
+  }();
+  std::vector<cudf::type_id> types;
+  for (int type_int = 0; type_int < static_cast<int32_t>(cudf::type_id::NUM_TYPE_IDS); ++type_int) {
+    auto const type = static_cast<cudf::type_id>(type_int);
+    if (type != cudf::type_id::EMPTY && fn(cudf::data_type(type))) types.push_back(type);
+  }
+  return types;
+}
+
+std::vector<cudf::type_id> get_type_or_group(std::vector<int32_t> const& ids)
+{
+  std::vector<cudf::type_id> all_type_ids;
+  for (auto& id : ids) {
+    auto const type_ids = get_type_or_group(id);
+    all_type_ids.insert(std::end(all_type_ids), std::cbegin(type_ids), std::cend(type_ids));
+  }
+  return all_type_ids;
+}

--- a/src/main/cpp/benchmarks/common/generate_input.hpp
+++ b/src/main/cpp/benchmarks/common/generate_input.hpp
@@ -1,0 +1,481 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/table/table.hpp>
+#include <cudf/utilities/traits.hpp>
+
+#include <map>
+#include <optional>
+
+/**
+ * @file generate_input.hpp
+ * @brief Contains declarations of functions that generate columns filled with random data.
+ *
+ * Also includes the data profile descriptor classes.
+ *
+ * The create_random_table functions take a data profile, the information about table size and a
+ * seed to deterministically generate a table with given parameters.
+ *
+ * Currently, the data generation is done on the CPU and the data is then copied to the device
+ * memory.
+ */
+
+/**
+ * @brief Identifies a group of related column's logical element types.
+ */
+enum class type_group_id : int32_t {
+  INTEGRAL = static_cast<int32_t>(cudf::type_id::NUM_TYPE_IDS),
+  INTEGRAL_SIGNED,
+  FLOATING_POINT,
+  NUMERIC,
+  TIMESTAMP,
+  DURATION,
+  FIXED_POINT,
+  COMPOUND,
+  NESTED,
+};
+
+/**
+ * @brief Identifies a probability distribution type.
+ */
+enum class distribution_id : int8_t {
+  UNIFORM,    ///< Uniform sampling between the given bounds. Provides the best coverage of the
+              ///< overall value range. Real data rarely has this distribution.
+  NORMAL,     ///< Gaussian sampling - most samples are close to the middle of the range. Good for
+              ///< simulating real-world numeric data.
+  GEOMETRIC,  ///< Geometric sampling - highest chance to sample close to the lower bound. Good for
+              ///< simulating real data with asymmetric distribution (unsigned values, timestamps).
+};
+
+// Default distribution types for each type
+namespace {
+template <typename T, std::enable_if_t<cudf::is_chrono<T>()>* = nullptr>
+distribution_id default_distribution_id()
+{
+  return distribution_id::GEOMETRIC;
+}
+
+template <typename T, std::enable_if_t<!std::is_unsigned_v<T> && cudf::is_numeric<T>()>* = nullptr>
+distribution_id default_distribution_id()
+{
+  return distribution_id::NORMAL;
+}
+
+template <typename T,
+          std::enable_if_t<!std::is_same_v<T, bool> && std::is_unsigned_v<T> &&
+                           cudf::is_numeric<T>()>* = nullptr>
+distribution_id default_distribution_id()
+{
+  return distribution_id::GEOMETRIC;
+}
+
+/**
+ * @brief Default range for the timestamp types: 1970 - 2020.
+ *
+ * The 2020 timestamp is used as a lower bound to bias the geometric distribution to recent
+ * timestamps.
+ */
+template <typename T, std::enable_if_t<cudf::is_timestamp<T>()>* = nullptr>
+std::pair<int64_t, int64_t> default_range()
+{
+  using cuda::std::chrono::duration_cast;
+  auto const year = duration_cast<typename T::duration>(cudf::duration_D{365l});
+  return {50 * year.count(), 0};
+}
+
+/**
+ * @brief Default range for the duration types.
+ *
+ * If a geometric distribution is used, it will bias towards short duration values.
+ */
+template <typename T, std::enable_if_t<cudf::is_duration<T>()>* = nullptr>
+std::pair<int64_t, int64_t> default_range()
+{
+  using cuda::std::chrono::duration_cast;
+  auto const year = duration_cast<typename T::duration>(cudf::duration_D{365l});
+  return {0, 2 * year.count()};
+}
+
+template <typename T, std::enable_if_t<cudf::is_numeric<T>()>* = nullptr>
+std::pair<T, T> default_range()
+{
+  // Limits need to be such that `upper - lower` does not overflow
+  return {std::numeric_limits<T>::lowest() / 2, std::numeric_limits<T>::max() / 2};
+}
+}  // namespace
+
+/**
+ * @brief Enables partial specializations with SFINAE.
+ */
+template <typename T, typename Enable = void>
+struct distribution_params;
+
+/**
+ * @brief Numeric values are parameterized with a distribution type and bounds of the same type.
+ */
+template <typename T>
+struct distribution_params<T, std::enable_if_t<!std::is_same_v<T, bool> && cudf::is_numeric<T>()>> {
+  distribution_id id;
+  T lower_bound;
+  T upper_bound;
+};
+
+/**
+ * @brief Booleans are parameterized with the probability of getting `true` value.
+ */
+template <typename T>
+struct distribution_params<T, std::enable_if_t<std::is_same_v<T, bool>>> {
+  double probability_true;
+};
+
+/**
+ * @brief Timestamps and durations are parameterized with a distribution type and int64_t bounds.
+ */
+template <typename T>
+struct distribution_params<T, std::enable_if_t<cudf::is_chrono<T>()>> {
+  distribution_id id;
+  int64_t lower_bound;
+  int64_t upper_bound;
+};
+
+/**
+ * @brief Strings are parameterized by the distribution of their length, as an integral value.
+ */
+template <typename T>
+struct distribution_params<T, std::enable_if_t<std::is_same_v<T, cudf::string_view>>> {
+  distribution_params<uint32_t> length_params;
+};
+
+/**
+ * @brief Lists are parameterized by the distribution of their length, maximal nesting level, and
+ * the element type.
+ */
+template <typename T>
+struct distribution_params<T, std::enable_if_t<std::is_same_v<T, cudf::list_view>>> {
+  cudf::type_id element_type;
+  distribution_params<uint32_t> length_params;
+  cudf::size_type max_depth;
+};
+
+/**
+ * @brief Structs are parameterized by the maximal nesting level, and the leaf column types.
+ */
+template <typename T>
+struct distribution_params<T, std::enable_if_t<std::is_same_v<T, cudf::struct_view>>> {
+  std::vector<cudf::type_id> leaf_types;
+  cudf::size_type max_depth;
+};
+
+// Present for compilation only. To be implemented once reader/writers support the fixed width type.
+template <typename T>
+struct distribution_params<T, std::enable_if_t<cudf::is_fixed_point<T>()>> {
+};
+
+/**
+ * @brief Returns a vector of types, corresponding to the input type or a type group.
+ *
+ * If the input is a `cudf::type_id` enumerator, function simply returns a vector containing this
+ * type. If the input value corresponds to a `type_group_id` enumerator, function returns a vector
+ * containing all types in the input group.
+ *
+ * @param id Integer equal to either a `cudf::type_id` enumerator or a `type_group_id` enumerator.
+ */
+std::vector<cudf::type_id> get_type_or_group(int32_t id);
+
+/**
+ * @brief Returns a vector of types, corresponding to the input types or type groups.
+ *
+ * If an element of the input vector is a `cudf::type_id` enumerator, function return value simply
+ * includes this type. If an element of the input vector is a `type_group_id` enumerator, function
+ * return value includes all types corresponding to the group enumerator.
+ *
+ * @param ids Vector of integers equal to either a `cudf::type_id` enumerator or a `type_group_id`
+ * enumerator.
+ */
+std::vector<cudf::type_id> get_type_or_group(std::vector<int32_t> const& ids);
+
+/**
+ * @brief Contains data parameters for all types.
+ *
+ * This class exposes APIs to set and get distribution parameters for each supported type.
+ * Parameters can be set for multiple types with a single call by passing a `type_group_id` instead
+ * of `cudf::type_id`.
+ *
+ * All types have default parameters so it's not necessary to set the parameters before using them.
+ */
+class data_profile {
+  std::map<cudf::type_id, distribution_params<uint64_t>> int_params;
+  std::map<cudf::type_id, distribution_params<double>> float_params;
+  distribution_params<cudf::string_view> string_dist_desc{{distribution_id::NORMAL, 0, 32}};
+  distribution_params<cudf::list_view> list_dist_desc{
+    cudf::type_id::INT32, {distribution_id::GEOMETRIC, 0, 100}, 2};
+  distribution_params<cudf::struct_view> struct_dist_desc{
+    {cudf::type_id::INT32, cudf::type_id::FLOAT32, cudf::type_id::STRING}, 2};
+  std::map<cudf::type_id, distribution_params<__uint128_t>> decimal_params;
+
+  double bool_probability              = 0.5;
+  std::optional<double> null_frequency = 0.01;
+  cudf::size_type cardinality          = 2000;
+  cudf::size_type avg_run_length       = 4;
+
+ public:
+  template <typename T,
+            std::enable_if_t<!std::is_same_v<T, bool> && cuda::std::is_integral_v<T>, T>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    auto it = int_params.find(cudf::type_to_id<T>());
+    if (it == int_params.end()) {
+      auto const range = default_range<T>();
+      return distribution_params<T>{default_distribution_id<T>(), range.first, range.second};
+    } else {
+      auto& desc = it->second;
+      return {desc.id, static_cast<T>(desc.lower_bound), static_cast<T>(desc.upper_bound)};
+    }
+  }
+
+  template <typename T, std::enable_if_t<std::is_floating_point_v<T>, T>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    auto it = float_params.find(cudf::type_to_id<T>());
+    if (it == float_params.end()) {
+      auto const range = default_range<T>();
+      return distribution_params<T>{default_distribution_id<T>(), range.first, range.second};
+    } else {
+      auto& desc = it->second;
+      return {desc.id, static_cast<T>(desc.lower_bound), static_cast<T>(desc.upper_bound)};
+    }
+  }
+
+  template <typename T, std::enable_if_t<std::is_same_v<T, bool>>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    return distribution_params<T>{bool_probability};
+  }
+
+  template <typename T, std::enable_if_t<cudf::is_chrono<T>()>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    auto it = int_params.find(cudf::type_to_id<T>());
+    if (it == int_params.end()) {
+      auto const range = default_range<T>();
+      return distribution_params<T>{default_distribution_id<T>(), range.first, range.second};
+    } else {
+      auto& desc = it->second;
+      return {
+        desc.id, static_cast<int64_t>(desc.lower_bound), static_cast<int64_t>(desc.upper_bound)};
+    }
+  }
+
+  template <typename T, std::enable_if_t<std::is_same_v<T, cudf::string_view>>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    return string_dist_desc;
+  }
+
+  template <typename T, std::enable_if_t<std::is_same_v<T, cudf::list_view>>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    return list_dist_desc;
+  }
+
+  template <typename T, std::enable_if_t<std::is_same_v<T, cudf::struct_view>>* = nullptr>
+  distribution_params<T> get_distribution_params() const
+  {
+    return struct_dist_desc;
+  }
+
+  template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
+  distribution_params<typename T::rep> get_distribution_params() const
+  {
+    using rep = typename T::rep;
+    auto it   = decimal_params.find(cudf::type_to_id<T>());
+    if (it == decimal_params.end()) {
+      auto const range = default_range<rep>();
+      return distribution_params<rep>{default_distribution_id<rep>(), range.first, range.second};
+    } else {
+      auto& desc = it->second;
+      return {desc.id, static_cast<rep>(desc.lower_bound), static_cast<rep>(desc.upper_bound)};
+    }
+  }
+
+  auto get_bool_probability() const { return bool_probability; }
+  auto get_null_frequency() const { return null_frequency; };
+  [[nodiscard]] auto get_cardinality() const { return cardinality; };
+  [[nodiscard]] auto get_avg_run_length() const { return avg_run_length; };
+
+  // Users should pass integral values for bounds when setting the parameters for types that have
+  // discrete distributions (integers, strings, lists). Otherwise the call with have no effect.
+  template <typename T,
+            typename Type_enum,
+            std::enable_if_t<cuda::std::is_integral_v<T>, T>* = nullptr>
+  void set_distribution_params(Type_enum type_or_group,
+                               distribution_id dist,
+                               T lower_bound,
+                               T upper_bound)
+  {
+    for (auto tid : get_type_or_group(static_cast<int32_t>(type_or_group))) {
+      if (tid == cudf::type_id::STRING) {
+        string_dist_desc.length_params = {
+          dist, static_cast<uint32_t>(lower_bound), static_cast<uint32_t>(upper_bound)};
+      } else if (tid == cudf::type_id::LIST) {
+        list_dist_desc.length_params = {
+          dist, static_cast<uint32_t>(lower_bound), static_cast<uint32_t>(upper_bound)};
+      } else {
+        int_params[tid] = {
+          dist, static_cast<uint64_t>(lower_bound), static_cast<uint64_t>(upper_bound)};
+      }
+    }
+  }
+
+  // Users should pass floating point values for bounds when setting the parameters for types that
+  // have continuous distributions (floating point types). Otherwise the call with have no effect.
+  template <typename T,
+            typename Type_enum,
+            std::enable_if_t<std::is_floating_point_v<T>, T>* = nullptr>
+  void set_distribution_params(Type_enum type_or_group,
+                               distribution_id dist,
+                               T lower_bound,
+                               T upper_bound)
+  {
+    for (auto tid : get_type_or_group(static_cast<int32_t>(type_or_group))) {
+      float_params[tid] = {
+        dist, static_cast<double>(lower_bound), static_cast<double>(upper_bound)};
+    }
+  }
+
+  template <typename T, typename Type_enum, std::enable_if_t<cudf::is_chrono<T>(), T>* = nullptr>
+  void set_distribution_params(Type_enum type_or_group,
+                               distribution_id dist,
+                               typename T::rep lower_bound,
+                               typename T::rep upper_bound)
+  {
+    for (auto tid : get_type_or_group(static_cast<int32_t>(type_or_group))) {
+      int_params[tid] = {
+        dist, static_cast<uint64_t>(lower_bound), static_cast<uint64_t>(upper_bound)};
+    }
+  }
+
+  void set_bool_probability(double p) { bool_probability = p; }
+  void set_null_frequency(std::optional<double> f) { null_frequency = f; }
+  void set_cardinality(cudf::size_type c) { cardinality = c; }
+  void set_avg_run_length(cudf::size_type avg_rl) { avg_run_length = avg_rl; }
+
+  void set_list_depth(cudf::size_type max_depth)
+  {
+    CUDF_EXPECTS(max_depth > 0, "List depth must be positive");
+    list_dist_desc.max_depth = max_depth;
+  }
+
+  void set_list_type(cudf::type_id type) { list_dist_desc.element_type = type; }
+
+  void set_struct_depth(cudf::size_type max_depth)
+  {
+    CUDF_EXPECTS(max_depth > 0, "Struct depth must be positive");
+    struct_dist_desc.max_depth = max_depth;
+  }
+
+  void set_struct_types(std::vector<cudf::type_id> const& types)
+  {
+    CUDF_EXPECTS(
+      std::none_of(
+        types.cbegin(), types.cend(), [](auto& type) { return type == cudf::type_id::STRUCT; }),
+      "Cannot include STRUCT as its own subtype");
+    struct_dist_desc.leaf_types = types;
+  }
+};
+
+/**
+ * @brief Strongly typed table size in bytes. Used to disambiguate overloads of
+ * `create_random_table`.
+ */
+struct table_size_bytes {
+  size_t size;
+};
+
+/**
+ * @brief Strongly typed row count. Used to disambiguate overloads of `create_random_table`.
+ */
+struct row_count {
+  cudf::size_type count;
+};
+
+/**
+ * @brief Deterministically generates a table filled with data with the given parameters.
+ *
+ * @param dtype_ids Vector of requested column types
+ * @param table_bytes Target size of the output table, in bytes. Some type may not produce columns
+ * of exact size
+ * @param data_params optional, set of data parameters describing the data profile for each type
+ * @param seed optional, seed for the pseudo-random engine
+ */
+std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
+                                                 table_size_bytes table_bytes,
+                                                 data_profile const& data_params = data_profile{},
+                                                 unsigned seed                   = 1);
+
+/**
+ * @brief Deterministically generates a table filled with data with the given parameters.
+ *
+ * @param dtype_ids Vector of requested column types
+ * @param num_rows Number of rows in the output table
+ * @param data_params optional, set of data parameters describing the data profile for each type
+ * @param seed optional, seed for the pseudo-random engine
+ */
+std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
+                                                 row_count num_rows,
+                                                 data_profile const& data_params = data_profile{},
+                                                 unsigned seed                   = 1);
+
+/**
+ * @brief Generate sequence columns starting with value 0 in first row and increasing by 1 in
+ * subsequent rows.
+ *
+ * @param dtype_ids Vector of requested column types
+ * @param num_rows Number of rows in the output table
+ * @param null_probability optional, probability of a null value
+ *  no value implies no null mask, =0 implies all valids, >=1 implies all nulls
+ * @param seed optional, seed for the pseudo-random engine
+ * @return A table with the sequence columns.
+ */
+std::unique_ptr<cudf::table> create_sequence_table(
+  std::vector<cudf::type_id> const& dtype_ids,
+  row_count num_rows,
+  std::optional<double> null_probability = std::nullopt,
+  unsigned seed                          = 1);
+
+/**
+ * @brief Repeats the input data types cyclically to fill a vector of @ref num_cols
+ * elements.
+ *
+ * @param dtype_ids Vector of requested column types
+ * @param num_cols Number of types in the output vector
+ * @return A vector of type_ids
+ */
+std::vector<cudf::type_id> cycle_dtypes(std::vector<cudf::type_id> const& dtype_ids,
+                                        cudf::size_type num_cols);
+/**
+ * @brief Create a random null mask object
+ *
+ * @param size number of rows
+ * @param null_probability probability of a null value
+ *  no value implies no null mask, =0 implies all valids, >=1 implies all nulls
+ * @param seed optional, seed for the pseudo-random engine
+ * @return null mask device buffer with random null mask data and null count
+ */
+std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
+  cudf::size_type size, std::optional<double> null_probability = std::nullopt, unsigned seed = 1);

--- a/src/main/cpp/benchmarks/common/random_distribution_factory.cuh
+++ b/src/main/cpp/benchmarks/common/random_distribution_factory.cuh
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "generate_input.hpp"
+
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <thrust/execution_policy.h>
+#include <thrust/random.h>
+#include <thrust/random/normal_distribution.h>
+#include <thrust/random/uniform_int_distribution.h>
+#include <thrust/tabulate.h>
+
+#include <algorithm>
+#include <memory>
+#include <type_traits>
+
+/**
+ * @brief Real Type that has atleast number of bits of integral type in its mantissa.
+ *  number of bits of integrals < 23 bits of mantissa in float
+ * to allow full range of integer bits to be generated.
+ * @tparam T integral type
+ */
+template <typename T>
+using integral_to_realType =
+  std::conditional_t<cuda::std::is_floating_point_v<T>,
+                     T,
+                     std::conditional_t<sizeof(T) * 8 <= 23, float, double>>;
+
+/**
+ * @brief Generates a normal distribution between zero and upper_bound.
+ */
+template <typename T>
+auto make_normal_dist(T lower_bound, T upper_bound)
+{
+  using realT    = integral_to_realType<T>;
+  T const mean   = lower_bound + (upper_bound - lower_bound) / 2;
+  T const stddev = (upper_bound - lower_bound) / 6;
+  return thrust::random::normal_distribution<realT>(mean, stddev);
+}
+
+template <typename T, std::enable_if_t<cuda::std::is_integral_v<T>, T>* = nullptr>
+auto make_uniform_dist(T range_start, T range_end)
+{
+  return thrust::uniform_int_distribution<T>(range_start, range_end);
+}
+
+template <typename T, std::enable_if_t<cudf::is_floating_point<T>()>* = nullptr>
+auto make_uniform_dist(T range_start, T range_end)
+{
+  return thrust::uniform_real_distribution<T>(range_start, range_end);
+}
+
+template <typename T>
+double geometric_dist_p(T range_size)
+{
+  constexpr double percentage_in_range = 0.99;
+  double const p                       = 1 - exp(log(1 - percentage_in_range) / range_size);
+  return p ? p : std::numeric_limits<double>::epsilon();
+}
+
+/**
+ * @brief Generates a geometric distribution between lower_bound and upper_bound.
+ * This distribution is an approximation generated using normal distribution.
+ *
+ * @tparam T Result type of the number to produce.
+ */
+template <typename T>
+class geometric_distribution : public thrust::random::normal_distribution<integral_to_realType<T>> {
+  using realType = integral_to_realType<T>;
+  using super_t  = thrust::random::normal_distribution<realType>;
+  T _lower_bound;
+  T _upper_bound;
+
+ public:
+  using result_type = T;
+  __host__ __device__ explicit geometric_distribution(T lower_bound, T upper_bound)
+    : super_t(0, std::labs(upper_bound - lower_bound) / 4.0),
+      _lower_bound(lower_bound),
+      _upper_bound(upper_bound)
+  {
+  }
+
+  template <typename UniformRandomNumberGenerator>
+  __host__ __device__ result_type operator()(UniformRandomNumberGenerator& urng)
+  {
+    return _lower_bound < _upper_bound ? std::abs(super_t::operator()(urng)) + _lower_bound
+                                       : _lower_bound - std::abs(super_t::operator()(urng));
+  }
+};
+
+template <typename T, typename Generator>
+struct value_generator {
+  using result_type = T;
+
+  value_generator(T lower_bound, T upper_bound, thrust::minstd_rand& engine, Generator gen)
+    : lower_bound(std::min(lower_bound, upper_bound)),
+      upper_bound(std::max(lower_bound, upper_bound)),
+      engine(engine),
+      dist(gen)
+  {
+  }
+
+  __device__ T operator()(size_t n)
+  {
+    engine.discard(n);
+    if constexpr (cuda::std::is_integral_v<T> &&
+                  cuda::std::is_floating_point_v<decltype(dist(engine))>) {
+      return std::clamp(static_cast<T>(std::round(dist(engine))), lower_bound, upper_bound);
+    } else {
+      return std::clamp(dist(engine), lower_bound, upper_bound);
+    }
+    // Note: uniform does not need clamp, because already range is guaranteed to be within bounds.
+  }
+
+  T lower_bound;
+  T upper_bound;
+  thrust::minstd_rand engine;
+  Generator dist;
+};
+
+template <typename T>
+using distribution_fn = std::function<rmm::device_uvector<T>(thrust::minstd_rand&, size_t)>;
+
+template <
+  typename T,
+  std::enable_if_t<cuda::std::is_integral_v<T> or cuda::std::is_floating_point_v<T>, T>* = nullptr>
+distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T upper_bound)
+{
+  switch (dist_id) {
+    case distribution_id::NORMAL:
+      return [lower_bound, upper_bound, dist = make_normal_dist(lower_bound, upper_bound)](
+               thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
+        rmm::device_uvector<T> result(size, cudf::default_stream_value);
+        thrust::tabulate(thrust::device,
+                         result.begin(),
+                         result.end(),
+                         value_generator{lower_bound, upper_bound, engine, dist});
+        return result;
+      };
+    case distribution_id::UNIFORM:
+      return [lower_bound, upper_bound, dist = make_uniform_dist(lower_bound, upper_bound)](
+               thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
+        rmm::device_uvector<T> result(size, cudf::default_stream_value);
+        thrust::tabulate(thrust::device,
+                         result.begin(),
+                         result.end(),
+                         value_generator{lower_bound, upper_bound, engine, dist});
+        return result;
+      };
+    case distribution_id::GEOMETRIC:
+      // kind of exponential distribution from lower_bound to upper_bound.
+      return [lower_bound, upper_bound, dist = geometric_distribution<T>(lower_bound, upper_bound)](
+               thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
+        rmm::device_uvector<T> result(size, cudf::default_stream_value);
+        thrust::tabulate(thrust::device,
+                         result.begin(),
+                         result.end(),
+                         value_generator{lower_bound, upper_bound, engine, dist});
+        return result;
+      };
+    default: CUDF_FAIL("Unsupported probability distribution");
+  }
+}


### PR DESCRIPTION
Closes #337

Currently, building benchmarks in spark-rapids-jni requires building of the cudf benchmarks in order to get the libcudf_datagen library. This PR copies the library from cudf and disables building the cudf benchmarks. 

Signed-off-by: Srikar Vanavasam<srikar.vanavasam@gmail.com>

