### PR TITLE
changing cmake to 3.23.3

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -35,7 +35,7 @@ RUN scl enable rh-python38 "pip install requests"
 RUN mkdir /usr/local/rapids && mkdir /rapids && chmod 777 /usr/local/rapids && chmod 777 /rapids
 
 # 3.22.3: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
-ARG CMAKE_VERSION=3.22.3
+ARG CMAKE_VERSION=3.23.3
 
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \
    tar zxf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \


### PR DESCRIPTION
Ran into a problem with cmake versions when building:
```
[INFO]      [exec] CMake Error at /home/knobby/code/spark-rapids-jni/target/libcudfjni/_deps/rapids-cmake-src/CMakeLists.txt:28 (cmake_minimum_required):
[INFO]      [exec]   CMake 3.23.1 or higher is required.  You are running version 3.22.3
```

Bumped to 3.24.2, which is latest and ran into a regression finding `cupti_static`. This was fixed in [this PR,](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7608) but it isn't released yet, so the suggestion was to use 3.23.3.

Signed-off-by: Mike Wilson <knobby@burntsheep.com>
