### PR TITLE
[auto-merge] bot-auto-merge-branch-22.10 to branch-22.12 [skip ci] [bot]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
               - id: clang-format
                 files: \.(cu|cuh|h|hpp|cpp|inl)$
                 types_or: [file]
-                args: ['-fallback-style=none', '-style=file:thirdparty/cudf/cpp/.clang-format']
+                args: ['-fallback-style=none', '-style=file:thirdparty/cudf/.clang-format']


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.10` to create a PR keeping `branch-22.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.