### PR TITLE
Fixing ansi casting to integer with decimal string values

### DIFF
--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -65,14 +65,14 @@ TYPED_TEST(StringToIntegerTests, Ansi)
   } catch (spark_rapids_jni::cast_error& e) {
     auto const row = [&]() {
       if constexpr (is_signed_type) {
-        return 5;
+        return 4;
       } else {
         return 2;
       }
     }();
     auto const first_error_string = [&]() {
       if constexpr (is_signed_type) {
-        return "asdf";
+        return "4.2";
       } else {
         return "+1";
       }


### PR DESCRIPTION
During testing with the plugin, I found that I was incorrect with handling of decimal strings like "1.2" in ansi mode. These values are converted to 1 in non-ansi mode, but are invalid in ansi. This change fixes that.

Signed-off-by: Mike Wilson <knobby@burntsheep.com>