### PR TITLE
A Spark compatible implementation of decimal128 multiply.

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -143,6 +143,8 @@ add_library(
   src/RowConversionJni.cpp
   src/NativeParquetJni.cpp
   src/row_conversion.cu
+  src/DecimalUtilsJni.cpp
+  src/decimal_utils.cu
 )
 
 set_target_properties(

--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "decimal_utils.hpp"
+#include "cudf_jni_apis.hpp"
+
+extern "C" {
+
+JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_multiply128(JNIEnv *env, jclass,
+                                                                                       jlong j_view_a,
+                                                                                       jlong j_view_b,
+                                                                                       jint j_product_scale) {
+  JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
+  JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto view_a = reinterpret_cast<cudf::column_view const *>(j_view_a);
+    auto view_b = reinterpret_cast<cudf::column_view const *>(j_view_b);
+    auto scale = static_cast<int>(j_product_scale);
+    return cudf::jni::convert_table_for_return(env, cudf::jni::multiply_decimal128(*view_a, *view_b,
+                                                                                   scale));
+  }
+  CATCH_STD(env, 0);
+}
+
+} // extern "C"

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -102,10 +102,6 @@ struct chunked256 {
     }
   }
 
-  inline __device__ bool is_zero() {
-    return chunks[0] == 0 && chunks[1] == 0 && chunks[2] == 0 && chunks[3] == 0;
-  }
-
 private:
   uint64_t chunks[4];
 };
@@ -482,7 +478,6 @@ struct dec128_multiplier : public thrust::unary_function<cudf::size_type, __int1
       overflows[i] = true;
       return;
     }
-    float test_scale_div = std::pow(10, exponent);
     __int128_t scale_divisor = std::pow(10, exponent);
 
     // scale and round to target scale

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2022, NVIDIA CORPORATION.
  *
