### PR TITLE
Adding single kernel for string to decimal casting

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -59,4 +59,19 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toInteger(
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toDecimal(
+  JNIEnv* env, jclass, jlong input_column, jboolean ansi_enabled, jint precision, jint scale)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+
+    cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
+    return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_decimal(
+      precision, scale, scv, ansi_enabled, cudf::default_stream_value));
+  }
+  CATCH_CAST_EXCEPTION(env, 0);
+}
 }

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -357,9 +357,7 @@ __device__ thrust::optional<thrust::tuple<bool, int, int>> validate_and_exponent
     auto const last_state = state;
     state                 = validate_char(state, chr, char_num);
 
-    if (state == ST_INVALID) {
-      return thrust::nullopt;
-    }
+    if (state == ST_INVALID) { return thrust::nullopt; }
 
     if (last_state == ST_DIGITS && state != ST_DIGITS && state != ST_DECIMAL_POINT) {
       // past digits, save location

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -389,8 +389,7 @@ __global__ void string_to_decimal_kernel(T* out,
                                          bitmask_type const* incoming_null_mask,
                                          size_type num_rows,
                                          int32_t scale,
-                                         int32_t precision,
-                                         bool ansi_mode)
+                                         int32_t precision)
 {
   auto const group = cooperative_groups::this_thread_block();
   auto const warp  = cooperative_groups::tiled_partition<cudf::detail::warp_size>(group);
@@ -718,8 +717,7 @@ struct string_to_decimal_impl {
       string_col.null_mask(),
       string_col.size(),
       dtype.scale(),
-      precision,
-      ansi_mode);
+      precision);
 
     auto col =
       std::make_unique<column>(dtype, string_col.size(), data.release(), null_mask.release());

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -37,6 +37,12 @@ namespace detail {
 
 constexpr auto NUM_THREADS{256};
 
+/**
+ * @brief identifies if a character is whitespace
+ *
+ * @param chr character to test
+ * @return true if character is a whitespace character
+ */
 constexpr bool is_whitespace(char const chr)
 {
   switch (chr) {
@@ -48,8 +54,126 @@ constexpr bool is_whitespace(char const chr)
   }
 }
 
+template <typename T, std::enable_if_t<cuda::std::is_signed_v<T>>* = nullptr>
+T __device__ generic_abs(T value)
+{
+  return numeric::detail::abs(value);
+}
+
+template <typename T, std::enable_if_t<not cuda::std::is_signed_v<T>>* = nullptr>
+constexpr T __device__ generic_abs(T value)
+{
+  return value;
+}
+
+/**
+ * @brief determines if overflow will occur when multiplying
+ * a value by 10
+ *
+ * @tparam T type of the values
+ * @param val value to test
+ * @param adding adding or subtracting values
+ * @return true if overflow will occur by multiplying val by 10
+ */
 template <typename T>
-__global__ void string_to_integer_kernel(T* out,
+bool __device__ will_overflow(T const val, bool adding)
+{
+  if constexpr (std::is_signed_v<T>) {
+    if (!adding) {
+      auto constexpr minval = cuda::std::numeric_limits<T>::min() / 10;
+      if (val < minval) {
+        // overflow
+        return true;
+      }
+      return false;
+    }
+  }
+
+  auto constexpr maxval = cuda::std::numeric_limits<T>::max() / 10;
+  if (val > maxval) {
+    // overflow
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @brief determines if overflow will occur when adding or subtracting values
+ *
+ * @tparam T type of the values
+ * @param lhs left hand side of the operation
+ * @param rhs right hand side of the operation
+ * @param adding true if adding, false if subtracting
+ * @return true if overflow will occur from the operation
+ */
+template <typename T>
+bool __device__ will_overflow(T const lhs, T const rhs, bool adding)
+{
+  if constexpr (std::is_signed_v<T>) {
+    if (!adding) {
+      auto const min_val = cuda::std::numeric_limits<T>::min() + rhs;
+      if (lhs < min_val) {
+        // overflow
+        return true;
+      }
+      return false;
+    }
+  }
+
+  auto const max_val = cuda::std::numeric_limits<T>::max() - rhs;
+  if (lhs > max_val) {
+    // overflow
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @brief process a single digit of input
+ *
+ * @tparam T type of the input data
+ * @param first_value true if this is the first value added
+ * @param current_val current computed value
+ * @param new_digit digit to append to the computed value
+ * @param adding true if adding, false if subtracting
+ * @return true if success, false if overflow
+ */
+template <typename T>
+bool __device__ process_value(bool first_value, T& current_val, T const new_digit, bool adding)
+{
+  if (!first_value) {
+    if (will_overflow(current_val, adding)) { return false; }
+
+    current_val *= 10;
+  }
+
+  if (will_overflow(current_val, new_digit, adding)) { return false; }
+
+  if (adding) {
+    current_val += new_digit;
+  } else {
+    current_val -= new_digit;
+  }
+
+  return true;
+}
+
+/**
+ * @brief kernel to cast an array of strings to an array of integers
+ *
+ * @tparam T type of the integer array
+ * @param out integer array being written
+ * @param validity validity bit array for output data
+ * @param chars incoming character array
+ * @param offsets incoming offsets array into the character array
+ * @param incoming_null_mask incoming null mask for offsets array
+ * @param num_rows total number of elements in the integer array
+ * @param ansi_mode true if ansi mode is required, which is more strict and throws
+ */
+template <typename T>
+void __global__ string_to_integer_kernel(T* out,
                                          bitmask_type* validity,
                                          const char* const chars,
                                          offset_type const* offsets,
@@ -115,48 +239,321 @@ __global__ void string_to_integer_kernel(T* out,
       }
 
       if (!truncating && !trailing_whitespace) {
-        if (c != i) {
-          if (is_signed_type && sign < 0) {
-            auto constexpr minval = std::numeric_limits<T>::min() / 10;
-            if (thread_val < minval) {
-              // overflow
-              valid = false;
-              break;
-            }
-          } else {
-            auto constexpr maxval = std::numeric_limits<T>::max() / 10;
-            if (thread_val > maxval) {
-              // overflow
-              valid = false;
-              break;
-            }
-          }
-
-          thread_val *= 10;
-        }
-        if (is_signed_type && sign < 0) {
-          auto const c       = chr - '0';
-          auto const min_val = std::numeric_limits<T>::min() + c;
-          if (thread_val < min_val) {
-            // overflow
-            valid = false;
-            break;
-          }
-          thread_val -= c;
-        } else {
-          auto const c       = chr - '0';
-          auto const max_val = std::numeric_limits<T>::max() - c;
-          if (thread_val > max_val) {
-            // overflow
-            valid = false;
-            break;
-          }
-          thread_val += c;
+        T const new_digit = chr - '0';
+        if (!process_value(c == i, thread_val, new_digit, sign > 0)) {
+          valid = false;
+          break;
         }
       }
     }
 
     out[row] = thread_val;
+  }
+
+  auto const validity_int32 = warp.ballot(static_cast<int>(valid));
+  if (warp.thread_rank() == 0) {
+    validity[warp.meta_group_rank() + blockIdx.x * warp.meta_group_size()] = validity_int32;
+  }
+}
+
+template <typename T>
+__device__ thrust::optional<thrust::tuple<bool, int, int>> validate_and_exponent(const char* chars,
+                                                                                 const int len)
+{
+  T exponent_val         = 0;
+  int i                  = 0;
+  bool positive          = true;
+  bool exponent_positive = true;
+  int decimal_location   = -1;
+
+  // first pass is validation and figuring out decimal location taking into account possible
+  // scientific notation.
+
+  enum processing_state {
+    ST_DIGITS = 0,           // digits of decimal value
+    ST_EXPONENT,             // digits of exponent
+    ST_DECIMAL_POINT,        // reading a decimal point
+    ST_EXPONENT_OR_SIGN,     // reading exponent or sign value
+    ST_EXPONENT_SIGN,        // reading an exponent sign value
+    ST_VALIDATING_ONLY,      // validating string, but no longer processing values
+    ST_TRAILING_WHITESPACE,  // skipping over trailing whitespace
+    ST_INVALID,              // invalid data
+  };
+
+  auto validate_char = [&decimal_location, &exponent_positive](
+                         processing_state const state, const char chr, int chr_idx) {
+    switch (state) {
+      case ST_TRAILING_WHITESPACE:
+        if (!is_whitespace(chr)) { return ST_INVALID; }
+        break;
+      case ST_DECIMAL_POINT:
+      case ST_DIGITS:
+        if (chr > '9' || chr < '0') {
+          if (chr == '.' && decimal_location == -1) {
+            decimal_location = chr_idx;
+            return ST_DECIMAL_POINT;
+          } else if (chr == 'e' || chr == 'E') {
+            return ST_EXPONENT_OR_SIGN;
+          } else if (is_whitespace(chr) && chr_idx != 0) {
+            return ST_TRAILING_WHITESPACE;
+          } else {
+            // invalid character
+            return ST_INVALID;
+          }
+        }
+        return ST_DIGITS;
+      case ST_EXPONENT_OR_SIGN:
+        // we just skipped the e value, next is either a sign or a digit
+        if (chr == '+') {
+          return ST_EXPONENT_SIGN;
+        } else if (chr == '-') {
+          exponent_positive = false;
+          return ST_EXPONENT_SIGN;
+        } else if (is_whitespace(chr) && chr_idx != 0) {
+          return ST_TRAILING_WHITESPACE;
+        } else if (chr > '9' || chr < '0') {
+          return ST_INVALID;
+        } else {
+          return ST_EXPONENT;
+        }
+        break;
+      case ST_EXPONENT_SIGN:
+      case ST_EXPONENT:
+        if (chr > '9' || chr < '0') {
+          return ST_INVALID;
+        } else {
+          return ST_EXPONENT;
+        }
+        break;
+    }
+    return state;
+  };
+
+  if (len == 0) { return thrust::nullopt; }
+
+  processing_state state = ST_DIGITS;
+
+  // skip leading whitespace
+  while (i < len && is_whitespace(chars[i + row_start])) {
+    i++;
+  }
+
+  if (i < len) {
+    // check for leading +-
+    if (chars[i] == '-') {
+      positive = false;
+      i++;
+    } else if (chars[i] == '+') {
+      i++;
+    }
+  }
+
+  // if there is no data left, this is invalid
+  if (i == len) { return thrust::nullopt; }
+
+  auto const first_digit = i;
+  int last_digit         = len;
+  for (int c = i; c < len; ++c) {
+    auto const chr        = chars[c];
+    auto const char_num   = c - i;
+    auto const last_state = state;
+    state                 = validate_char(state, chr, char_num);
+
+    if (last_state == ST_DIGITS && state != ST_DIGITS && state != ST_DECIMAL_POINT) {
+      // past digits, save location
+      last_digit = c;
+    }
+
+    if (state == ST_EXPONENT) {
+      T const new_digit = chr - '0';
+      if (!process_value(exponent_val == 0, exponent_val, new_digit, exponent_positive)) {
+        return thrust::nullopt;
+      }
+    }
+  }
+
+  // decimal location moves to end of digits if no decimal found
+  if (decimal_location < 0) { decimal_location = last_digit - first_digit; }
+
+  // adjust decimal location based on exponent
+  decimal_location += exponent_val;
+
+  return thrust::make_tuple(positive, decimal_location, first_digit);
+}
+
+/**
+ * @brief kernel to cast an array of strings to an array of decimal values
+ *
+ * @tparam T underlying data type for the decimal array
+ * @param out array of decimal values
+ * @param validity validity for output array
+ * @param chars incoming character array
+ * @param offsets incoming offsets array into the character array
+ * @param incoming_null_mask incoming null mask for offsets array
+ * @param num_rows total number of elements in the integer array
+ * @param scale scale of desired decimals
+ * @param precision precision of desired decimals
+ * @param ansi_mode true if ansi mode is required, which is more strict and throws
+ * @return __global__
+ */
+template <typename T>
+__global__ void string_to_decimal_kernel(T* out,
+                                         bitmask_type* validity,
+                                         const char* const chars,
+                                         offset_type const* offsets,
+                                         bitmask_type const* incoming_null_mask,
+                                         size_type num_rows,
+                                         int32_t scale,
+                                         int32_t precision,
+                                         bool ansi_mode)
+{
+  auto const group = cooperative_groups::this_thread_block();
+  auto const warp  = cooperative_groups::tiled_partition<cudf::detail::warp_size>(group);
+
+  // each thread takes a row and marches it and builds the decimal for that row
+  auto const row = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row >= num_rows) { return; }
+  auto const active      = cooperative_groups::coalesced_threads();
+  auto const row_start   = offsets[row];
+  auto const len         = offsets[row + 1] - row_start;
+  bool const valid_entry = incoming_null_mask == nullptr || bit_is_set(incoming_null_mask, row);
+
+  auto ret   = validate_and_exponent<T>(&chars[row_start], len);
+  bool valid = ret.has_value();
+  bool positive;
+  int decimal_location;
+  int first_digit;
+
+  // first_digit is distance into the string array for the first digit to process. This skips +, -,
+  // whitespace, etc. decimal_location is the index into the string where the decimal point should
+  // live relative to first_digit. Note this isn't always where the decimal point is in the string.
+  // If it is the index of a digit, that digit is after the decimal point.
+
+  // turn into std::count_if
+  auto count_significant_digits = [](const char* str, int len, int num_digits) {
+    int count        = 0;
+    int digits_found = 0;
+    for (int i = 0; i < len && digits_found < num_digits; ++i) {
+      if (str[i] == 'e' || str[i] == 'E') {
+        break;
+      } else if (str[i] != '.') {
+        digits_found++;
+        if (count != 0 || str[i] != '0') {
+          count++;
+          continue;
+        }
+      }
+    }
+
+    return count;
+  };
+
+  if (valid) {
+    thrust::tie(positive, decimal_location, first_digit) = *ret;
+
+    auto const max_digits_before_decimal                   = precision + scale;
+    auto const significant_digits_before_decimal_in_string = count_significant_digits(
+      &chars[row_start + first_digit], len - first_digit, decimal_location);
+
+    // last digit we can process is scale units before or after the decimal
+    // depending on the scale sign. Note that rounding still needs to occur after that digit.
+    auto const last_digit = decimal_location - scale;
+
+    // number of precise digits we have encountered
+    int num_precise_digits = 0;
+    // number of digits we have encountered, even leading 0's
+    int total_digits = 0;
+
+    T thread_val = 0;
+
+    bool found_sig_digit = false;
+
+    // march string starting at first_digit and build value
+    for (int i = first_digit; i < len && valid; ++i) {
+      auto const chr = chars[row_start + i];
+      if (chr == '.') {
+        continue;
+      } else if (chr > '9' || chr < '0') {
+        // finished processing
+        break;
+      }
+
+      T const new_digit = chr - '0';
+      if (num_precise_digits + 1 > precision || total_digits + 1 > last_digit) {
+        // more digits than required, but we need to round
+        if (new_digit >= 5) {
+          if (will_overflow(thread_val, static_cast<T>(1), positive)) {
+            valid = false;
+            break;
+          } else if (positive) {
+            thread_val++;
+          } else {
+            thread_val--;
+          }
+        }
+        break;
+      }
+
+      total_digits++;
+      if (found_sig_digit || total_digits > decimal_location || new_digit != 0) {
+        found_sig_digit = true;
+        num_precise_digits++;
+      }
+
+      if (!process_value(i == first_digit, thread_val, new_digit, positive)) {
+        valid = false;
+        break;
+      }
+    }
+
+    auto const significant_preceeding_zeros = decimal_location < 0 ? abs(decimal_location) : 0;
+    auto const zeros_to_decimal             = std::max(0, decimal_location - total_digits);
+    auto const significant_digits_before_decimal =
+      significant_digits_before_decimal_in_string + zeros_to_decimal;
+
+    if (max_digits_before_decimal < significant_digits_before_decimal) {
+      // precision - scale gives us the maximum number of digits before the
+      // decimal before we need more precision to store the entire value.
+      // since scale is inverted, we add scale here.
+      valid = false;
+    }
+
+    // at this point we have the precise digits we need, but we might need trailing zeros on this
+    // value
+
+    // add zero pad until we hit the decimal location
+    // decimal(6,-2)
+    // string: 123456
+    // thread_value: 1235
+    // result -> 123500
+    for (int i = 0; i < zeros_to_decimal; ++i) {
+      if (will_overflow(thread_val, positive)) {
+        valid = false;
+        break;
+      }
+      thread_val *= 10;
+      num_precise_digits++;
+    }
+
+    // add zero pad to get to scale
+    // decimal(6,5)
+    // string: 0.012
+    // thread_value: 12
+    // result -> 1200
+    auto const digits_after_decimal =
+      num_precise_digits - significant_digits_before_decimal + significant_preceeding_zeros;
+    auto const digits_needed_after_decimal =
+      min(precision - significant_digits_before_decimal, -scale);
+
+    for (int i = digits_after_decimal; i < digits_needed_after_decimal; ++i) {
+      if (will_overflow(thread_val, positive)) {
+        valid = false;
+        break;
+      }
+      thread_val *= 10;
+    }
+
+    if (valid) { out[row] = thread_val; }
   }
 
   auto const validity_int32 = warp.ballot(static_cast<int>(valid));
@@ -176,7 +573,59 @@ struct row_valid_fn {
   bitmask_type const* string_col_null_mask;
 };
 
+/**
+ * @brief validates a column has no ansi errors, throws if error
+ *
+ * @param col column to verify
+ * @param source_col original string column used to create col
+ * @param stream stream on which to operate
+ */
+void validate_ansi_column(column_view const& col,
+                          strings_column_view const& source_col,
+                          rmm::cuda_stream_view stream)
+{
+  auto const num_nulls      = col.null_count();
+  auto const incoming_nulls = source_col.null_count();
+  auto const num_errors     = num_nulls - incoming_nulls;
+  if (num_errors > 0) {
+    auto const first_error = thrust::find_if(rmm::exec_policy(stream),
+                                             thrust::make_counting_iterator(0),
+                                             thrust::make_counting_iterator(col.size()),
+                                             row_valid_fn{col.null_mask(), source_col.null_mask()});
+
+    offset_type string_bounds[2];
+    cudaMemcpyAsync(&string_bounds,
+                    &source_col.offsets().data<offset_type>()[*first_error],
+                    sizeof(offset_type) * 2,
+                    cudaMemcpyDeviceToHost,
+                    stream.value());
+    stream.synchronize();
+
+    std::string dest;
+    dest.resize(string_bounds[1] - string_bounds[0]);
+
+    cudaMemcpyAsync(dest.data(),
+                    &source_col.chars().data<char const>()[string_bounds[0]],
+                    string_bounds[1] - string_bounds[0],
+                    cudaMemcpyDeviceToHost,
+                    stream.value());
+    stream.synchronize();
+
+    throw cast_error(*first_error, dest);
+  }
+}
+
 struct string_to_integer_impl {
+  /**
+   * @brief create column of type T from string columns
+   *
+   * @tparam T type of column to create
+   * @param string_col string column of incoming data
+   * @param ansi_mode strict ansi mode checking of incoming data, can throw
+   * @param stream stream on which to operate
+   * @param mr memory resource to use for allocations
+   * @return std::unique_ptr<column> column of type T created from strings
+   */
   template <typename T, typename std::enable_if_t<is_numeric<T>()>* = nullptr>
   std::unique_ptr<column> operator()(strings_column_view const& string_col,
                                      bool ansi_mode,
@@ -202,42 +651,14 @@ struct string_to_integer_impl {
     auto col = std::make_unique<column>(
       data_type{type_to_id<T>()}, string_col.size(), data.release(), null_mask.release());
 
-    if (ansi_mode) {
-      auto const num_nulls      = col->null_count();
-      auto const incoming_nulls = string_col.null_count();
-      auto const num_errors     = num_nulls - incoming_nulls;
-      if (num_errors > 0) {
-        auto const first_error =
-          thrust::find_if(rmm::exec_policy(stream),
-                          thrust::make_counting_iterator(0),
-                          thrust::make_counting_iterator(col->size()),
-                          row_valid_fn{col->view().null_mask(), string_col.null_mask()});
-
-        offset_type string_bounds[2];
-        cudaMemcpyAsync(&string_bounds,
-                        &string_col.offsets().data<offset_type>()[*first_error],
-                        sizeof(offset_type) * 2,
-                        cudaMemcpyDeviceToHost,
-                        stream.value());
-        stream.synchronize();
-
-        std::string dest;
-        dest.resize(string_bounds[1] - string_bounds[0]);
-
-        cudaMemcpyAsync(dest.data(),
-                        &string_col.chars().data<char const>()[string_bounds[0]],
-                        string_bounds[1] - string_bounds[0],
-                        cudaMemcpyDeviceToHost,
-                        stream.value());
-        stream.synchronize();
-
-        throw cast_error(*first_error, dest);
-      }
-    }
+    if (ansi_mode) { validate_ansi_column(col->view(), string_col, stream); }
 
     return col;
   }
 
+  /**
+   * @brief stub function for invalid types
+   */
   template <typename T, typename std::enable_if_t<!is_numeric<T>()>* = nullptr>
   std::unique_ptr<column> operator()(strings_column_view const& string_col,
                                      bool ansi_mode,
@@ -245,6 +666,70 @@ struct string_to_integer_impl {
                                      rmm::mr::device_memory_resource* mr)
   {
     CUDF_FAIL("Invalid integer column type");
+  }
+};
+
+struct string_to_decimal_impl {
+  /**
+   * @brief create deimal column of type T from strings column
+   *
+   * @tparam T decimal type requested
+   * @param dtype data type of result column, includes scale
+   * @param precision precision of incoming string data
+   * @param string_col strings to convert to decimal
+   * @param ansi_mode strict ansi mode checking of incoming data, can throw
+   * @param stream stream on which to operate
+   * @param mr memory resource to use for allocations
+   * @return std::unique_ptr<column> decimal column created from strings
+   */
+  template <typename T, typename std::enable_if_t<is_fixed_point<T>()>* = nullptr>
+  std::unique_ptr<column> operator()(data_type dtype,
+                                     int32_t precision,
+                                     strings_column_view const& string_col,
+                                     bool ansi_mode,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::mr::device_memory_resource* mr)
+  {
+    using Type = device_storage_type_t<T>;
+
+    rmm::device_uvector<Type> data(string_col.size(), stream, mr);
+    auto const num_words = bitmask_allocation_size_bytes(string_col.size()) / sizeof(bitmask_type);
+    rmm::device_uvector<bitmask_type> null_mask(num_words, stream, mr);
+
+    dim3 const blocks(util::div_rounding_up_unsafe(string_col.size(), detail::NUM_THREADS));
+    dim3 const threads{detail::NUM_THREADS};
+
+    detail::string_to_decimal_kernel<<<blocks, threads, 0, stream.value()>>>(
+      data.data(),
+      null_mask.data(),
+      string_col.chars().data<char const>(),
+      string_col.offsets().data<offset_type>(),
+      string_col.null_mask(),
+      string_col.size(),
+      dtype.scale(),
+      precision,
+      ansi_mode);
+
+    auto col =
+      std::make_unique<column>(dtype, string_col.size(), data.release(), null_mask.release());
+
+    if (ansi_mode) { validate_ansi_column(col->view(), string_col, stream); }
+
+    return col;
+  }
+
+  /**
+   * @brief stub function for invalid types
+   */
+  template <typename T, typename std::enable_if_t<!is_fixed_point<T>()>* = nullptr>
+  std::unique_ptr<column> operator()(data_type dtype,
+                                     int32_t precision,
+                                     strings_column_view const& string_col,
+                                     bool ansi_mode,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::mr::device_memory_resource* mr)
+  {
+    CUDF_FAIL("Invalid decimal column type");
   }
 };
 
@@ -269,6 +754,39 @@ std::unique_ptr<column> string_to_integer(data_type dtype,
 {
   return type_dispatcher(
     dtype, detail::string_to_integer_impl{}, string_col, ansi_mode, stream, mr);
+}
+
+/**
+ * @brief Convert a string column into an decimal column.
+ *
+ * @param precision precision of input data
+ * @param scale scale of input data
+ * @param string_col Incoming string column to convert to decimals.
+ * @param ansi_mode If true, strict conversion and throws on erorr.
+ *                  If false, null invalid entries.
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column
+ * @return std::unique_ptr<column> Decimal column that was created from string_col.
+ */
+std::unique_ptr<column> string_to_decimal(int32_t precision,
+                                          int32_t scale,
+                                          strings_column_view const& string_col,
+                                          bool ansi_mode,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr)
+{
+  data_type dtype = [precision, scale]() {
+    if (precision <= cuda::std::numeric_limits<int32_t>::digits10)
+      return data_type(type_id::DECIMAL32, -scale);
+    else if (precision <= cuda::std::numeric_limits<int64_t>::digits10)
+      return data_type(type_id::DECIMAL64, -scale);
+    else if (precision <= cuda::std::numeric_limits<__int128_t>::digits10)
+      return data_type(type_id::DECIMAL128, -scale);
+    else
+      CUDF_FAIL("Unable to support decimal with precision " + std::to_string(precision));
+  }();
+  return type_dispatcher(
+    dtype, detail::string_to_decimal_impl{}, dtype, precision, string_col, ansi_mode, stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -38,7 +38,7 @@ namespace detail {
 constexpr auto NUM_THREADS{256};
 
 /**
- * @brief identifies if a character is whitespace
+ * @brief Identify if a character is whitespace.
  *
  * @param chr character to test
  * @return true if character is a whitespace character
@@ -67,8 +67,7 @@ constexpr T __device__ generic_abs(T value)
 }
 
 /**
- * @brief determines if overflow will occur when multiplying
- * a value by 10
+ * @brief Determine if overflow will occur when multiplying a value by 10.
  *
  * @tparam T type of the values
  * @param val value to test
@@ -81,25 +80,16 @@ bool __device__ will_overflow(T const val, bool adding)
   if constexpr (std::is_signed_v<T>) {
     if (!adding) {
       auto constexpr minval = cuda::std::numeric_limits<T>::min() / 10;
-      if (val < minval) {
-        // overflow
-        return true;
-      }
-      return false;
+      return val < minval;
     }
   }
 
   auto constexpr maxval = cuda::std::numeric_limits<T>::max() / 10;
-  if (val > maxval) {
-    // overflow
-    return true;
-  }
-
-  return false;
+  return val > maxval;
 }
 
 /**
- * @brief determines if overflow will occur when adding or subtracting values
+ * @brief Determine if overflow will occur when adding or subtracting values.
  *
  * @tparam T type of the values
  * @param lhs left hand side of the operation

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -55,6 +55,17 @@ struct cast_error : public std::runtime_error {
   std::string _string_with_error;
 };
 
+/**
+ * @brief Convert a string column into an integer column.
+ *
+ * @param dtype Type of column to return.
+ * @param string_col Incoming string column to convert to integers.
+ * @param ansi_mode If true, strict conversion and throws on erorr.
+ *                  If false, null invalid entries.
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column
+ * @return std::unique_ptr<column> Integer column that was created from string_col.
+ */
 std::unique_ptr<cudf::column> string_to_integer(
   cudf::data_type dtype,
   cudf::strings_column_view const& string_col,
@@ -62,4 +73,23 @@ std::unique_ptr<cudf::column> string_to_integer(
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+/**
+ * @brief Convert a string column into an decimal column.
+ *
+ * @param precision precision of input data
+ * @param scale scale of input data
+ * @param string_col Incoming string column to convert to decimals.
+ * @param ansi_mode If true, strict conversion and throws on erorr.
+ *                  If false, null invalid entries.
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column
+ * @return std::unique_ptr<column> Decimal column that was created from string_col.
+ */
+std::unique_ptr<cudf::column> string_to_decimal(
+  int32_t precision,
+  int32_t scale,
+  cudf::strings_column_view const& string_col,
+  bool ansi_mode,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -320,6 +320,22 @@ TEST_F(StringToDecimalTests, PositiveScale)
 TEST_F(StringToDecimalTests, Edges)
 {
   {
+    auto const str = test::strings_column_wrapper({"123456789012345678901234567890123456.01"});
+    strings_column_view scv{str};
+
+    auto const result =
+      spark_rapids_jni::string_to_decimal(38, -2, scv, false, rmm::cuda_stream_default);
+    test::fixed_point_column_wrapper<__int128_t> expected(
+      {(static_cast<__int128_t>(123456789012345678ull) * 1000000000000000ull +
+        static_cast<__int128_t>(901234567890123ull)) *
+         100000 +
+       45601},
+      {1},
+      numeric::scale_type{-2});
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
+  }
+  {
     auto const str = test::strings_column_wrapper({"8.483315330475049E-4"});
     strings_column_view scv{str};
 
@@ -453,7 +469,8 @@ TEST_F(StringToDecimalTests, Edges)
 
     auto const result =
       spark_rapids_jni::string_to_decimal(6, 0, scv, false, rmm::cuda_stream_default);
-    test::fixed_point_column_wrapper<int32_t> expected({0, 0, 0, 0}, {0, 0, 0, 1}, numeric::scale_type{0});
+    test::fixed_point_column_wrapper<int32_t> expected(
+      {0, 0, 0, 0}, {0, 0, 0, 1}, numeric::scale_type{0});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
   }

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -320,6 +320,28 @@ TEST_F(StringToDecimalTests, PositiveScale)
 TEST_F(StringToDecimalTests, Edges)
 {
   {
+    auto const str = test::strings_column_wrapper({"8.483315330475049E-4"});
+    strings_column_view scv{str};
+
+    auto const result =
+      spark_rapids_jni::string_to_decimal(15, -1, scv, false, rmm::cuda_stream_default);
+    test::fixed_point_column_wrapper<int64_t> expected({0}, {1}, numeric::scale_type{-1});
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
+  }
+
+  {
+    auto const str = test::strings_column_wrapper({"8.483315330475049E-2"});
+    strings_column_view scv{str};
+
+    auto const result =
+      spark_rapids_jni::string_to_decimal(15, -1, scv, false, rmm::cuda_stream_default);
+    test::fixed_point_column_wrapper<int64_t> expected({1}, {1}, numeric::scale_type{-1});
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
+  }
+
+  {
     auto const str = test::strings_column_wrapper({"-1.0E14"});
     strings_column_view scv{str};
 
@@ -421,6 +443,17 @@ TEST_F(StringToDecimalTests, Edges)
     auto const result =
       spark_rapids_jni::string_to_decimal(6, -6, scv, false, rmm::cuda_stream_default);
     test::fixed_point_column_wrapper<int32_t> expected({0}, {0}, numeric::scale_type{-6});
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
+  }
+
+  {
+    auto const str = test::strings_column_wrapper({"NaN", "inf", "-inf", "0"});
+    strings_column_view scv{str};
+
+    auto const result =
+      spark_rapids_jni::string_to_decimal(6, 0, scv, false, rmm::cuda_stream_default);
+    test::fixed_point_column_wrapper<int32_t> expected({0, 0, 0, 0}, {0, 0, 0, 1}, numeric::scale_type{0});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
   }

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -21,8 +21,6 @@
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <cudf/io/parquet.hpp>
-
 #include <limits>
 #include <rmm/device_uvector.hpp>
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -36,5 +36,18 @@ public class CastStrings {
     return new ColumnVector(toInteger(cv.getNativeView(), ansiMode, type.getTypeId().getNativeId()));
   }
 
+  /**
+   * Convert a string column to an integer column of a specified type.
+   *
+   * @param cv the column data to process.
+   * @param ansiMode true if invalid data are errors, false if they should be nulls.
+   * @param type the type of the return column.
+   * @return the converted column.
+   */
+  public static ColumnVector toDecimal(ColumnView cv, boolean ansiMode, int precision, int scale) {
+    return new ColumnVector(toDecimal(cv.getNativeView(), ansiMode, precision, scale));
+  }
+
   private static native long toInteger(long nativeColumnView, boolean ansi_enabled, int dtype);
+  private static native long toDecimal(long nativeColumnView, boolean ansi_enabled, int precision, int scale);
 }


### PR DESCRIPTION
This adds a kernel to support casting a string to a decimal.

This is currently still WIP as there are some known edge cases from the plugin tests. I wanted to get this up to get input and decide about 22.10 vs 22.12 release.