### PR TITLE
Fixing incorrect invalidation of positive cudf scale decimal values

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -520,7 +520,7 @@ __global__ void string_to_decimal_kernel(T* out,
       }
     }
 
-    auto const significant_preceding_zeros = decimal_location < 0 ? abs(decimal_location) : 0;
+    auto const significant_preceding_zeros = decimal_location < 0 ? -decimal_location : 0;
     auto const zeros_to_decimal            = std::max(
       0, scale > 0 ? decimal_location - total_digits - scale : decimal_location - total_digits);
     auto const significant_digits_before_decimal =

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -521,7 +521,8 @@ __global__ void string_to_decimal_kernel(T* out,
     }
 
     auto const significant_preceeding_zeros = decimal_location < 0 ? abs(decimal_location) : 0;
-    auto const zeros_to_decimal             = std::max(0, decimal_location - total_digits);
+    auto const zeros_to_decimal             = std::max(
+      0, scale > 0 ? decimal_location - total_digits - scale : decimal_location - total_digits);
     auto const significant_digits_before_decimal =
       significant_digits_before_decimal_in_string + zeros_to_decimal + rounding_digits;
 

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -520,8 +520,8 @@ __global__ void string_to_decimal_kernel(T* out,
       }
     }
 
-    auto const significant_preceeding_zeros = decimal_location < 0 ? abs(decimal_location) : 0;
-    auto const zeros_to_decimal             = std::max(
+    auto const significant_preceding_zeros = decimal_location < 0 ? abs(decimal_location) : 0;
+    auto const zeros_to_decimal            = std::max(
       0, scale > 0 ? decimal_location - total_digits - scale : decimal_location - total_digits);
     auto const significant_digits_before_decimal =
       significant_digits_before_decimal_in_string + zeros_to_decimal + rounding_digits;
@@ -552,7 +552,7 @@ __global__ void string_to_decimal_kernel(T* out,
     // thread_value: 12
     // result -> 1200
     auto const digits_after_decimal =
-      num_precise_digits - significant_digits_before_decimal + significant_preceeding_zeros;
+      num_precise_digits - significant_digits_before_decimal + significant_preceding_zeros;
     auto const digits_needed_after_decimal =
       min(precision - significant_digits_before_decimal, -scale);
 


### PR DESCRIPTION
As outlined in https://github.com/NVIDIA/spark-rapids/issues/6693 with great details and reproduction steps, the latest kernel changes were incorrectly processing cudf positive scale decimals. Note that these are represented by Spark as negative scale decimals.

The issue was incorrectly counting the scaled off zeros as significant digits and resulting in either too many digits saved in the value or an invalid value. There were positive scale tests, but they were both insufficient and incorrect. These have been adjusted.

New test added that mimics the failed Spark test. Edge case tests added to verify the reproduction steps in the bug. Original tests adjusted to expect and produce the proper output.