@@ -51,13 +50,17 @@ struct chunked256 {
   inline __device__ uint64_t operator[](int i) const { return chunks[i]; }
   inline __device__ uint64_t &operator[](int i) { return chunks[i]; }
   inline __device__ int64_t sign() const { return static_cast<int64_t>(chunks[3]) >> 63; }
+
   inline __device__ void add(int a) {
-    // TODO how do we add -1? Done we need to sign extend it fully???
-    __uint128_t sum = a;
+    add(chunked256(static_cast<__int128_t>(a)));
+  }
+
+  inline __device__ void add(chunked256 const &a) {
+    __uint128_t carry_and_sum = 0;
     for (int i = 0; i < 4; ++i) {
-      sum = (sum + chunks[i]);
-      chunks[i] = static_cast<uint64_t>(sum);
-      sum >>= 64;
+      carry_and_sum += static_cast<__uint128_t>(chunks[i]) + a.chunks[i];
+      chunks[i] = static_cast<uint64_t>(carry_and_sum);
+      carry_and_sum >>= 64;
     }
   }
 
@@ -68,7 +71,7 @@ struct chunked256 {
     add(1);
   }
 
-  inline __device__ bool lt_unsigned(chunked256 & other) {
+  inline __device__ bool lt_unsigned(chunked256 const &other) const {
     for (int i = 3; i >= 0; i--) {
       if (chunks[i] < other.chunks[i]) {
         return true;
@@ -80,11 +83,11 @@ struct chunked256 {
   }
 
 
-  inline __device__ bool gte_unsigned(chunked256 & other) {
+  inline __device__ bool gte_unsigned(chunked256 const &other) const {
       return !lt_unsigned(other);
   }
 
-  inline __device__ int leading_zeros() {
+  inline __device__ int leading_zeros() const {
     if (sign() < 0) {
       chunked256 tmp = *this;
       tmp.negate();
@@ -173,259 +176,299 @@ __device__ divmod256 divide(chunked256 const &n, __int128_t const &d) {
   }
 }
 
-inline __device__ chunked256 pow_ten(int exp) {
-    switch(exp) {
-        case 0:
-  //1
-  return chunked256(0x0, 0x0, 0x0, 0x1);
-case 1:
-  //10
-  return chunked256(0x0, 0x0, 0x0, 0xa);
-case 2:
-  //100
-  return chunked256(0x0, 0x0, 0x0, 0x64);
-case 3:
-  //1000
-  return chunked256(0x0, 0x0, 0x0, 0x3e8);
-case 4:
-  //10000
-  return chunked256(0x0, 0x0, 0x0, 0x2710);
-case 5:
-  //100000
-  return chunked256(0x0, 0x0, 0x0, 0x186a0);
-case 6:
-  //1000000
-  return chunked256(0x0, 0x0, 0x0, 0xf4240);
-case 7:
-  //10000000
-  return chunked256(0x0, 0x0, 0x0, 0x989680);
-case 8:
-  //100000000
-  return chunked256(0x0, 0x0, 0x0, 0x5f5e100);
-case 9:
-  //1000000000
-  return chunked256(0x0, 0x0, 0x0, 0x3b9aca00);
-case 10:
-  //10000000000
-  return chunked256(0x0, 0x0, 0x0, 0x2540be400);
-case 11:
-  //100000000000
-  return chunked256(0x0, 0x0, 0x0, 0x174876e800);
-case 12:
-  //1000000000000
-  return chunked256(0x0, 0x0, 0x0, 0xe8d4a51000);
-case 13:
-  //10000000000000
-  return chunked256(0x0, 0x0, 0x0, 0x9184e72a000);
-case 14:
-  //100000000000000
-  return chunked256(0x0, 0x0, 0x0, 0x5af3107a4000);
-case 15:
-  //1000000000000000
-  return chunked256(0x0, 0x0, 0x0, 0x38d7ea4c68000);
-case 16:
-  //10000000000000000
-  return chunked256(0x0, 0x0, 0x0, 0x2386f26fc10000);
-case 17:
-  //100000000000000000
-  return chunked256(0x0, 0x0, 0x0, 0x16345785d8a0000);
-case 18:
-  //1000000000000000000
-  return chunked256(0x0, 0x0, 0x0, 0xde0b6b3a7640000);
-case 19:
-  //10000000000000000000
-  return chunked256(0x0, 0x0, 0x0, 0x8ac7230489e80000);
-case 20:
-  //100000000000000000000
-  return chunked256(0x0, 0x0, 0x5, 0x6bc75e2d63100000);
-case 21:
-  //1000000000000000000000
-  return chunked256(0x0, 0x0, 0x36, 0x35c9adc5dea00000);
-case 22:
-  //10000000000000000000000
-  return chunked256(0x0, 0x0, 0x21e, 0x19e0c9bab2400000);
-case 23:
-  //100000000000000000000000
-  return chunked256(0x0, 0x0, 0x152d, 0x2c7e14af6800000);
-case 24:
-  //1000000000000000000000000
-  return chunked256(0x0, 0x0, 0xd3c2, 0x1bcecceda1000000);
-case 25:
-  //10000000000000000000000000
-  return chunked256(0x0, 0x0, 0x84595, 0x161401484a000000);
-case 26:
-  //100000000000000000000000000
-  return chunked256(0x0, 0x0, 0x52b7d2, 0xdcc80cd2e4000000);
-case 27:
-  //1000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x33b2e3c, 0x9fd0803ce8000000);
-case 28:
-  //10000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x204fce5e, 0x3e25026110000000);
-case 29:
-  //100000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x1431e0fae, 0x6d7217caa0000000);
-case 30:
-  //1000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0xc9f2c9cd0, 0x4674edea40000000);
-case 31:
-  //10000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x7e37be2022, 0xc0914b2680000000);
-case 32:
-  //100000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x4ee2d6d415b, 0x85acef8100000000);
-case 33:
-  //1000000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x314dc6448d93, 0x38c15b0a00000000);
-case 34:
-  //10000000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x1ed09bead87c0, 0x378d8e6400000000);
-case 35:
-  //100000000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x13426172c74d82, 0x2b878fe800000000);
-case 36:
-  //1000000000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0xc097ce7bc90715, 0xb34b9f1000000000);
-case 37:
-  //10000000000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x785ee10d5da46d9, 0xf436a000000000);
-case 38:
-  //100000000000000000000000000000000000000
-  return chunked256(0x0, 0x0, 0x4b3b4ca85a86c47a, 0x98a224000000000);
-case 39:
-  //1000000000000000000000000000000000000000
-  return chunked256(0x0, 0x2, 0xf050fe938943acc4, 0x5f65568000000000);
-case 40:
-  //10000000000000000000000000000000000000000
-  return chunked256(0x0, 0x1d, 0x6329f1c35ca4bfab, 0xb9f5610000000000);
-case 41:
-  //100000000000000000000000000000000000000000
-  return chunked256(0x0, 0x125, 0xdfa371a19e6f7cb5, 0x4395ca0000000000);
-case 42:
-  //1000000000000000000000000000000000000000000
-  return chunked256(0x0, 0xb7a, 0xbc627050305adf14, 0xa3d9e40000000000);
-case 43:
-  //10000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x72cb, 0x5bd86321e38cb6ce, 0x6682e80000000000);
-case 44:
-  //100000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x47bf1, 0x9673df52e37f2410, 0x11d100000000000);
-case 45:
-  //1000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x2cd76f, 0xe086b93ce2f768a0, 0xb22a00000000000);
-case 46:
-  //10000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x1c06a5e, 0xc5433c60ddaa1640, 0x6f5a400000000000);
-case 47:
-  //100000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x118427b3, 0xb4a05bc8a8a4de84, 0x5986800000000000);
-case 48:
-  //1000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0xaf298d05, 0xe4395d69670b12b, 0x7f41000000000000);
-case 49:
-  //10000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x6d79f8232, 0x8ea3da61e066ebb2, 0xf88a000000000000);
-case 50:
-  //100000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x446c3b15f9, 0x926687d2c40534fd, 0xb564000000000000);
-case 51:
-  //1000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x2ac3a4edbbf, 0xb8014e3ba83411e9, 0x15e8000000000000);
-case 52:
-  //10000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x1aba4714957d, 0x300d0e549208b31a, 0xdb10000000000000);
-case 53:
-  //100000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x10b46c6cdd6e3, 0xe0828f4db456ff0c, 0x8ea0000000000000);
-case 54:
-  //1000000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0xa70c3c40a64e6, 0xc51999090b65f67d, 0x9240000000000000);
-case 55:
-  //10000000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x6867a5a867f103, 0xb2fffa5a71fba0e7, 0xb680000000000000);
-case 56:
-  //100000000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x4140c78940f6a24, 0xfdffc78873d4490d, 0x2100000000000000);
-case 57:
-  //1000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x0, 0x28c87cb5c89a2571, 0xebfdcb54864ada83, 0x4a00000000000000);
-case 58:
-  //10000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x1, 0x97d4df19d6057673, 0x37e9f14d3eec8920, 0xe400000000000000);
-case 59:
-  //100000000000000000000000000000000000000000000000000000000000
-  return chunked256(0xf, 0xee50b7025c36a080, 0x2f236d04753d5b48, 0xe800000000000000);
-case 60:
-  //1000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x9f, 0x4f2726179a224501, 0xd762422c946590d9, 0x1000000000000000);
-case 61:
-  //10000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x639, 0x17877cec0556b212, 0x69d695bdcbf7a87a, 0xa000000000000000);
-case 62:
-  //100000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x3e3a, 0xeb4ae1383562f4b8, 0x2261d969f7ac94ca, 0x4000000000000000);
-case 63:
-  //1000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x26e4d, 0x30eccc3215dd8f31, 0x57d27e23acbdcfe6, 0x8000000000000000);
-case 64:
-  //10000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x184f03, 0xe93ff9f4daa797ed, 0x6e38ed64bf6a1f01, 0x0);
-case 65:
-  //100000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0xf31627, 0x1c7fc3908a8bef46, 0x4e3945ef7a25360a, 0x0);
-case 66:
-  //1000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x97edd87, 0x1cfda3a5697758bf, 0xe3cbb5ac5741c64, 0x0);
-case 67:
-  //10000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x5ef4a747, 0x21e864761ea97776, 0x8e5f518bb6891be8, 0x0);
-case 68:
-  //100000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x3b58e88c7, 0x5313ec9d329eaaa1, 0x8fb92f75215b1710, 0x0);
-case 69:
-  //1000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x25179157c9, 0x3ec73e23fa32aa4f, 0x9d3bda934d8ee6a0, 0x0);
-case 70:
-  //10000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x172ebad6ddc, 0x73c86d67c5faa71c, 0x245689c107950240, 0x0);
-case 71:
-  //100000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0xe7d34c64a9c, 0x85d4460dbbca8719, 0x6b61618a4bd21680, 0x0);
-case 72:
-  //1000000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x90e40fbeea1d, 0x3a4abc8955e946fe, 0x31cdcf66f634e100, 0x0);
-case 73:
-  //10000000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x5a8e89d752524, 0x46eb5d5d5b1cc5ed, 0xf20a1a059e10ca00, 0x0);
-case 74:
-  //100000000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x3899162693736a, 0xc531a5a58f1fbb4b, 0x746504382ca7e400, 0x0);
-case 75:
-  //1000000000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x235fadd81c2822b, 0xb3f07877973d50f2, 0x8bf22a31be8ee800, 0x0);
-case 76:
-  //10000000000000000000000000000000000000000000000000000000000000000000000000000
-  return chunked256(0x161bcca7119915b5, 0x764b4abe8652979, 0x7775a5f171951000, 0x0);
-default:
-  return chunked256(0);
-    }
+/**
+ * Divide n by d and do half up rounding based off of the remainder returned.
+ */
+__device__ chunked256 divide_and_round(chunked256 const &n, __int128_t const &d) {
+  divmod256 div_result = divide(n, d);
 
+  bool const needIncrement = (div_result.remainder < 0 ? -div_result.remainder : div_result.remainder) 
+      >= (d >> 1);
+  int64_t const sign = div_result.quotient.sign();
+  int const roundIncrement = (needIncrement ? (sign < 0 ? -1 : 1) : 0);
+  div_result.quotient.add(roundIncrement);
+  return div_result.quotient;
+}
+
+inline __device__ chunked256 pow_ten(int exp) {
+  // Note that the body of this was generated using the following scala script
+  /*
+  import java.math.BigInteger
+  import java.lang.Long.toHexString
+
+  val lmax = new BigInteger(Long.MaxValue.toString())
+  val mask = lmax.or(lmax.shiftLeft(64))
+
+  def printAsInt128s(v: BigInteger): Unit = {
+    val len = v.bitLength();
+    System.out.print(s"0x${toHexString(v.shiftRight(192).longValue())}, ")
+    System.out.print(s"0x${toHexString(v.shiftRight(128).longValue())}, ")
+    System.out.print(s"0x${toHexString(v.shiftRight(64).longValue())}, ")
+    System.out.print(s"0x${toHexString(v.longValue)}")
+  }
+
+  (0 until 77).foreach { exp =>
+    val ret = BigInteger.TEN.pow(exp);
+    System.out.println(s"    case $exp:")
+    System.out.println(s"      //$ret")
+    System.out.print("      return chunked256(")
+    printAsInt128s(ret)
+    System.out.println(");")
+  }
+  */ 
+  switch(exp) {
+    case 0:
+      //1
+      return chunked256(0x0, 0x0, 0x0, 0x1);
+    case 1:
+      //10
+      return chunked256(0x0, 0x0, 0x0, 0xa);
+    case 2:
+      //100
+      return chunked256(0x0, 0x0, 0x0, 0x64);
+    case 3:
+      //1000
+      return chunked256(0x0, 0x0, 0x0, 0x3e8);
+    case 4:
+      //10000
+      return chunked256(0x0, 0x0, 0x0, 0x2710);
+    case 5:
+      //100000
+      return chunked256(0x0, 0x0, 0x0, 0x186a0);
+    case 6:
+      //1000000
+      return chunked256(0x0, 0x0, 0x0, 0xf4240);
+    case 7:
+      //10000000
+      return chunked256(0x0, 0x0, 0x0, 0x989680);
+    case 8:
+      //100000000
+      return chunked256(0x0, 0x0, 0x0, 0x5f5e100);
+    case 9:
+      //1000000000
+      return chunked256(0x0, 0x0, 0x0, 0x3b9aca00);
+    case 10:
+      //10000000000
+      return chunked256(0x0, 0x0, 0x0, 0x2540be400);
+    case 11:
+      //100000000000
+      return chunked256(0x0, 0x0, 0x0, 0x174876e800);
+    case 12:
+      //1000000000000
+      return chunked256(0x0, 0x0, 0x0, 0xe8d4a51000);
+    case 13:
+      //10000000000000
+      return chunked256(0x0, 0x0, 0x0, 0x9184e72a000);
+    case 14:
+      //100000000000000
+      return chunked256(0x0, 0x0, 0x0, 0x5af3107a4000);
+    case 15:
+      //1000000000000000
+      return chunked256(0x0, 0x0, 0x0, 0x38d7ea4c68000);
+    case 16:
+      //10000000000000000
+      return chunked256(0x0, 0x0, 0x0, 0x2386f26fc10000);
+    case 17:
+      //100000000000000000
+      return chunked256(0x0, 0x0, 0x0, 0x16345785d8a0000);
+    case 18:
+      //1000000000000000000
+      return chunked256(0x0, 0x0, 0x0, 0xde0b6b3a7640000);
+    case 19:
+      //10000000000000000000
+      return chunked256(0x0, 0x0, 0x0, 0x8ac7230489e80000);
+    case 20:
+      //100000000000000000000
+      return chunked256(0x0, 0x0, 0x5, 0x6bc75e2d63100000);
+    case 21:
+      //1000000000000000000000
+      return chunked256(0x0, 0x0, 0x36, 0x35c9adc5dea00000);
+    case 22:
+      //10000000000000000000000
+      return chunked256(0x0, 0x0, 0x21e, 0x19e0c9bab2400000);
+    case 23:
+      //100000000000000000000000
+      return chunked256(0x0, 0x0, 0x152d, 0x2c7e14af6800000);
+    case 24:
+      //1000000000000000000000000
+      return chunked256(0x0, 0x0, 0xd3c2, 0x1bcecceda1000000);
+    case 25:
+      //10000000000000000000000000
+      return chunked256(0x0, 0x0, 0x84595, 0x161401484a000000);
+    case 26:
+      //100000000000000000000000000
+      return chunked256(0x0, 0x0, 0x52b7d2, 0xdcc80cd2e4000000);
+    case 27:
+      //1000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x33b2e3c, 0x9fd0803ce8000000);
+    case 28:
+      //10000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x204fce5e, 0x3e25026110000000);
+    case 29:
+      //100000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x1431e0fae, 0x6d7217caa0000000);
+    case 30:
+      //1000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0xc9f2c9cd0, 0x4674edea40000000);
+    case 31:
+      //10000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x7e37be2022, 0xc0914b2680000000);
+    case 32:
+      //100000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x4ee2d6d415b, 0x85acef8100000000);
+    case 33:
+      //1000000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x314dc6448d93, 0x38c15b0a00000000);
+    case 34:
+      //10000000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x1ed09bead87c0, 0x378d8e6400000000);
+    case 35:
+      //100000000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x13426172c74d82, 0x2b878fe800000000);
+    case 36:
+      //1000000000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0xc097ce7bc90715, 0xb34b9f1000000000);
+    case 37:
+      //10000000000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x785ee10d5da46d9, 0xf436a000000000);
+    case 38:
+      //100000000000000000000000000000000000000
+      return chunked256(0x0, 0x0, 0x4b3b4ca85a86c47a, 0x98a224000000000);
+    case 39:
+      //1000000000000000000000000000000000000000
+      return chunked256(0x0, 0x2, 0xf050fe938943acc4, 0x5f65568000000000);
+    case 40:
+      //10000000000000000000000000000000000000000
+      return chunked256(0x0, 0x1d, 0x6329f1c35ca4bfab, 0xb9f5610000000000);
+    case 41:
+      //100000000000000000000000000000000000000000
+      return chunked256(0x0, 0x125, 0xdfa371a19e6f7cb5, 0x4395ca0000000000);
+    case 42:
+      //1000000000000000000000000000000000000000000
+      return chunked256(0x0, 0xb7a, 0xbc627050305adf14, 0xa3d9e40000000000);
+    case 43:
+      //10000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x72cb, 0x5bd86321e38cb6ce, 0x6682e80000000000);
+    case 44:
+      //100000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x47bf1, 0x9673df52e37f2410, 0x11d100000000000);
+    case 45:
+      //1000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x2cd76f, 0xe086b93ce2f768a0, 0xb22a00000000000);
+    case 46:
+      //10000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x1c06a5e, 0xc5433c60ddaa1640, 0x6f5a400000000000);
+    case 47:
+      //100000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x118427b3, 0xb4a05bc8a8a4de84, 0x5986800000000000);
+    case 48:
+      //1000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0xaf298d05, 0xe4395d69670b12b, 0x7f41000000000000);
+    case 49:
+      //10000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x6d79f8232, 0x8ea3da61e066ebb2, 0xf88a000000000000);
+    case 50:
+      //100000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x446c3b15f9, 0x926687d2c40534fd, 0xb564000000000000);
+    case 51:
+      //1000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x2ac3a4edbbf, 0xb8014e3ba83411e9, 0x15e8000000000000);
+    case 52:
+      //10000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x1aba4714957d, 0x300d0e549208b31a, 0xdb10000000000000);
+    case 53:
+      //100000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x10b46c6cdd6e3, 0xe0828f4db456ff0c, 0x8ea0000000000000);
+    case 54:
+      //1000000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0xa70c3c40a64e6, 0xc51999090b65f67d, 0x9240000000000000);
+    case 55:
+      //10000000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x6867a5a867f103, 0xb2fffa5a71fba0e7, 0xb680000000000000);
+    case 56:
+      //100000000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x4140c78940f6a24, 0xfdffc78873d4490d, 0x2100000000000000);
+    case 57:
+      //1000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x0, 0x28c87cb5c89a2571, 0xebfdcb54864ada83, 0x4a00000000000000);
+    case 58:
+      //10000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x1, 0x97d4df19d6057673, 0x37e9f14d3eec8920, 0xe400000000000000);
+    case 59:
+      //100000000000000000000000000000000000000000000000000000000000
+      return chunked256(0xf, 0xee50b7025c36a080, 0x2f236d04753d5b48, 0xe800000000000000);
+    case 60:
+      //1000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x9f, 0x4f2726179a224501, 0xd762422c946590d9, 0x1000000000000000);
+    case 61:
+      //10000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x639, 0x17877cec0556b212, 0x69d695bdcbf7a87a, 0xa000000000000000);
+    case 62:
+      //100000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x3e3a, 0xeb4ae1383562f4b8, 0x2261d969f7ac94ca, 0x4000000000000000);
+    case 63:
+      //1000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x26e4d, 0x30eccc3215dd8f31, 0x57d27e23acbdcfe6, 0x8000000000000000);
+    case 64:
+      //10000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x184f03, 0xe93ff9f4daa797ed, 0x6e38ed64bf6a1f01, 0x0);
+    case 65:
+      //100000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0xf31627, 0x1c7fc3908a8bef46, 0x4e3945ef7a25360a, 0x0);
+    case 66:
+      //1000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x97edd87, 0x1cfda3a5697758bf, 0xe3cbb5ac5741c64, 0x0);
+    case 67:
+      //10000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x5ef4a747, 0x21e864761ea97776, 0x8e5f518bb6891be8, 0x0);
+    case 68:
+      //100000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x3b58e88c7, 0x5313ec9d329eaaa1, 0x8fb92f75215b1710, 0x0);
+    case 69:
+      //1000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x25179157c9, 0x3ec73e23fa32aa4f, 0x9d3bda934d8ee6a0, 0x0);
+    case 70:
+      //10000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x172ebad6ddc, 0x73c86d67c5faa71c, 0x245689c107950240, 0x0);
+    case 71:
+      //100000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0xe7d34c64a9c, 0x85d4460dbbca8719, 0x6b61618a4bd21680, 0x0);
+    case 72:
+      //1000000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x90e40fbeea1d, 0x3a4abc8955e946fe, 0x31cdcf66f634e100, 0x0);
+    case 73:
+      //10000000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x5a8e89d752524, 0x46eb5d5d5b1cc5ed, 0xf20a1a059e10ca00, 0x0);
+    case 74:
+      //100000000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x3899162693736a, 0xc531a5a58f1fbb4b, 0x746504382ca7e400, 0x0);
+    case 75:
+      //1000000000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x235fadd81c2822b, 0xb3f07877973d50f2, 0x8bf22a31be8ee800, 0x0);
+    case 76:
+      //10000000000000000000000000000000000000000000000000000000000000000000000000000
+      return chunked256(0x161bcca7119915b5, 0x764b4abe8652979, 0x7775a5f171951000, 0x0);
+    default:
+      // This is not a supported value...
+      assert(0);
+    }
 }
 
 // check that the divide is going to do the right thing
 void check_scale_divisor(int source_scale, int target_scale) {
-  CUDF_EXPECTS(source_scale <= target_scale, "source scale is larger than target scale");
   int exponent = target_scale - source_scale;
   CUDF_EXPECTS(exponent <= cuda::std::numeric_limits<__int128_t>::digits10, "divisor too big");
 }
 
-// This gets a little complicated. We are trying to find the precision of a large
-// number that could up to 256 bits.
 inline __device__ int precision10(chunked256 value) {
     if (value.sign() < 0) {
-      // we wnat to do this on positive numbers
+      // we want to do this on positive numbers
       value.negate();
     }
+    // TODO this is a horrible way to do this. We should at least
+    // be able to approximate the log10 using the leading zeros similar to 
+    // http://graphics.stanford.edu/~seander/bithacks.html and then start
+    // the search around the guess.
     for (int i = 0; i <= 76; i++) {
       chunked256 tmp = pow_ten(i);
       if (tmp.gte_unsigned(value)) {
@@ -460,36 +503,35 @@ struct dec128_multiplier : public thrust::unary_function<cudf::size_type, __int1
 
     int mult_scale = a_scale + b_scale;
     if (first_div_precision > 0) {
+      //TODO would be great to have this reuse the look up table for pow10 for chunked256
       __int128_t first_div_scale_divisor = std::pow(10, first_div_precision);
-      divmod256 div_result = divide(product, first_div_scale_divisor);
-      product = div_result.quotient;
+      product = divide_and_round(product, first_div_scale_divisor);
 
-      bool const needIncrement = (div_result.remainder < 0 ? -div_result.remainder : div_result.remainder) 
-          >= (first_div_scale_divisor >> 1);
-      int64_t const sign = product.sign();
-      int const roundIncrement = (needIncrement ? sign < 0 ? -1 : 1 : 0);
-      product.add(roundIncrement);
       // a_scale and b_scale are negative. first_div_precision is not
       mult_scale = a_scale + b_scale + first_div_precision;
     }
 
     int exponent = prod_scale - mult_scale;
     if (exponent < 0) {
-      overflows[i] = true;
-      return;
-    }
-    __int128_t scale_divisor = std::pow(10, exponent);
+      // we need to multiply, but only if this will not overflow.
+      int new_precision = precision10(product);
+      if (new_precision - exponent > 38) {
+        // this would overflow...
+        overflows[i] = true;
+        return;
+      } else {
+        //TODO would be great to have this reuse the look up table for pow10 for chunked256
+        __int128_t scale_mult = std::pow(10, -exponent);
+        product = multiply(product, chunked256(scale_mult));
+      }
+    } else {
+      //TODO would be great to have this reuse the look up table for pow10 for chunked256
+      __int128_t scale_divisor = std::pow(10, exponent);
 
-    // scale and round to target scale
-    if (scale_divisor != 1) {
-      divmod256 div_result = divide(product, scale_divisor);
-      product = div_result.quotient;
-
-      bool const needIncrement = (div_result.remainder < 0 ? -div_result.remainder : div_result.remainder) 
-          >= (scale_divisor >> 1);
-      int64_t const sign = product.sign();
-      int const roundIncrement = (needIncrement ? sign < 0 ? -1 : 1 : 0);
-      product.add(roundIncrement);
+      // scale and round to target scale
+      if (scale_divisor != 1) {
+        product = divide_and_round(product, scale_divisor);
+      }
     }
 
     // check for overflow by ensuring no significant bits will be lost when truncating to 128-bits

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -1,0 +1,547 @@
+
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "decimal_utils.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/utilities/error.hpp>
+#include <cudf/table/table_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cmath>
+#include <cstddef>
+
+namespace {
+
+// Holds the 64-bit chunks of a 256-bit value
+struct chunked256 {
+  inline chunked256() = default;
+
+  // sign-extend a 128-bit value into a chunked 256-bit value
+  inline __device__ explicit chunked256(__int128_t x) {
+    chunks[0] = static_cast<uint64_t>(x);
+    __int128_t x_shifted = x >> 64;
+    chunks[1] = static_cast<uint64_t>(x_shifted);
+    chunks[2] = static_cast<uint64_t>(x_shifted >> 64);
+    chunks[3] = chunks[2];
+  }
+
+  inline __device__ explicit chunked256(uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
+    chunks[0] = d;
+    chunks[1] = c;
+    chunks[2] = b;
+    chunks[3] = a;
+  }
+
+  inline __device__ uint64_t operator[](int i) const { return chunks[i]; }
+  inline __device__ uint64_t &operator[](int i) { return chunks[i]; }
+  inline __device__ int64_t sign() const { return static_cast<int64_t>(chunks[3]) >> 63; }
+  inline __device__ void add(int a) {
+    // TODO how do we add -1? Done we need to sign extend it fully???
+    __uint128_t sum = a;
+    for (int i = 0; i < 4; ++i) {
+      sum = (sum + chunks[i]);
+      chunks[i] = static_cast<uint64_t>(sum);
+      sum >>= 64;
+    }
+  }
+
+  inline __device__ void negate() {
+    for (int i = 0; i < 4; i++) {
+      chunks[i] = ~chunks[i];
+    }
+    add(1);
+  }
+
+  inline __device__ bool lt_unsigned(chunked256 & other) {
+    for (int i = 3; i >= 0; i--) {
+      if (chunks[i] < other.chunks[i]) {
+        return true;
+      } else if (chunks[i] > other.chunks[i]) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+
+  inline __device__ bool gte_unsigned(chunked256 & other) {
+      return !lt_unsigned(other);
+  }
+
+  inline __device__ int leading_zeros() {
+    if (sign() < 0) {
+      chunked256 tmp = *this;
+      tmp.negate();
+      return tmp.leading_zeros();
+    }
+
+    int ret = 0;
+    for (int i = 3; i >= 0; i--) {
+      if (chunks[i] == 0) {
+        ret += 64;
+      } else {
+        ret += __clzll(chunks[i]);
+        return ret;
+      }
+    }
+  }
+
+  inline __device__ bool is_zero() {
+    return chunks[0] == 0 && chunks[1] == 0 && chunks[2] == 0 && chunks[3] == 0;
+  }
+
+private:
+  uint64_t chunks[4];
+};
+
+struct divmod256 {
+  chunked256 quotient;
+  __int128_t remainder;
+};
+
+// Perform a 256-bit multiply in 64-bit chunks
+__device__ chunked256 multiply(chunked256 const &a, chunked256 const &b) {
+  chunked256 r;
+  __uint128_t mul;
+  uint64_t carry = 0;
+  for (int a_idx = 0; a_idx < 4; ++a_idx) {
+    mul = static_cast<__uint128_t>(a[a_idx]) * b[0] + carry;
+    r[a_idx] = static_cast<uint64_t>(mul);
+    carry = static_cast<uint64_t>(mul >> 64);
+  }
+  for (int b_idx = 1; b_idx < 4; ++b_idx) {
+    carry = 0;
+    for (int a_idx = 0; a_idx < 4 - b_idx; ++a_idx) {
+      int r_idx = a_idx + b_idx;
+      mul = static_cast<__uint128_t>(a[a_idx]) * b[b_idx] + r[r_idx] + carry;
+      r[r_idx] = static_cast<uint64_t>(mul);
+      carry = static_cast<uint64_t>(mul >> 64);
+    }
+  }
+  return r;
+}
+
+__device__ divmod256 divide_unsigned(chunked256 const &n, __int128_t const &d) {
+  // TODO: FIXME this is long division, and so it is likely very slow...
+  chunked256 q(0);
+  __int128_t r = 0;
+
+  for (int i = 255; i >= 0; i--) {
+    int block = i / 64;
+    int bit = i % 64;
+    int read = (int)((n[block] >> bit) & 0x01);
+    r = r << 1;
+    r = r | read;
+
+    if (r >= d) {
+      r = r - d;
+
+      int64_t bit_set = 1L << bit;
+      q[block] = q[block] | bit_set;
+    }
+  }
+  return divmod256{q, r};
+}
+
+__device__ divmod256 divide(chunked256 const &n, __int128_t const &d) {
+  // TODO for now we are going to assume that d is not 0 and d is not negative
+  //   This is because it fits with how we currently use this divide and it can be added in later.
+  if (n.sign() >= 0) {
+    return divide_unsigned(n, d);
+  } else {
+    chunked256 tmp_n = n;
+    tmp_n.negate();
+
+    auto tmp_ret = divide_unsigned(tmp_n, d);
+      
+    tmp_ret.quotient.negate();
+    tmp_ret.remainder = -tmp_ret.remainder;
+
+    return tmp_ret;
+  }
+}
+
+inline __device__ chunked256 pow_ten(int exp) {
+    switch(exp) {
+        case 0:
+  //1
+  return chunked256(0x0, 0x0, 0x0, 0x1);
+case 1:
+  //10
+  return chunked256(0x0, 0x0, 0x0, 0xa);
+case 2:
+  //100
+  return chunked256(0x0, 0x0, 0x0, 0x64);
+case 3:
+  //1000
+  return chunked256(0x0, 0x0, 0x0, 0x3e8);
+case 4:
+  //10000
+  return chunked256(0x0, 0x0, 0x0, 0x2710);
+case 5:
+  //100000
+  return chunked256(0x0, 0x0, 0x0, 0x186a0);
+case 6:
+  //1000000
+  return chunked256(0x0, 0x0, 0x0, 0xf4240);
+case 7:
+  //10000000
+  return chunked256(0x0, 0x0, 0x0, 0x989680);
+case 8:
+  //100000000
+  return chunked256(0x0, 0x0, 0x0, 0x5f5e100);
+case 9:
+  //1000000000
+  return chunked256(0x0, 0x0, 0x0, 0x3b9aca00);
+case 10:
+  //10000000000
+  return chunked256(0x0, 0x0, 0x0, 0x2540be400);
+case 11:
+  //100000000000
+  return chunked256(0x0, 0x0, 0x0, 0x174876e800);
+case 12:
+  //1000000000000
+  return chunked256(0x0, 0x0, 0x0, 0xe8d4a51000);
+case 13:
+  //10000000000000
+  return chunked256(0x0, 0x0, 0x0, 0x9184e72a000);
+case 14:
+  //100000000000000
+  return chunked256(0x0, 0x0, 0x0, 0x5af3107a4000);
+case 15:
+  //1000000000000000
+  return chunked256(0x0, 0x0, 0x0, 0x38d7ea4c68000);
+case 16:
+  //10000000000000000
+  return chunked256(0x0, 0x0, 0x0, 0x2386f26fc10000);
+case 17:
+  //100000000000000000
+  return chunked256(0x0, 0x0, 0x0, 0x16345785d8a0000);
+case 18:
+  //1000000000000000000
+  return chunked256(0x0, 0x0, 0x0, 0xde0b6b3a7640000);
+case 19:
+  //10000000000000000000
+  return chunked256(0x0, 0x0, 0x0, 0x8ac7230489e80000);
+case 20:
+  //100000000000000000000
+  return chunked256(0x0, 0x0, 0x5, 0x6bc75e2d63100000);
+case 21:
+  //1000000000000000000000
+  return chunked256(0x0, 0x0, 0x36, 0x35c9adc5dea00000);
+case 22:
+  //10000000000000000000000
+  return chunked256(0x0, 0x0, 0x21e, 0x19e0c9bab2400000);
+case 23:
+  //100000000000000000000000
+  return chunked256(0x0, 0x0, 0x152d, 0x2c7e14af6800000);
+case 24:
+  //1000000000000000000000000
+  return chunked256(0x0, 0x0, 0xd3c2, 0x1bcecceda1000000);
+case 25:
+  //10000000000000000000000000
+  return chunked256(0x0, 0x0, 0x84595, 0x161401484a000000);
+case 26:
+  //100000000000000000000000000
+  return chunked256(0x0, 0x0, 0x52b7d2, 0xdcc80cd2e4000000);
+case 27:
+  //1000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x33b2e3c, 0x9fd0803ce8000000);
+case 28:
+  //10000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x204fce5e, 0x3e25026110000000);
+case 29:
+  //100000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x1431e0fae, 0x6d7217caa0000000);
+case 30:
+  //1000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0xc9f2c9cd0, 0x4674edea40000000);
+case 31:
+  //10000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x7e37be2022, 0xc0914b2680000000);
+case 32:
+  //100000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x4ee2d6d415b, 0x85acef8100000000);
+case 33:
+  //1000000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x314dc6448d93, 0x38c15b0a00000000);
+case 34:
+  //10000000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x1ed09bead87c0, 0x378d8e6400000000);
+case 35:
+  //100000000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x13426172c74d82, 0x2b878fe800000000);
+case 36:
+  //1000000000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0xc097ce7bc90715, 0xb34b9f1000000000);
+case 37:
+  //10000000000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x785ee10d5da46d9, 0xf436a000000000);
+case 38:
+  //100000000000000000000000000000000000000
+  return chunked256(0x0, 0x0, 0x4b3b4ca85a86c47a, 0x98a224000000000);
+case 39:
+  //1000000000000000000000000000000000000000
+  return chunked256(0x0, 0x2, 0xf050fe938943acc4, 0x5f65568000000000);
+case 40:
+  //10000000000000000000000000000000000000000
+  return chunked256(0x0, 0x1d, 0x6329f1c35ca4bfab, 0xb9f5610000000000);
+case 41:
+  //100000000000000000000000000000000000000000
+  return chunked256(0x0, 0x125, 0xdfa371a19e6f7cb5, 0x4395ca0000000000);
+case 42:
+  //1000000000000000000000000000000000000000000
+  return chunked256(0x0, 0xb7a, 0xbc627050305adf14, 0xa3d9e40000000000);
+case 43:
+  //10000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x72cb, 0x5bd86321e38cb6ce, 0x6682e80000000000);
+case 44:
+  //100000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x47bf1, 0x9673df52e37f2410, 0x11d100000000000);
+case 45:
+  //1000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x2cd76f, 0xe086b93ce2f768a0, 0xb22a00000000000);
+case 46:
+  //10000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x1c06a5e, 0xc5433c60ddaa1640, 0x6f5a400000000000);
+case 47:
+  //100000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x118427b3, 0xb4a05bc8a8a4de84, 0x5986800000000000);
+case 48:
+  //1000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0xaf298d05, 0xe4395d69670b12b, 0x7f41000000000000);
+case 49:
+  //10000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x6d79f8232, 0x8ea3da61e066ebb2, 0xf88a000000000000);
+case 50:
+  //100000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x446c3b15f9, 0x926687d2c40534fd, 0xb564000000000000);
+case 51:
+  //1000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x2ac3a4edbbf, 0xb8014e3ba83411e9, 0x15e8000000000000);
+case 52:
+  //10000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x1aba4714957d, 0x300d0e549208b31a, 0xdb10000000000000);
+case 53:
+  //100000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x10b46c6cdd6e3, 0xe0828f4db456ff0c, 0x8ea0000000000000);
+case 54:
+  //1000000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0xa70c3c40a64e6, 0xc51999090b65f67d, 0x9240000000000000);
+case 55:
+  //10000000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x6867a5a867f103, 0xb2fffa5a71fba0e7, 0xb680000000000000);
+case 56:
+  //100000000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x4140c78940f6a24, 0xfdffc78873d4490d, 0x2100000000000000);
+case 57:
+  //1000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x0, 0x28c87cb5c89a2571, 0xebfdcb54864ada83, 0x4a00000000000000);
+case 58:
+  //10000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x1, 0x97d4df19d6057673, 0x37e9f14d3eec8920, 0xe400000000000000);
+case 59:
+  //100000000000000000000000000000000000000000000000000000000000
+  return chunked256(0xf, 0xee50b7025c36a080, 0x2f236d04753d5b48, 0xe800000000000000);
+case 60:
+  //1000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x9f, 0x4f2726179a224501, 0xd762422c946590d9, 0x1000000000000000);
+case 61:
+  //10000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x639, 0x17877cec0556b212, 0x69d695bdcbf7a87a, 0xa000000000000000);
+case 62:
+  //100000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x3e3a, 0xeb4ae1383562f4b8, 0x2261d969f7ac94ca, 0x4000000000000000);
+case 63:
+  //1000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x26e4d, 0x30eccc3215dd8f31, 0x57d27e23acbdcfe6, 0x8000000000000000);
+case 64:
+  //10000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x184f03, 0xe93ff9f4daa797ed, 0x6e38ed64bf6a1f01, 0x0);
+case 65:
+  //100000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0xf31627, 0x1c7fc3908a8bef46, 0x4e3945ef7a25360a, 0x0);
+case 66:
+  //1000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x97edd87, 0x1cfda3a5697758bf, 0xe3cbb5ac5741c64, 0x0);
+case 67:
+  //10000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x5ef4a747, 0x21e864761ea97776, 0x8e5f518bb6891be8, 0x0);
+case 68:
+  //100000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x3b58e88c7, 0x5313ec9d329eaaa1, 0x8fb92f75215b1710, 0x0);
+case 69:
+  //1000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x25179157c9, 0x3ec73e23fa32aa4f, 0x9d3bda934d8ee6a0, 0x0);
+case 70:
+  //10000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x172ebad6ddc, 0x73c86d67c5faa71c, 0x245689c107950240, 0x0);
+case 71:
+  //100000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0xe7d34c64a9c, 0x85d4460dbbca8719, 0x6b61618a4bd21680, 0x0);
+case 72:
+  //1000000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x90e40fbeea1d, 0x3a4abc8955e946fe, 0x31cdcf66f634e100, 0x0);
+case 73:
+  //10000000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x5a8e89d752524, 0x46eb5d5d5b1cc5ed, 0xf20a1a059e10ca00, 0x0);
+case 74:
+  //100000000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x3899162693736a, 0xc531a5a58f1fbb4b, 0x746504382ca7e400, 0x0);
+case 75:
+  //1000000000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x235fadd81c2822b, 0xb3f07877973d50f2, 0x8bf22a31be8ee800, 0x0);
+case 76:
+  //10000000000000000000000000000000000000000000000000000000000000000000000000000
+  return chunked256(0x161bcca7119915b5, 0x764b4abe8652979, 0x7775a5f171951000, 0x0);
+default:
+  return chunked256(0);
+    }
+
+}
+
+// check that the divide is going to do the right thing
+void check_scale_divisor(int source_scale, int target_scale) {
+  CUDF_EXPECTS(source_scale <= target_scale, "source scale is larger than target scale");
+  int exponent = target_scale - source_scale;
+  CUDF_EXPECTS(exponent <= cuda::std::numeric_limits<__int128_t>::digits10, "divisor too big");
+}
+
+// This gets a little complicated. We are trying to find the precision of a large
+// number that could up to 256 bits.
+inline __device__ int precision10(chunked256 value) {
+    if (value.sign() < 0) {
+      // we wnat to do this on positive numbers
+      value.negate();
+    }
+    for (int i = 0; i <= 76; i++) {
+      chunked256 tmp = pow_ten(i);
+      if (tmp.gte_unsigned(value)) {
+        return i;
+      }
+    }
+    return -1;
+}
+
+// Functor to multiply two DECIMAL128 columns with rounding and overflow detection.
+struct dec128_multiplier : public thrust::unary_function<cudf::size_type, __int128_t> {
+  dec128_multiplier(bool *overflows, cudf::mutable_column_view const &product_view,
+                    cudf::column_view const &a_col, cudf::column_view const &b_col)
+      : overflows(overflows), a_data(a_col.data<__int128_t>()), b_data(b_col.data<__int128_t>()),
+        product_data(product_view.data<__int128_t>()),
+        a_scale(a_col.type().scale()), b_scale(b_col.type().scale()),
+        prod_scale(product_view.type().scale()) {}
+
+  __device__ __int128_t operator()(cudf::size_type i) const {
+    chunked256 const a(a_data[i]);
+    chunked256 const b(b_data[i]);
+
+    chunked256 product = multiply(a, b);
+
+    // Spark does some really odd things that I personally think are a bug
+    // https://issues.apache.org/jira/browse/SPARK-40129
+    // But to match Spark we need to first round the result to a precision of 38
+    // and this is specific to the value in the result of the multiply.
+    // Then we need to round the result to the final scale that we care about.
+    int dec_precision = precision10(product);
+    int first_div_precision = dec_precision - 38;
+
+    int mult_scale = a_scale + b_scale;
+    if (first_div_precision > 0) {
+      __int128_t first_div_scale_divisor = std::pow(10, first_div_precision);
+      divmod256 div_result = divide(product, first_div_scale_divisor);
+      product = div_result.quotient;
+
+      bool const needIncrement = (div_result.remainder < 0 ? -div_result.remainder : div_result.remainder) 
+          >= (first_div_scale_divisor >> 1);
+      int64_t const sign = product.sign();
+      int const roundIncrement = (needIncrement ? sign < 0 ? -1 : 1 : 0);
+      product.add(roundIncrement);
+      // a_scale and b_scale are negative. first_div_precision is not
+      mult_scale = a_scale + b_scale + first_div_precision;
+    }
+
+    int exponent = prod_scale - mult_scale;
+    if (exponent < 0) {
+      overflows[i] = true;
+      return;
+    }
+    float test_scale_div = std::pow(10, exponent);
+    __int128_t scale_divisor = std::pow(10, exponent);
+
+    // scale and round to target scale
+    if (scale_divisor != 1) {
+      divmod256 div_result = divide(product, scale_divisor);
+      product = div_result.quotient;
+
+      bool const needIncrement = (div_result.remainder < 0 ? -div_result.remainder : div_result.remainder) 
+          >= (scale_divisor >> 1);
+      int64_t const sign = product.sign();
+      int const roundIncrement = (needIncrement ? sign < 0 ? -1 : 1 : 0);
+      product.add(roundIncrement);
+    }
+
+    // check for overflow by ensuring no significant bits will be lost when truncating to 128-bits
+    int64_t sign = static_cast<int64_t>(product[1]) >> 63;
+    overflows[i] = !(sign == static_cast<int64_t>(product[2]) && sign == static_cast<int64_t>(product[3]));
+    product_data[i] = (static_cast<__int128_t>(product[1]) << 64) | product[0];
+  }
+
+private:
+
+  // output column for overflow detected
+  bool * const overflows;
+
+  // input data for multiply
+  __int128_t const * const a_data;
+  __int128_t const * const b_data;
+  __int128_t * const product_data;
+  int const a_scale;
+  int const b_scale;
+  int const prod_scale;
+};
+
+} // anonymous namespace
+
+namespace cudf::jni {
+
+std::unique_ptr<cudf::table>
+multiply_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t product_scale,
+                    rmm::cuda_stream_view stream) {
+  CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
+  CUDF_EXPECTS(b.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");
+  auto const num_rows = a.size();
+  CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
+  auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(cudf::table_view{{a, b}}, stream);
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  // copy the null mask here, as it will be used again later
+  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8}, num_rows,
+                                                  rmm::device_buffer(result_null_mask, stream), result_null_count, stream));
+  columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::DECIMAL128, product_scale}, num_rows, std::move(result_null_mask), result_null_count, stream));
+  auto overflows_view = columns[0]->mutable_view();
+  auto product_view = columns[1]->mutable_view();
+  check_scale_divisor(a.type().scale() + b.type().scale(), product_scale);
+  thrust::transform(rmm::exec_policy(stream), thrust::make_counting_iterator<cudf::size_type>(0),
+                    thrust::make_counting_iterator<cudf::size_type>(num_rows),
+                    product_view.begin<__int128_t>(),
+                    dec128_multiplier(overflows_view.begin<bool>(), product_view, a, b));
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+} // namespace cudf::jni

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/table/table.hpp>
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cstddef>
+
+namespace cudf::jni {
+
+std::unique_ptr<cudf::table>
+multiply_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t product_scale,
+                    rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+} // namespace cudf::jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnView;
+import ai.rapids.cudf.NativeDepsLoader;
+import ai.rapids.cudf.Table;
+
+public class DecimalUtils {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+
+  /**
+   * Multiply two DECIMAL128 columns together into a DECIMAL128 product rounded to the specified
+   * scale with overflow detection.
+   * @param a            factor input, must match row count of the other factor input
+   * @param b            factor input, must match row count of the other factor input
+   * @param productScale scale to use for the product type
+   * @return table containing a boolean column and a DECIMAL128 product column of the specified
+   *         scale. The boolean value will be true if an overflow was detected for that row's
+   *         DECIMAL128 product value. A null input row will result in a corresponding null output
+   *         row.
+   */
+  public static Table multiply128(ColumnView a, ColumnView b, int productScale) {
+    return new Table(multiply128(a.getNativeView(), b.getNativeView(), productScale));
+  }
+
+  private static native long[] multiply128(long viewA, long viewB, int productScale);
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -18,14 +18,10 @@ package com.nvidia.spark.rapids.jni;
 
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.DType;
-import ai.rapids.cudf.HostColumnVector;
 import ai.rapids.cudf.Table;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.MathContext;
-import java.math.RoundingMode;
 
 import static ai.rapids.cudf.AssertUtils.*;
 
@@ -68,6 +64,22 @@ public class DecimalUtilsTest {
              makeDec128Column("1.0", "5.6");
          ColumnVector expectedValid =
              ColumnVector.fromBooleans(false, false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -1)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void simplePosMultiplyZeroByNegOne() {
+    try (ColumnVector lhs =
+             makeDec128Column("1");
+         ColumnVector rhs =
+             makeDec128Column("1e1");
+         ColumnVector expectedBasic =
+             makeDec128Column("10.0");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false);
          Table found = DecimalUtils.multiply128(lhs, rhs, -1)) {
       assertColumnsAreEqual(expectedValid, found.getColumn(0));
       assertColumnsAreEqual(expectedBasic, found.getColumn(1));

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.HostColumnVector;
+import ai.rapids.cudf.Table;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.math.RoundingMode;
+
+import static ai.rapids.cudf.AssertUtils.*;
+
+public class DecimalUtilsTest {
+  ColumnVector makeDec128Column(String ... values) {
+    BigDecimal[] decVals = new BigDecimal[values.length];
+    for (int i = 0; i < values.length; i++) {
+      if (values[i] != null) {
+        decVals[i] = new BigDecimal(values[i]);
+      }
+    }
+    try (ColumnVector small = ColumnVector.fromDecimals(decVals)) {
+      return small.castTo(DType.create(DType.DTypeEnum.DECIMAL128, small.getType().getScale()));
+    }
+  }
+
+  @Test
+  void simplePosMultiplyOneByZero() {
+    try (ColumnVector lhs =
+             makeDec128Column("1.0", "10.0", "1000000000000000000000000000000000000.0");
+         ColumnVector rhs =
+             makeDec128Column("1",   "1",    "1");
+         ColumnVector expectedBasic =
+             makeDec128Column("1.0", "10.0", "1000000000000000000000000000000000000.0");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false, false, false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -1)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void simplePosMultiplyOneByOne() {
+    try (ColumnVector lhs =
+             makeDec128Column("1.0", "3.7");
+         ColumnVector rhs =
+             makeDec128Column("1.0", "1.5");
+         ColumnVector expectedBasic =
+             makeDec128Column("1.0", "5.6");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false, false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -1)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void largePosMultiplyTenByTen() {
+    try (ColumnVector lhs =
+             makeDec128Column("577694940161436285811555447.3103121126");
+         ColumnVector rhs =
+             makeDec128Column("100.0000000000");
+         ColumnVector expectedBasic =
+             makeDec128Column("57769494016143628581155544731.031211");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -6)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void overflowMult() {
+    try (ColumnVector lhs =
+             makeDec128Column("577694938495380589068894346.7625198736");
+         ColumnVector rhs =
+             makeDec128Column("-1258508260891400005608241690.1564700995");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(true);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -6)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+    }
+
+  }
+
+  @Test
+  void simpleNegMultiplyOneByZero() {
+    try (ColumnVector lhs =
+             makeDec128Column("1.0",  "-1.0", "10.0");
+         ColumnVector rhs =
+             makeDec128Column("-1",   "1",    "-1");
+         ColumnVector expectedBasic =
+             makeDec128Column("-1.0", "-1.0", "-10.0");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false, false, false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -1)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void simpleNegMultiplyOneByOne() {
+    try (ColumnVector lhs =
+             makeDec128Column("1.0",  "-1.0", "3.7");
+         ColumnVector rhs =
+             makeDec128Column("-1.0", "-1.0", "-1.5");
+         ColumnVector expectedBasic =
+             makeDec128Column("-1.0",  "1.0", "-5.6");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false, false, false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -1)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void simpleNegMultiplyTenByTenSparkCompat() {
+    // many of the numbers listed here are *NOT* what BigDecimal would 
+    // normally spit out. Spark has a bug https://issues.apache.org/jira/browse/SPARK-40129
+    // which causes some of the rounding to be off, so these come directly from
+    // Spark. It should be simple to fix this issue by deleteing code, or bypassing the
+    // first divide step when/if Spark fixes it.
+    try (ColumnVector lhs =
+             makeDec128Column("3358377338823096511784947656.4650294583",
+                 "7161021785186010157110137546.5940777916",
+                 "9173594185998001607642838421.5479932913");
+         ColumnVector rhs =
+             makeDec128Column("-12.0000000000",
+                 "-12.0000000000",
+                 "-12.0000000000");
+         ColumnVector expectedBasic =
+             makeDec128Column("-40300528065877158141419371877.580354",
+                 "-85932261422232121885321650559.128933",
+                 "-110083130231976019291714061058.575920");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false, false, false);
+         Table found = DecimalUtils.multiply128(lhs, rhs, -6)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+}


### PR DESCRIPTION
This is the native portion of doing an Apache Spark compatible full decimal multiply that requires up to a 256-bit intermediate value.

The code here is highly unoptimized. The divide is horribly slow. There are very basic optimizations we could do to almost any part of the code.  But even without all of those optimizations it is still a lot faster than the CPU, and it even appears to be faster than the existing multiply implementation. I have not done any profiling of the benchmarks to know why, but I suspect that it has something to do with having all of the overflow checks and scaling operations being done in a single kernel, instead of in multiple different kernels.

For the benchmark I ran the following query on a 12 thread/6-core CPU with an a6000 GPU in it. The batch size was set to 1 GiB because the batches get to be kind of big after casing a long to a 128-bit decimal value. I set the GPU parallelism to 4.

```
spark.time(spark.range(10000000000L).selectExpr("CAST(id as DECIMAL($PRECISION,0))").selectExpr("id * id as p").filter("p > 0").count())
```

precision | GPU | CPU | speedup
-- | -- | -- | --
9 | 6,413 | 63,248 | 9.86
10 | 8,062 | 151,103 | 18.74
18 | 8,027 | 175,387 | 21.85
19 | 4,844 | 174,887 | 36.10
32 | 4,853 | 172,636 | 35.57
38 | 4,859 | 173,061 | 35.62


The drop from about 8 seconds to 4.8 seconds at precision 19 appears to be when this new kernel takes over.

I will file follow on issues to actually optimize the code, and some others to try to migrate all decimal multiply operations to this, or a variant that is more specific to the given types involved.

Some of the core code is based off of an initial patch from @jlowe, but it has been highly modified.
