### PR TITLE
Add an integer divide kernel for adding 128-bit numbers

### DIFF
--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -49,8 +49,11 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divid
     auto view_b = reinterpret_cast<cudf::column_view const *>(j_view_b);
     auto scale = static_cast<int>(j_quotient_scale);
     auto is_int_division = static_cast<bool>(j_is_int_div);
-    return cudf::jni::convert_table_for_return(env, cudf::jni::divide_decimal128(*view_a, *view_b,
-                                                                                 scale, is_int_division));
+    if (is_int_division) {
+      return cudf::jni::convert_table_for_return(env, cudf::jni::integer_divide_decimal128(*view_a, *view_b, scale));
+    } else {
+      return cudf::jni::convert_table_for_return(env, cudf::jni::divide_decimal128(*view_a, *view_b, scale));
+    }
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -39,7 +39,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_multi
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divide128(JNIEnv *env, jclass,
                                                                                      jlong j_view_a,
                                                                                      jlong j_view_b,
-                                                                                     jint j_quotient_scale) {
+                                                                                     jint j_quotient_scale,
+                                                                                     jboolean j_is_int_div) {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
   try {
@@ -47,8 +48,9 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divid
     auto view_a = reinterpret_cast<cudf::column_view const *>(j_view_a);
     auto view_b = reinterpret_cast<cudf::column_view const *>(j_view_b);
     auto scale = static_cast<int>(j_quotient_scale);
+    auto is_int_division = static_cast<bool>(j_is_int_div);
     return cudf::jni::convert_table_for_return(env, cudf::jni::divide_decimal128(*view_a, *view_b,
-                                                                                 scale));
+                                                                                 scale, is_int_division));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -228,10 +228,11 @@ __device__ chunked256 round_from_remainder(chunked256 const &q, __int128_t const
 }
 
 /**
- * Divide n by d and do half up rounding based off of the remainder returned
+ * Divide n by d and do half up rounding based off of the remainder returned.
  */
 __device__ chunked256 divide_and_round(chunked256 const &n, __int128_t const &d) {
   divmod256 div_result = divide(n, d);
+
   return round_from_remainder(div_result.quotient, div_result.remainder, n, d);
 }
 
@@ -802,6 +803,7 @@ private:
 
   // output column for overflow detected
   bool * const overflows;
+
   bool const is_int_div;
   // input data for multiply
   __int128_t const * const a_data;

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -28,13 +28,17 @@ multiply_decimal128(cudf::column_view const &a, cudf::column_view const &b, int3
 
 std::unique_ptr<cudf::table>
 divide_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
-                  bool &is_int_div, rmm::cuda_stream_view stream = rmm::cuda_stream_default);
-
-std::unique_ptr<cudf::table>
-add_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 std::unique_ptr<cudf::table>
+integer_divide_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
+                          rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+std::unique_ptr<cudf::table>
+add_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
+               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+std::unique_ptr<cudf::table>
 sub_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
