### PR TITLE
Fixing empty columns when casting to integer or decimal crashing

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -643,6 +643,10 @@ struct string_to_integer_impl {
                                      rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr)
   {
+    if (string_col.size() == 0) {
+      return std::make_unique<column>(data_type{type_to_id<T>()}, 0, rmm::device_buffer{});
+    }
+
     rmm::device_uvector<T> data(string_col.size(), stream, mr);
     auto const num_words = bitmask_allocation_size_bytes(string_col.size()) / sizeof(bitmask_type);
     rmm::device_uvector<bitmask_type> null_mask(num_words, stream, mr);
@@ -762,8 +766,6 @@ std::unique_ptr<column> string_to_integer(data_type dtype,
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
 {
-  if (string_col.size() == 0) { return std::make_unique<column>(); }
-
   return type_dispatcher(
     dtype, detail::string_to_integer_impl{}, string_col, ansi_mode, stream, mr);
 }
@@ -787,7 +789,6 @@ std::unique_ptr<column> string_to_decimal(int32_t precision,
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
 {
-  if (string_col.size() == 0) { return std::make_unique<column>(); }
   data_type dtype = [precision, scale]() {
     if (precision <= cuda::std::numeric_limits<int32_t>::digits10)
       return data_type(type_id::DECIMAL32, scale);
@@ -798,6 +799,9 @@ std::unique_ptr<column> string_to_decimal(int32_t precision,
     else
       CUDF_FAIL("Unable to support decimal with precision " + std::to_string(precision));
   }();
+
+  if (string_col.size() == 0) { return std::make_unique<column>(dtype, 0, rmm::device_buffer{}); }
+
   return type_dispatcher(
     dtype, detail::string_to_decimal_impl{}, dtype, precision, string_col, ansi_mode, stream, mr);
 }

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -762,6 +762,8 @@ std::unique_ptr<column> string_to_integer(data_type dtype,
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
 {
+  if (string_col.size() == 0) { return std::make_unique<column>(); }
+
   return type_dispatcher(
     dtype, detail::string_to_integer_impl{}, string_col, ansi_mode, stream, mr);
 }
@@ -785,6 +787,7 @@ std::unique_ptr<column> string_to_decimal(int32_t precision,
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
 {
+  if (string_col.size() == 0) { return std::make_unique<column>(); }
   data_type dtype = [precision, scale]() {
     if (precision <= cuda::std::numeric_limits<int32_t>::digits10)
       return data_type(type_id::DECIMAL32, scale);

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -239,6 +239,7 @@ TYPED_TEST(StringToIntegerTests, Empty)
                                                     rmm::cuda_stream_default);
 
   EXPECT_EQ(result->size(), 0);
+  EXPECT_EQ(result->type().id(), type_to_id<TypeParam>());
 }
 
 TEST_F(StringToDecimalTests, Simple)
@@ -536,4 +537,6 @@ TEST_F(StringToDecimalTests, Empty)
     8, 2, strings_column_view{empty->view()}, false, rmm::cuda_stream_default);
 
   EXPECT_EQ(result->size(), 0);
+  EXPECT_EQ(result->type().id(), type_id::DECIMAL32);
+  EXPECT_EQ(result->type().scale(), 2);
 }

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -229,6 +229,18 @@ TYPED_TEST(StringToIntegerTests, Overflow)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 }
 
+TYPED_TEST(StringToIntegerTests, Empty)
+{
+  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{});
+
+  auto result = spark_rapids_jni::string_to_integer(data_type{type_to_id<TypeParam>()},
+                                                    strings_column_view{empty->view()},
+                                                    false,
+                                                    rmm::cuda_stream_default);
+
+  EXPECT_EQ(result->size(), 0);
+}
+
 TEST_F(StringToDecimalTests, Simple)
 {
   auto const strings = test::strings_column_wrapper({"1", "0", "-1"});
@@ -514,4 +526,14 @@ TEST_F(StringToDecimalTests, Edges)
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
   }
+}
+
+TEST_F(StringToDecimalTests, Empty)
+{
+  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{});
+
+  auto const result = spark_rapids_jni::string_to_decimal(
+    8, 2, strings_column_view{empty->view()}, false, rmm::cuda_stream_default);
+
+  EXPECT_EQ(result->size(), 0);
 }


### PR DESCRIPTION
As outlined in https://github.com/NVIDIA/spark-rapids/issues/6748 passing a completely empty string column into the casting kernel crashes. This fixes that since an empty column is valid.

closes https://github.com/NVIDIA/spark-rapids/issues/6748