### PR TITLE
Update location of clang-format file in cudf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
               - id: clang-format
                 files: \.(cu|cuh|h|hpp|cpp|inl)$
                 types_or: [file]
-                args: ['-fallback-style=none', '-style=file:thirdparty/cudf/cpp/.clang-format']
+                args: ['-fallback-style=none', '-style=file:thirdparty/cudf/.clang-format']


### PR DESCRIPTION
Cudf moved the location of the clang-format file we are using for formatting rules in [this PR](https://github.com/rapidsai/cudf/pull/11319). This change updates to where it lives now.