-                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+               rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 } // namespace cudf::jni

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -28,7 +28,7 @@ multiply_decimal128(cudf::column_view const &a, cudf::column_view const &b, int3
 
 std::unique_ptr<cudf::table>
 divide_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
-                  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                  bool &is_int_div, rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
 std::unique_ptr<cudf::table>
 add_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -60,8 +60,7 @@ public class DecimalUtils {
 
   /**
    * Divide two DECIMAL128 columns and produce a INT64 quotient with overflow detection.
-   * This method considers a precision greater than 19 as overflow even if the number still fits in
-   * a 64-bit representation.
+   * This method considers an overflow if a number is cannot be represented in 64-bit.
    * @param a factor input, must match row count of the other factor input
    * @param b factor input, must match row count of the other factor input
    * @return table containing a boolean column and a INT64 quotient column.

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -60,7 +60,15 @@ public class DecimalUtils {
 
   /**
    * Divide two DECIMAL128 columns and produce a INT64 quotient with overflow detection.
-   * This method considers an overflow if a number is cannot be represented in 64-bit.
+   * This method considers an overflow if the 128-bit quotient of the original numbers overflows
+   * and doesn't base the decision on the 64-bit number.
+   * Example:
+   * 451635271134476686911387864.48 div -961.110 = 2284624887606872042L
+   * A positive number divided by a negative number resulting in a positive result is clearly
+   * an overflow but Spark doesn't consider this an overflow as the 128-bit
+   * answer (-469910073908789510993942.27973) is still within the expected 38 digits of
+   * precision
+   *
    * @param a factor input, must match row count of the other factor input
    * @param b factor input, must match row count of the other factor input
    * @return table containing a boolean column and a INT64 quotient column.

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -55,9 +55,23 @@ public class DecimalUtils {
    *         row.
    */
   public static Table divide128(ColumnView a, ColumnView b, int quotientScale) {
-    return new Table(divide128(a.getNativeView(), b.getNativeView(), quotientScale));
+    return new Table(divide128(a.getNativeView(), b.getNativeView(), quotientScale, false));
   }
 
+  /**
+   * Divide two DECIMAL128 columns and produce a INT64 quotient with overflow detection.
+   * This method considers a precision greater than 19 as overflow even if the number still fits in
+   * a 64-bit representation.
+   * @param a factor input, must match row count of the other factor input
+   * @param b factor input, must match row count of the other factor input
+   * @return table containing a boolean column and a INT64 quotient column.
+   *         The boolean value will be true if an overflow was detected for that row's
+   *         INT64 quotient value. A null input row will result in a corresponding null output
+   *         row.
+   */
+  public static Table integerDivide128(ColumnView a, ColumnView b) {
+    return new Table(divide128(a.getNativeView(), b.getNativeView(), 0, true));
+  }
   /**
    * Subtract two DECIMAL128 columns and produce a DECIMAL128 result rounded to the specified
    * scale with overflow detection. This method considers a precision greater than 38 as overflow
@@ -108,7 +122,7 @@ public class DecimalUtils {
 
   private static native long[] multiply128(long viewA, long viewB, int productScale);
 
-  private static native long[] divide128(long viewA, long viewB, int quotientScale);
+  private static native long[] divide128(long viewA, long viewB, int quotientScale, boolean isIntegerDivide);
 
   private static native long[] add128(long viewA, long viewB, int targetScale);
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -206,6 +206,23 @@ public class DecimalUtilsTest {
   }
 
   @Test
+  void intDivideNotOverflow() {
+    // Spark doesn't report this as an overflow even though this has obviously overflowed.
+    // Incase of integral divide, it still bases whether a column has overflown by checking the
+    // 128-bit value and not the returned 64-bit value
+    try (ColumnVector lhs =
+             makeDec128Column("451635271134476686911387864.48", "5313675970270560086329837153.18");
+         ColumnVector rhs =
+             makeDec128Column("-961.110", "181.958");
+         ColumnVector expectedBasic = ColumnVector.fromLongs(2284624887606872042L, -2928582767902049472L);
+         ColumnVector expectedValid = ColumnVector.fromBooleans(false, false);
+         Table found = DecimalUtils.integerDivide128(lhs, rhs)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
   void intDivideOverflow() {
     try (ColumnVector lhs =
              makeDec128Column("3396191716868766147341919609.06", "-6893798181986328848375556144.67");

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -192,6 +192,22 @@ public class DecimalUtilsTest {
   }
 
   @Test
+  void intDivide() {
+    try (ColumnVector lhs =
+             makeDec128Column("3396191716868766147341919609.06", "-6893798181986328848375556144.67");
+         ColumnVector rhs =
+             makeDec128Column("7317548469.64", "98565515088.44");
+         ColumnVector expectedBasic =
+             makeDec128Column("464116053478747633", "-69941278912819784");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(false, false);
+         Table found = DecimalUtils.integerDivide128(lhs, rhs)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
   void simplePosDivOneByOne() {
     try (ColumnVector lhs =
              makeDec128Column("1.0", "3.7", "99.9");

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -225,10 +225,9 @@ public class DecimalUtilsTest {
   @Test
   void intDivideOverflow() {
     try (ColumnVector lhs =
-             makeDec128Column("3396191716868766147341919609.06", "-6893798181986328848375556144.67");
-         ColumnVector rhs = makeDec128Column("2.00", "1.00");
-         ColumnVector expectedValid =
-             ColumnVector.fromBooleans(true, true);
+             makeDec128Column("-999999999999999999999999999999999999.99", "999999999999999999999999999999999999.99");
+         ColumnVector rhs = makeDec128Column("0", "0");
+         ColumnVector expectedValid = ColumnVector.fromBooleans(true, true);
          Table found = DecimalUtils.integerDivide128(lhs, rhs)) {
       assertColumnsAreEqual(expectedValid, found.getColumn(0));
     }

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -197,13 +197,23 @@ public class DecimalUtilsTest {
              makeDec128Column("3396191716868766147341919609.06", "-6893798181986328848375556144.67");
          ColumnVector rhs =
              makeDec128Column("7317548469.64", "98565515088.44");
-         ColumnVector expectedBasic =
-             makeDec128Column("464116053478747633", "-69941278912819784");
-         ColumnVector expectedValid =
-             ColumnVector.fromBooleans(false, false);
+         ColumnVector expectedBasic = ColumnVector.fromLongs(464116053478747633L, -69941278912819784L);
+         ColumnVector expectedValid = ColumnVector.fromBooleans(false, false);
          Table found = DecimalUtils.integerDivide128(lhs, rhs)) {
       assertColumnsAreEqual(expectedValid, found.getColumn(0));
       assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
+  void intDivideOverflow() {
+    try (ColumnVector lhs =
+             makeDec128Column("3396191716868766147341919609.06", "-6893798181986328848375556144.67");
+         ColumnVector rhs = makeDec128Column("2.00", "1.00");
+         ColumnVector expectedValid =
+             ColumnVector.fromBooleans(true, true);
+         Table found = DecimalUtils.integerDivide128(lhs, rhs)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
     }
   }
 


### PR DESCRIPTION
This PR repurposes an existing kernel to return a Long output after dividing two decimal columns

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
