### PR TITLE
Update cudf submodule ref branch to 22.12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "thirdparty/cudf"]
 	path = thirdparty/cudf
 	url = https://github.com/rapidsai/cudf.git
-	branch = branch-22.10 # TODO: update to branch-22.12 when https://github.com/rapidsai/cudf/pull/11764 is merged
+	branch = branch-22.12


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #567, update submodule ref to cudf branch-22.12, update commit to current 22.12 HEAD https://github.com/rapidsai/cudf/commit/69a031cf1704a199a8575de9946681e4a705dceb

22.12 CI of cudf is available, we can bypass https://github.com/rapidsai/cudf/pull/11764 (will be covered by sync up pipeline after this PR) to update submodule ref first.
