### PR TITLE
add DOCKER_BUILD_EXTRA_ARGS and DOCKER_RUN_EXTRA_ARGS variable [skip ci]

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -26,7 +26,8 @@ REPODIR=$SCRIPTDIR/..
 
 CUDA_VERSION=${CUDA_VERSION:-11.5.0}
 DOCKER_CMD=${DOCKER_CMD:-docker}
-DOCKER_NETWORKING=${DOCKER_NETWORKING:-""}
+DOCKER_BUILD_EXTRA_ARGS=${DOCKER_BUILD_EXTRA_ARGS:-""}
+DOCKER_RUN_EXTRA_ARGS=${DOCKER_RUN_EXTRA_ARGS:-""}
 LOCAL_CCACHE_DIR=${LOCAL_CCACHE_DIR:-"$HOME/.ccache"}
 LOCAL_MAVEN_REPO=${LOCAL_MAVEN_REPO:-"$HOME/.m2/repository"}
 
@@ -35,7 +36,7 @@ SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-devel-centos7"
 # ensure directories exist
 mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO"
 
-$DOCKER_CMD build  $DOCKER_NETWORKING -f $REPODIR/ci/Dockerfile \
+$DOCKER_CMD build $DOCKER_BUILD_EXTRA_ARGS -f $REPODIR/ci/Dockerfile \
   --build-arg CUDA_VERSION=$CUDA_VERSION \
   -t $SPARK_IMAGE_NAME \
   $REPODIR/build
@@ -51,7 +52,7 @@ else
   DOCKER_ARGS="$*"
 fi
 
-$DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_NETWORKING -it -u $(id -u):$(id -g) --rm \
+$DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -it -u $(id -u):$(id -g) --rm \
   -v "/etc/group:/etc/group:ro" \
   -v "/etc/passwd:/etc/passwd:ro" \
   -v "/etc/shadow:/etc/shadow:ro" \

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -26,6 +26,7 @@ REPODIR=$SCRIPTDIR/..
 
 CUDA_VERSION=${CUDA_VERSION:-11.5.0}
 DOCKER_CMD=${DOCKER_CMD:-docker}
+DOCKER_NETWORKING=${DOCKER_NETWORKING:-""}
 LOCAL_CCACHE_DIR=${LOCAL_CCACHE_DIR:-"$HOME/.ccache"}
 LOCAL_MAVEN_REPO=${LOCAL_MAVEN_REPO:-"$HOME/.m2/repository"}
 
@@ -34,7 +35,7 @@ SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-devel-centos7"
 # ensure directories exist
 mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO"
 
-$DOCKER_CMD build -f $REPODIR/ci/Dockerfile \
+$DOCKER_CMD build  $DOCKER_NETWORKING -f $REPODIR/ci/Dockerfile \
   --build-arg CUDA_VERSION=$CUDA_VERSION \
   -t $SPARK_IMAGE_NAME \
   $REPODIR/build
@@ -50,7 +51,7 @@ else
   DOCKER_ARGS="$*"
 fi
 
-$DOCKER_CMD run $DOCKER_GPU_OPTS -it -u $(id -u):$(id -g) --rm \
+$DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_NETWORKING -it -u $(id -u):$(id -g) --rm \
   -v "/etc/group:/etc/group:ro" \
   -v "/etc/passwd:/etc/passwd:ro" \
   -v "/etc/shadow:/etc/shadow:ro" \


### PR DESCRIPTION
`./build/build-in-docker` is not working if vpn is enabled. And it's inconvenient to change script directly, So the PR add a DOCKER_NETWORKING to pass the network parameter, for example

```
DOCKER_NETWORKING="--network host" ./build/build-in-docker ...
```