### PR TITLE
Add in support for hilbert index as a part of zorder work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <submodule.check.skip>false</submodule.check.skip>
     <antrun.version>3.0.0</antrun.version>
+    <hilbert.version>0.2.2</hilbert.version>
   </properties>
 
   <dependencies>
@@ -151,6 +152,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.davidmoten</groupId>
+      <artifactId>hilbert-curve</artifactId>
+      <version>${hilbert.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/cpp/src/ZOrderJni.cpp
+++ b/src/main/cpp/src/ZOrderJni.cpp
@@ -35,4 +35,20 @@ Java_com_nvidia_spark_rapids_jni_ZOrder_interleaveBits(JNIEnv *env, jclass, jlon
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_jni_ZOrder_hilbertIndex(JNIEnv *env, jclass, jint num_bits, jlongArray input_columns) {
+  JNI_NULL_CHECK(env, input_columns, "input is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::jni::native_jpointerArray<cudf::column_view> n_input_columns(env, input_columns);
+    cudf::table_view tbl(n_input_columns.get_dereferenced());
+
+    return cudf::jni::ptr_as_jlong(spark_rapids_jni::hilbert_index(num_bits, tbl).release());
+  }
+  CATCH_STD(env, 0);
+}
+
+
+
 }

--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -27,6 +27,118 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 
+namespace {
+
+// pretends to be an array of uint32_t, but really only stores
+// the data in a long with a set number of bits allocated for
+// each item
+struct long_backed_array {
+  long_backed_array() = delete;
+  ~long_backed_array() = default;
+  long_backed_array(long_backed_array const&) = default;  ///< Copy constructor
+  long_backed_array(long_backed_array&&) = default;  ///< Move constructor
+  inline __device__ explicit long_backed_array(int32_t num_bits): data(0), 
+    num_bits(num_bits),  mask(static_cast<uint64_t>((1L << num_bits) - 1)) {}
+
+  /**
+   * @brief Copy assignment operator
+   *
+   * @return Reference to this object
+   */
+  long_backed_array& operator=(long_backed_array const&) = default;
+  /**
+   * @brief Move assignment operator
+   *
+   * @return Reference to this object (after transferring ownership)
+   */
+  long_backed_array& operator=(long_backed_array&&) = default;
+
+  inline __device__ uint32_t operator[](int i) const {
+    int32_t offset = num_bits * i;
+    return (data >> offset) & mask;
+  }
+
+  inline __device__ void set(int i, uint32_t value) {
+    int32_t offset = i * num_bits;
+    uint64_t masked_data = data & ~(static_cast<uint64_t>(mask) << offset);
+    data = masked_data | (static_cast<uint64_t>(value & mask) << offset);
+  }
+
+private:
+  uint64_t data;
+  int32_t num_bits;
+  uint32_t mask;
+};
+
+
+// Most of the hilbert index code is based off of the work done by David Moten at
+// https://github.com/davidmoten/hilbert-curve, which has the following Note in
+// the code too
+// This algorithm is derived from work done by John Skilling and published
+// in "Programming the Hilbert curve". (c) 2004 American Institute of Physics.
+// With thanks also to Paul Chernoch who published a C# algorithm for Skilling's
+// work on StackOverflow and
+// <a href="https://github.com/paulchernoch/HilbertTransformation">GitHub</a>.
+__device__ uint64_t to_hilbert_index(const long_backed_array & transposed_index, const int num_bits, const int num_dimensions) {
+  uint64_t b = 0;
+  int32_t length = num_bits * num_dimensions;
+  int32_t b_index = length - 1;
+  uint64_t mask = 1L << (num_bits - 1);
+  for (int i = 0; i < num_bits; i++) {
+    for (int j = 0; j < num_dimensions; j++) {
+      if ((transposed_index[j] & mask) != 0) {
+        b |= 1L << b_index;
+      }
+      b_index--;
+    }
+    mask >>= 1;
+  }
+  // b is expected to be BigEndian
+  return b;
+}
+
+__device__ long_backed_array hilbert_transposed_index(const long_backed_array & point, const int num_bits, const int num_dimensions) {
+  uint32_t const M = 1L << (num_bits - 1);
+  int32_t const n = num_dimensions;
+  long_backed_array x = point;
+
+  uint32_t p, q, t;
+  uint32_t i;
+  // Inverse undo
+  for (q = M; q > 1; q >>= 1) {
+    p = q - 1;
+    for (i = 0; i < n; i++) {
+      if ((x[i] & q) != 0) {
+        x.set(0, x[0] ^ p); // invert
+      } else {
+        t = (x[0] ^ x[i]) & p;
+        x.set(0, x[0] ^ t);
+        x.set(i, x[i] ^ t);
+      }
+    }
+  } // exchange
+
+  // Gray encode
+  for (i = 1; i < n; i++) {
+    x.set(i, x[i] ^ x[i - 1]);
+  }
+  t = 0;
+  for (q = M; q > 1; q >>= 1) {
+    if ((x[n - 1] & q) != 0) {
+      t ^= q - 1;
+    }
+  }
+
+  for (i = 0; i < n; i++) {
+    x.set(i, x[i] ^ t);
+  }
+
+  return x;
+}
+
+
+} // namespace
+
 namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> interleave_bits(
@@ -112,6 +224,54 @@ std::unique_ptr<cudf::column> interleave_bits(
     rmm::device_buffer(),
     stream,
     mr);
+}
+
+std::unique_ptr<cudf::column> hilbert_index(
+  int32_t const num_bits,
+  cudf::table_view const& tbl,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr) {
+ 
+  auto num_rows = tbl.num_rows();
+  auto num_columns = tbl.num_columns();
+
+  CUDF_EXPECTS(num_bits > 0 && num_bits <= 32, "the number of bits must be >0 and <= 32.");
+  CUDF_EXPECTS(num_bits * num_columns <= 64, "we only support up to 64 bits of output right now.");
+  CUDF_EXPECTS(num_columns > 0, "at least one column is required.");
+
+  CUDF_EXPECTS(
+    std::all_of(tbl.begin(),
+                tbl.end(),
+                [](cudf::column_view const& col) { return col.type().id() == cudf::type_id::INT32; }),
+    "All columns of the input table must be INT32.");
+
+  auto input_dv = cudf::table_device_view::create(tbl, stream);
+
+  auto output_data_col = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT64}, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
+
+  auto output_dv_ptr = cudf::mutable_column_device_view::create(*output_data_col, stream);
+
+  thrust::for_each_n(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<cudf::size_type>(0),
+    num_rows,
+    [output_col = *output_dv_ptr,
+     num_bits,
+     num_columns,
+     input = *input_dv] __device__ (cudf::size_type row_index) {
+       long_backed_array row(num_bits);
+       for (cudf::size_type column_index = 0; column_index < num_columns; column_index++) {
+         auto const column = input.column(column_index);
+         uint32_t const data = column.is_valid(row_index) ? column.data<uint32_t>()[row_index] : 0;
+         row.set(column_index, data);
+       }
+
+       auto transposed_index = hilbert_transposed_index(row, num_bits, num_columns);
+       output_col.data<uint64_t>()[row_index] = to_hilbert_index(transposed_index, num_bits, num_columns);
+     });
+
+  return output_data_col;
 }
 
 } // namespace spark_rapids_jni

