### PR TITLE
[auto-merge] bot-auto-merge-branch-22.12 to branch-23.02 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,12 +18,12 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-      - branch-22.10
+      - branch-22.12
     types: [closed]
 
 env:
-  HEAD: branch-22.10
-  BASE: branch-22.12
+  HEAD: branch-22.12
+  BASE: branch-23.02
 
 jobs:
   auto-merge:


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.12` to create a PR keeping `branch-23.02` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.