### PR TITLE
Workaround to not use GITHUB_TOKEN checkout code in automerge [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -31,9 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           ref: ${{ env.HEAD }} # force to fetch from latest upstream instead of PR ref
+          token: ${{ secrets.AUTOMERGE_TOKEN }} # workaround auto-merge token to avoid GITHUB_TOKEN insufficient permission
 
       - name: push intermediate branch for auto-merge
         run: |


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

workaround to use PAT token instead default `GITHUB_TOKEN` to checkout code in automerge stages.

Verified in my forked ENV, to mimic the permission w/ read only access of `GITHUB_TOKEN`