--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -35,24 +35,8 @@ namespace {
 struct long_backed_array {
   using data_type = uint64_t;
   long_backed_array() = delete;
-  ~long_backed_array() = default;
-  long_backed_array(long_backed_array const&) = default;  ///< Copy constructor
-  long_backed_array(long_backed_array&&) = default;  ///< Move constructor
   __device__ explicit long_backed_array(int32_t num_bits_per_entry): data(0),
     num_bits_per_entry(num_bits_per_entry),  mask(static_cast<data_type>((1L << num_bits_per_entry) - 1)) {}
-
-  /**
-   * @brief Copy assignment operator
-   *
-   * @return Reference to this object
-   */
-  long_backed_array& operator=(long_backed_array const&) = default;
-  /**
-   * @brief Move assignment operator
-   *
-   * @return Reference to this object (after transferring ownership)
-   */
-  long_backed_array& operator=(long_backed_array&&) = default;
 
   __device__ uint32_t operator[](int32_t i) const {
     int32_t offset = num_bits_per_entry * i;

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -29,4 +29,10 @@ std::unique_ptr<cudf::column> interleave_bits(
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+std::unique_ptr<cudf::column> hilbert_index(
+  int32_t const num_bits,
+  cudf::table_view const& tbl,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 } // namespace spark_rapids_jni

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -26,13 +26,13 @@ namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> interleave_bits(
   cudf::table_view const& tbl,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> hilbert_index(
   int32_t const num_bits,
   cudf::table_view const& tbl,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::cuda_stream_view stream        = cudf::default_stream_value,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 } // namespace spark_rapids_jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/ZOrder.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ZOrder.java
@@ -58,6 +58,7 @@ public class ZOrder {
    * Yes a hilbertIndex is not technically used in zorder, but it is an alternative way to
    * cluster the data that databricks uses, and that is why we have it here. Please note that
    * this currently only supports indexes where numBits * inputColumns.length <= 64.
+   *
    * @param numBits the number of bits in the input columns to use. Typically, this is log2(max)
    *                for the values in all the inputColumns.
    * @param numRows the number of rows. Used if inputColumns is empty. I think this is also a corner

--- a/src/main/java/com/nvidia/spark/rapids/jni/ZOrder.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ZOrder.java
@@ -54,5 +54,34 @@ public class ZOrder {
     return new ColumnVector(interleaveBits(addrs));
   }
 
+  /**
+   * Yes a hilbertIndex is not technically used in zorder, but it is an alternative way to
+   * cluster the data that databricks uses, and that is why we have it here. Please note that
+   * this currently only supports indexes where numBits * inputColumns.length <= 64.
+   * @param numBits the number of bits in the input columns to use. Typically, this is log2(max)
+   *                for the values in all the inputColumns.
+   * @param numRows the number of rows. Used if inputColumns is empty. I think this is also a corner
+   *                case that can never happen in practice, but I am just covering my bases here.
+   *                a column of 0 is returned in this case.
+   * @param inputColumns The columns to intermix.
+   * @return the corresponding indexes stored as long values.
+   */
+  public static ColumnVector hilbertIndex(int numBits, int numRows, ColumnVector ... inputColumns) {
+    if (inputColumns.length == 0) {
+      try (Scalar zero = Scalar.fromLong(0)) {
+        return ColumnVector.fromScalar(zero, numRows);
+      }
+    }
+    long[] addrs = new long[inputColumns.length];
+    for (int index = 0; index < inputColumns.length; index++) {
+      ColumnVector cv = inputColumns[index];
+      addrs[index] = cv.getNativeView();
+    }
+
+    return new ColumnVector(hilbertIndex(numBits, addrs));
+  }
+
+  private static native long hilbertIndex(int numBits, long[] handles);
+
   private static native long interleaveBits(long[] handles);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/HilbertIndexTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HilbertIndexTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnVector;
+import org.davidmoten.hilbert.HilbertCurve;
+import org.davidmoten.hilbert.SmallHilbertCurve;
+import org.junit.jupiter.api.Test;
+
+import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+
+public class HilbertIndexTest {
+  static long[] getExpected(int numBits, int numRows, Integer[]... inputs) {
+    final int dimensions = inputs.length;
+    final int length = numBits * dimensions;
+    assert(length <= 64);
+    SmallHilbertCurve shc = HilbertCurve.small().bits(numBits).dimensions(dimensions);
+    long[] ret = new long[numRows];
+    long[] tmpInputs = new long[dimensions];
+    for (int rowIndex = 0; rowIndex < numRows; rowIndex++) {
+      for (int colIndex = 0; colIndex < dimensions; colIndex++) {
+        Integer i = inputs[colIndex][rowIndex];
+        if (i == null) {
+          i = 0;
+        }
+        tmpInputs[colIndex] = i;
+      }
+      if (tmpInputs.length == 0) {
+        ret[rowIndex] = 0;
+      } else {
+        ret[rowIndex] = shc.index(tmpInputs);
+      }
+    }
+    return ret;
+  }
+
+  public static void doTest(int numBits, int numRows, Integer[]... inputs) {
+    long[] expected = getExpected(numBits, numRows, inputs);
+    ColumnVector[] cvInputs = new ColumnVector[inputs.length];
+    try {
+      for (int columnIndex = 0; columnIndex < inputs.length; columnIndex++) {
+        cvInputs[columnIndex] = ColumnVector.fromBoxedInts(inputs[columnIndex]);
+      }
+      try (ColumnVector results = ZOrder.hilbertIndex(numBits, numRows, cvInputs);
+           ColumnVector expectedCv = ColumnVector.fromLongs(expected)) {
+        assertColumnsAreEqual(expectedCv, results);
+      }
+    } finally {
+      for (ColumnVector cv: cvInputs) {
+        if (cv != null) {
+          cv.close();
+        }
+      }
+    }
+  }
+
+  @Test
+  void test0() {
+    doTest(6, 10);
+  }
+
+  @Test
+  void test1NonNull() {
+    Integer[] inputs = {1, 2, 3, 4, 5};
+    doTest(3, inputs.length, inputs);
+  }
+
+  @Test
+  void test1Null() {
+    Integer[] inputs = {null, 7, null, 8};
+    doTest(4, inputs.length, inputs);
+  }
+
+  @Test
+  void testInt2NonNull() {
+    Integer[] inputs1 = {  1, 500, 1000, 250};
+    Integer[] inputs2 = {500, 400,  300, 200};
+    doTest(10, inputs1.length, inputs1, inputs2);
+  }
+
+  @Test
+  void testInt2Null() {
+    Integer[] inputs1 = {  0, null,  50, 1000};
+    Integer[] inputs2 = {200,  300, 100,    0};
+    doTest(10, inputs1.length, inputs1, inputs2);
+  }
+
+  @Test
+  void testInt3NonNull() {
+    Integer[] inputs1 = {0, 4, 1, 0, 1023, 512};
+    Integer[] inputs2 = {1, 8, 2, 0, 1023, 512};
+    Integer[] inputs3 = {2, 0, 4, 0, 1023, 512};
+    doTest(10, inputs1.length, inputs1, inputs2, inputs3);
+  }
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/InterleaveBitsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/InterleaveBitsTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
 
-public class ZOrderTest {
+public class InterleaveBitsTest {
 
   // The following source of truth comes from deltalake, but translated to java, and uses a List
   // to make our tests simpler. Deltalake only supports ints. For completeness and better


### PR DESCRIPTION
This is related to the interleave bits work done for zorder before. This is work to support the databricks internal implementation for zorder.