### PR TITLE
Allow providing a seed value for std::rand in faultinj config

### DIFF
--- a/src/main/cpp/faultinj/faultinj.cu
+++ b/src/main/cpp/faultinj/faultinj.cu
@@ -281,7 +281,7 @@ void CUPTIAPI faultInjectionCallbackHandler(void*,
 
   if (injectionProbability < 100) {
     if (injectionProbability <= 0) { return; }
-    const int rand10000     = rand() % 10000;
+    const int rand10000     = std::rand() % 10000;
     const int skipThreshold = injectionProbability * 10000 / 100;
     spdlog::trace("rand1000={} skipThreshold={}", rand10000, skipThreshold);
     if (rand10000 >= skipThreshold) { return; }
@@ -336,7 +336,7 @@ void CUPTIAPI faultInjectionCallbackHandler(void*,
         break;
       }
 
-    default: ;
+    default:;
   }
 }
 
@@ -366,6 +366,11 @@ void readFaultInjectorConfig(void)
   //
   const std::string dynamicConfigKey = "dynamic";
 
+  // An unsigned int to seed the random number generator to deterministically
+  // recreate a fault sequence
+  //
+  const std::string seedKey = "seed";
+
   // To retrieve a map of driver/runtime fault configs
   //   "functionName" -> fault config
   //   "CUPT callback id" -> fault config
@@ -380,6 +385,11 @@ void readFaultInjectorConfig(void)
 
     globalControl.dynamic =
       globalControl.configRoot.get_optional<bool>(dynamicConfigKey).value_or(false);
+
+    const unsigned seed =
+      globalControl.configRoot.get_optional<unsigned>(seedKey).value_or(std::time(0));
+    spdlog::info("Seeding std::srand with {}", seed);
+    std::srand(seed);
 
     const spdlog::level::level_enum logLevelEnum = static_cast<spdlog::level::level_enum>(logLevel);
     spdlog::info("changed log level to {}", logLevelEnum);

--- a/src/test/cpp/faultinj/test_faultinj.json
+++ b/src/test/cpp/faultinj/test_faultinj.json
@@ -17,7 +17,7 @@
             "interceptionCount": 1000
         },
         "cuLaunchKernel_ptsz": {
-            "percent": 1,
+            "percent": 0,
             "injectionType": 2,
             "substituteReturnCode": 2,
             "interceptionCount": 1000

--- a/src/test/cpp/faultinj/test_faultinj.json
+++ b/src/test/cpp/faultinj/test_faultinj.json
@@ -1,5 +1,6 @@
 {
     "logLevel": 1,
+    "seed": 12345,
     "dynamic": true,
     "cudaRuntimeFaults": {
         "cudaLaunchKernel_ptsz": {
@@ -16,7 +17,7 @@
             "interceptionCount": 1000
         },
         "cuLaunchKernel_ptsz": {
-            "percent": 10,
+            "percent": 1,
             "injectionType": 2,
             "substituteReturnCode": 2,
             "interceptionCount": 1000

--- a/src/test/cpp/faultinj/test_faultinj.json
+++ b/src/test/cpp/faultinj/test_faultinj.json
@@ -12,8 +12,14 @@
         "*": {
             "percent": 0,
             "injectionType": 2,
-            "substituteReturnCode": 999,
-            "interceptionCount": 1
+            "substituteReturnCode": 2,
+            "interceptionCount": 1000
+        },
+        "cuLaunchKernel_ptsz": {
+            "percent": 10,
+            "injectionType": 2,
+            "substituteReturnCode": 2,
+            "interceptionCount": 1000
         }
     }
 }


### PR DESCRIPTION
Add ability to provide a seed value in config. Closes #452  
    
Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
