### PR TITLE
[auto-merge] bot-auto-merge-branch-22.12 to branch-23.02 [skip ci] [bot]

### DIFF
--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -23,9 +23,10 @@ git submodule update --init --recursive
 
 MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
+USE_GDS=${USE_GDS:-ON}
 ${MVN} clean package ${MVN_MIRROR}  \
   -Psource-javadoc \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest \
+  -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest \
   -DBUILD_TESTS=ON


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-22.12` to create a PR keeping `branch-23.02` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.