### PR TITLE
Fix run-in-docker for interactive default shell

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -47,9 +47,10 @@ fi
 
 if (( $# == 0 )); then
   # no arguments gets an interactive shell
-  DOCKER_ARGS="/bin/bash"
+  DOCKER_OPTS="${DOCKER_OPTS} -it"
+  RUN_CMD="/bin/bash"
 else
-  DOCKER_ARGS="$*"
+  RUN_CMD="$*"
 fi
 
 $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --rm \
@@ -71,5 +72,6 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -e CUDA_VISIBLE_DEVICES \
   -e PARALLEL_LEVEL \
   -e VERBOSE \
+  $DOCKER_OPTS \
   $SPARK_IMAGE_NAME \
-  scl enable devtoolset-9 "$DOCKER_ARGS"
+  scl enable devtoolset-9 "$RUN_CMD"


### PR DESCRIPTION
Fixes run-in-docker to pass the flags for interactive TTY when running in the no-args default mode of an interactive shell.  Without these flags, the shell immediately terminates since there is no stdin.