### PR TITLE
Change cudf::default_stream_value to cudf::get_default_stream()

### DIFF
--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -206,7 +206,7 @@ struct random_value_fn<T, std::enable_if_t<cudf::is_chrono<T>()>> {
     } else {
       // Don't need a random seconds generator for sub-second intervals
       seconds_gen = [range_s](thrust::minstd_rand&, size_t size) {
-        rmm::device_uvector<int64_t> result(size, cudf::default_stream_value);
+        rmm::device_uvector<int64_t> result(size, cudf::get_default_stream());
         thrust::fill(thrust::device, result.begin(), result.end(), range_s.second.count());
         return result;
       };
@@ -224,7 +224,7 @@ struct random_value_fn<T, std::enable_if_t<cudf::is_chrono<T>()>> {
   {
     auto const sec = seconds_gen(engine, size);
     auto const ns  = nanoseconds_gen(engine, size);
-    rmm::device_uvector<T> result(size, cudf::default_stream_value);
+    rmm::device_uvector<T> result(size, cudf::get_default_stream());
     thrust::transform(
       thrust::device,
       sec.begin(),
@@ -268,7 +268,7 @@ struct random_value_fn<T, std::enable_if_t<cudf::is_fixed_point<T>()>> {
       scale = numeric::scale_type{scale_dist(engine_scale)};
     }
     auto const ints = dist(engine, size);
-    rmm::device_uvector<T> result(size, cudf::default_stream_value);
+    rmm::device_uvector<T> result(size, cudf::get_default_stream());
     // Clamp the generated random value to the specified range
     thrust::transform(thrust::device,
                       ints.begin(),
@@ -313,7 +313,7 @@ struct random_value_fn<T, typename std::enable_if_t<std::is_same_v<T, bool>>> {
   random_value_fn(distribution_params<bool> const& desc)
     : dist{[valid_prob = desc.probability_true](thrust::minstd_rand& engine,
                                                 size_t size) -> rmm::device_uvector<bool> {
-        rmm::device_uvector<bool> result(size, cudf::default_stream_value);
+        rmm::device_uvector<bool> result(size, cudf::get_default_stream());
         thrust::tabulate(
           thrust::device, result.begin(), result.end(), bool_generator(engine, valid_prob));
         return result;
@@ -365,7 +365,7 @@ rmm::device_uvector<cudf::size_type> sample_indices_with_run_length(cudf::size_t
         return samples_indices[sample_idx];
       });
     rmm::device_uvector<cudf::size_type> repeated_sample_indices(num_rows,
-                                                                 cudf::default_stream_value);
+                                                                 cudf::get_default_stream());
     thrust::copy(thrust::device,
                  avg_repeated_sample_indices_iterator,
                  avg_repeated_sample_indices_iterator + num_rows,
@@ -399,8 +399,8 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
 
   // Distribution for picking elements from the array of samples
   auto const avg_run_len = profile.get_avg_run_length();
-  rmm::device_uvector<T> data(0, cudf::default_stream_value);
-  rmm::device_uvector<bool> null_mask(0, cudf::default_stream_value);
+  rmm::device_uvector<T> data(0, cudf::get_default_stream());
+  rmm::device_uvector<bool> null_mask(0, cudf::get_default_stream());
 
   if (profile.get_cardinality() == 0 and avg_run_len == 1) {
     data      = value_dist(engine, num_rows);
@@ -415,8 +415,8 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
     // generate n samples and gather.
     auto const sample_indices =
       sample_indices_with_run_length(avg_run_len, cardinality, num_rows, engine);
-    data      = rmm::device_uvector<T>(num_rows, cudf::default_stream_value);
-    null_mask = rmm::device_uvector<bool>(num_rows, cudf::default_stream_value);
+    data      = rmm::device_uvector<T>(num_rows, cudf::get_default_stream());
+    null_mask = rmm::device_uvector<bool>(num_rows, cudf::get_default_stream());
     thrust::gather(
       thrust::device, sample_indices.begin(), sample_indices.end(), samples.begin(), data.begin());
     thrust::gather(thrust::device,
@@ -495,12 +495,12 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
   auto valid_lengths = thrust::make_transform_iterator(
     thrust::make_zip_iterator(thrust::make_tuple(lengths.begin(), null_mask.begin())),
     valid_or_zero{});
-  rmm::device_uvector<cudf::size_type> offsets(num_rows + 1, cudf::default_stream_value);
+  rmm::device_uvector<cudf::size_type> offsets(num_rows + 1, cudf::get_default_stream());
   thrust::exclusive_scan(
     thrust::device, valid_lengths, valid_lengths + lengths.size(), offsets.begin());
   // offfsets are ready.
   auto chars_length = *thrust::device_pointer_cast(offsets.end() - 1);
-  rmm::device_uvector<char> chars(chars_length, cudf::default_stream_value);
+  rmm::device_uvector<char> chars(chars_length, cudf::get_default_stream());
   thrust::for_each_n(thrust::device,
                      thrust::make_zip_iterator(offsets.begin(), offsets.begin() + 1),
                      num_rows,

--- a/src/main/cpp/benchmarks/common/random_distribution_factory.cuh
+++ b/src/main/cpp/benchmarks/common/random_distribution_factory.cuh
@@ -148,7 +148,7 @@ distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T u
     case distribution_id::NORMAL:
       return [lower_bound, upper_bound, dist = make_normal_dist(lower_bound, upper_bound)](
                thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
-        rmm::device_uvector<T> result(size, cudf::default_stream_value);
+        rmm::device_uvector<T> result(size, cudf::get_default_stream());
         thrust::tabulate(thrust::device,
                          result.begin(),
                          result.end(),
@@ -158,7 +158,7 @@ distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T u
     case distribution_id::UNIFORM:
       return [lower_bound, upper_bound, dist = make_uniform_dist(lower_bound, upper_bound)](
                thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
-        rmm::device_uvector<T> result(size, cudf::default_stream_value);
+        rmm::device_uvector<T> result(size, cudf::get_default_stream());
         thrust::tabulate(thrust::device,
                          result.begin(),
                          result.end(),
@@ -169,7 +169,7 @@ distribution_fn<T> make_distribution(distribution_id dist_id, T lower_bound, T u
       // kind of exponential distribution from lower_bound to upper_bound.
       return [lower_bound, upper_bound, dist = geometric_distribution<T>(lower_bound, upper_bound)](
                thrust::minstd_rand& engine, size_t size) -> rmm::device_uvector<T> {
-        rmm::device_uvector<T> result(size, cudf::default_stream_value);
+        rmm::device_uvector<T> result(size, cudf::get_default_stream());
         thrust::tabulate(thrust::device,
                          result.begin(),
                          result.end(),

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -55,7 +55,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toInteger(
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_integer(
-      cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, cudf::default_stream_value));
+      cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, cudf::get_default_stream()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }
@@ -70,7 +70,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toDecimal(
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_decimal(
-      precision, scale, scv, ansi_enabled, cudf::default_stream_value));
+      precision, scale, scv, ansi_enabled, cudf::get_default_stream()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }
@@ -85,7 +85,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toFloat(
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_float(
-      cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, cudf::default_stream_value));
+      cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, cudf::get_default_stream()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -1271,7 +1271,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
       input_data.data(), input_nm.data(), data->mutable_view().data<int8_t>());
 
   return make_lists_column(num_rows, std::move(offsets), std::move(data), 0,
-                           rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
+                           rmm::device_buffer{0, cudf::get_default_stream(), mr}, stream, mr);
 }
 
 static inline bool are_all_fixed_width(std::vector<data_type> const &schema) {
@@ -1884,7 +1884,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
                    return make_lists_column(
                        batch_info.row_batches[batch].row_count, std::move(offsets), std::move(data),
-                       0, rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
+                       0, rmm::device_buffer{0, cudf::get_default_stream(), mr}, stream, mr);
                  });
 
   return ret;

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -26,13 +26,13 @@ namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> interleave_bits(
   cudf::table_view const& tbl,
-  rmm::cuda_stream_view stream        = cudf::default_stream_value,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> hilbert_index(
   int32_t const num_bits,
   cudf::table_view const& tbl,
-  rmm::cuda_stream_view stream        = cudf::default_stream_value,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 } // namespace spark_rapids_jni

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -48,7 +48,7 @@ TYPED_TEST(StringToIntegerTests, Simple)
   strings_column_view scv{strings};
 
   auto const result = spark_rapids_jni::string_to_integer(
-    data_type{type_to_id<TypeParam>()}, scv, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, scv, false, cudf::get_default_stream());
 
   test::fixed_width_column_wrapper<TypeParam> expected({1, 0, 42}, {1, 1, 1});
 
@@ -71,7 +71,7 @@ TYPED_TEST(StringToIntegerTests, Ansi)
 
   try {
     spark_rapids_jni::string_to_integer(
-      data_type{type_to_id<TypeParam>()}, scv, true, cudf::default_stream_value);
+      data_type{type_to_id<TypeParam>()}, scv, true, cudf::get_default_stream());
     CUDF_EXPECTS(false, "expected exception!");
   } catch (spark_rapids_jni::cast_error& e) {
     auto const row = [&]() {
@@ -94,7 +94,7 @@ TYPED_TEST(StringToIntegerTests, Ansi)
   }
 
   auto const result = spark_rapids_jni::string_to_integer(
-    data_type{type_to_id<TypeParam>()}, scv, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, scv, false, cudf::get_default_stream());
 
   test::fixed_width_column_wrapper<TypeParam> expected = []() {
     if constexpr (is_signed_type) {
@@ -142,7 +142,7 @@ TYPED_TEST(StringToIntegerTests, Overflow)
   strings_column_view scv{strings};
 
   auto result = spark_rapids_jni::string_to_integer(
-    data_type{type_to_id<TypeParam>()}, scv, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, scv, false, cudf::get_default_stream());
 
   auto const expected = [&]() {
     if constexpr (std::is_same_v<TypeParam, int8_t>) {
@@ -245,7 +245,7 @@ TYPED_TEST(StringToIntegerTests, Empty)
   auto result = spark_rapids_jni::string_to_integer(data_type{type_to_id<TypeParam>()},
                                                     strings_column_view{empty->view()},
                                                     false,
-                                                    cudf::default_stream_value);
+                                                    cudf::get_default_stream());
 
   EXPECT_EQ(result->size(), 0);
   EXPECT_EQ(result->type().id(), type_to_id<TypeParam>());
@@ -257,7 +257,7 @@ TEST_F(StringToDecimalTests, Simple)
   strings_column_view scv{strings};
 
   auto const result =
-    spark_rapids_jni::string_to_decimal(1, 0, scv, false, cudf::default_stream_value);
+    spark_rapids_jni::string_to_decimal(1, 0, scv, false, cudf::get_default_stream());
 
   test::fixed_point_column_wrapper<int32_t> expected({1, 0, -1}, {1, 1, 1}, numeric::scale_type{0});
 
@@ -270,7 +270,7 @@ TEST_F(StringToDecimalTests, OverPrecise)
   strings_column_view scv{strings};
 
   auto const result =
-    spark_rapids_jni::string_to_decimal(5, 0, scv, false, cudf::default_stream_value);
+    spark_rapids_jni::string_to_decimal(5, 0, scv, false, cudf::get_default_stream());
 
   test::fixed_point_column_wrapper<int32_t> expected(
     {0, 0, 0, 0}, {0, 0, 0, 0}, numeric::scale_type{0});
@@ -284,7 +284,7 @@ TEST_F(StringToDecimalTests, Rounding)
   strings_column_view scv{strings};
 
   auto const result =
-    spark_rapids_jni::string_to_decimal(5, -4, scv, false, cudf::default_stream_value);
+    spark_rapids_jni::string_to_decimal(5, -4, scv, false, cudf::get_default_stream());
 
   test::fixed_point_column_wrapper<int32_t> expected(
     {12346, 100000, -12346, -100000}, {1, 0, 1, 0}, numeric::scale_type{-4});
@@ -299,7 +299,7 @@ TEST_F(StringToDecimalTests, DecimalValues)
   strings_column_view scv{strings};
 
   auto const result =
-    spark_rapids_jni::string_to_decimal(6, -5, scv, false, cudf::default_stream_value);
+    spark_rapids_jni::string_to_decimal(6, -5, scv, false, cudf::get_default_stream());
 
   test::fixed_point_column_wrapper<int32_t> expected(
     {123400, 12345, -103400, -123}, {1, 1, 1, 1}, numeric::scale_type{-5});
@@ -314,7 +314,7 @@ TEST_F(StringToDecimalTests, ExponentalNotation)
   strings_column_view scv{strings};
 
   auto const result =
-    spark_rapids_jni::string_to_decimal(6, -5, scv, false, cudf::default_stream_value);
+    spark_rapids_jni::string_to_decimal(6, -5, scv, false, cudf::get_default_stream());
 
   test::fixed_point_column_wrapper<int32_t> expected(
     {12340, 123450, -1034, -12346}, {1, 1, 1, 1}, numeric::scale_type{-5});
@@ -330,7 +330,7 @@ TEST_F(StringToDecimalTests, PositiveScale)
     strings_column_view scv{strings};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(6, 2, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(6, 2, scv, false, cudf::get_default_stream());
 
     test::fixed_point_column_wrapper<int32_t> expected(
       {1, 1235, -12, -12}, {1, 1, 1, 1}, numeric::scale_type{2});
@@ -346,7 +346,7 @@ TEST_F(StringToDecimalTests, PositiveScale)
     strings_column_view scv{strings};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(8, 3, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(8, 3, scv, false, cudf::get_default_stream());
 
     test::fixed_point_column_wrapper<int32_t> expected(
       {813847, 43470,  548977, 985947, 325680, 0,      957413, 541903, 150051, 663969,
@@ -365,7 +365,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(38, -2, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(38, -2, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<__int128_t> expected(
       {(static_cast<__int128_t>(123456789012345678ull) * 1000000000000000ull +
         static_cast<__int128_t>(901234567890123ull)) *
@@ -381,7 +381,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int64_t> expected({0}, {1}, numeric::scale_type{-1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -392,7 +392,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int64_t> expected({1}, {1}, numeric::scale_type{-1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -403,7 +403,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int64_t> expected({0}, {0}, numeric::scale_type{-1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -414,7 +414,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(16, -1, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(16, -1, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int64_t> expected(
       {-1'000'000'000'000'000}, {1}, numeric::scale_type{-1});
 
@@ -426,7 +426,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(15, -1, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int64_t> expected({8575859000}, {1}, numeric::scale_type{-1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -437,7 +437,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(3, -1, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(3, -1, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({100}, {1}, numeric::scale_type{-1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -448,7 +448,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(9, -8, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(9, -8, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({171428573}, {1}, numeric::scale_type{-8});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -459,13 +459,13 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(9, -8, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(9, -8, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({171428573}, {1}, numeric::scale_type{-8});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 
     auto const fail_result =
-      spark_rapids_jni::string_to_decimal(9, -9, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(9, -9, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> null_col({0}, {0}, numeric::scale_type{-9});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(fail_result->view(), null_col);
@@ -476,7 +476,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(9, -8, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(9, -8, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({0}, {0}, numeric::scale_type{-8});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -487,7 +487,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(6, -6, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(6, -6, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({123457}, {1}, numeric::scale_type{-6});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -498,7 +498,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(6, -6, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(6, -6, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({0}, {0}, numeric::scale_type{-6});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -509,7 +509,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(6, 0, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(6, 0, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected(
       {0, 0, 0, 0}, {0, 0, 0, 1}, numeric::scale_type{0});
 
@@ -520,7 +520,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(8, 3, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(8, 3, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected({1234568}, {1}, numeric::scale_type{3});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
@@ -530,7 +530,7 @@ TEST_F(StringToDecimalTests, Edges)
     strings_column_view scv{str};
 
     auto const result =
-      spark_rapids_jni::string_to_decimal(4, 6, scv, false, cudf::default_stream_value);
+      spark_rapids_jni::string_to_decimal(4, 6, scv, false, cudf::get_default_stream());
     test::fixed_point_column_wrapper<int32_t> expected(
       {4347, 4348}, {1, 1}, numeric::scale_type{6});
 
@@ -543,7 +543,7 @@ TEST_F(StringToDecimalTests, Empty)
   auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{});
 
   auto const result = spark_rapids_jni::string_to_decimal(
-    8, 2, strings_column_view{empty->view()}, false, cudf::default_stream_value);
+    8, 2, strings_column_view{empty->view()}, false, cudf::get_default_stream());
 
   EXPECT_EQ(result->size(), 0);
   EXPECT_EQ(result->type().id(), type_id::DECIMAL32);
@@ -578,7 +578,7 @@ TYPED_TEST(StringToFloatTests, Simple)
     cudf::test::detail::make_null_mask(valid_iter, valid_iter + expected->size()));
 
   auto const result = spark_rapids_jni::string_to_float(
-    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::get_default_stream());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected->view());
 }
@@ -595,7 +595,7 @@ TYPED_TEST(StringToFloatTests, InfNaN)
     cudf::test::detail::make_null_mask(valid_iter, valid_iter + expected->size()));
 
   auto const result = spark_rapids_jni::string_to_float(
-    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::get_default_stream());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected->view());
 }
@@ -612,7 +612,7 @@ TYPED_TEST(StringToFloatTests, InvalidValues)
     cudf::test::detail::make_null_mask(valid_iter, valid_iter + expected->size()));
 
   auto const result = spark_rapids_jni::string_to_float(
-    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::get_default_stream());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected->view());
 }
@@ -626,7 +626,7 @@ TYPED_TEST(StringToFloatTests, ANSIInvalids)
       auto const result = spark_rapids_jni::string_to_float(data_type{type_to_id<TypeParam>()},
                                                             strings_column_view{col},
                                                             true,
-                                                            cudf::default_stream_value);
+                                                            cudf::get_default_stream());
       CUDF_EXPECTS(false, "expected exception!");
     } catch (spark_rapids_jni::cast_error& e) {
       EXPECT_EQ(e.get_row_number(), 0);
@@ -668,7 +668,7 @@ TYPED_TEST(StringToFloatTests, TrickyValues)
                                                        {1, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0});
 
   auto const result = spark_rapids_jni::string_to_float(
-    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::default_stream_value);
+    data_type{type_to_id<TypeParam>()}, strings_column_view{in}, false, cudf::get_default_stream());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 }
@@ -680,7 +680,7 @@ TYPED_TEST(StringToFloatTests, Empty)
   auto const result = spark_rapids_jni::string_to_float(data_type{type_to_id<TypeParam>()},
                                                         strings_column_view{empty->view()},
                                                         false,
-                                                        cudf::default_stream_value);
+                                                        cudf::get_default_stream());
 
   EXPECT_EQ(result->size(), 0);
 }


### PR DESCRIPTION
Updates the spark-rapids-jni code for a recent cudf change where cudf::get_default_stream() must be called to get the default stream rather than cudf::default_stream_value.