### PR TITLE
Init JNI version 22.12.0-SNAPSHOT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "thirdparty/cudf"]
 	path = thirdparty/cudf
 	url = https://github.com/rapidsai/cudf.git
-	branch = branch-22.10
+	branch = branch-22.10 # TODO: update to branch-22.12 when https://github.com/rapidsai/cudf/pull/11764 is merged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ $ ./build/build-in-docker install ...
 ```
 
 Now cd to ~/repos/NVIDIA/spark-rapids and build with one of the options from
-[spark-rapids instructions](https://github.com/NVIDIA/spark-rapids/blob/branch-22.10/CONTRIBUTING.md#building-from-source).
+[spark-rapids instructions](https://github.com/NVIDIA/spark-rapids/blob/branch-22.12/CONTRIBUTING.md#building-from-source).
 
 ```bash
 $ ./build/buildall

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.nvidia</groupId>
   <artifactId>spark-rapids-jni</artifactId>
-  <version>22.10.0-SNAPSHOT</version>
+  <version>22.12.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>RAPIDS Accelerator JNI for Apache Spark</name>
   <description>

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ rapids_cuda_init_architectures(SPARK_RAPIDS_JNI)
 
 project(
   SPARK_RAPIDS_JNI
-  VERSION 22.10.00
+  VERSION 22.12.00
   LANGUAGES C CXX CUDA
 )
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Update JNI project version to 22.12

NOTE: 
As https://github.com/rapidsai/cudf/pull/11764 cudf 22.12 CI is not ready yet, we keep the submodule to 22.10

