### PR TITLE
Dynamic link libcupti for aarch64

### DIFF
--- a/src/main/cpp/faultinj/CMakeLists.txt
+++ b/src/main/cpp/faultinj/CMakeLists.txt
@@ -36,6 +36,8 @@ include_directories(
   "${SPDLOG_INCLUDE}"
 )
 
-target_link_libraries(
-  cufaultinj CUDA::cupti_static
-)
+if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
+    target_link_libraries(cufaultinj CUDA::cupti)
+else ()
+    target_link_libraries(cufaultinj CUDA::cupti_static)
+endif()


### PR DESCRIPTION
To close: #680
This PR adds in a conditional link method for libcupti. 
Due to the lack of static library of libcupti in arm64 cuda Docker image, we must link cupti dynamically.
This PR is verified on an AWS ARM instance inside RockyLinux8 docker container.
Please note, dynamic link will require users to install cuda toolkit in their environment when they need to use faultinj module.