### PR TITLE
Update signoff checkout action ver to V3 [skip ci]

### DIFF
--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -23,7 +23,7 @@ jobs:
   signoff-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: sigoff-check job
         uses: ./.github/workflows/signoff-check


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

One more version update for signoff-check action,

All existing actions should have no more deprecations for 
>Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

>The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/