### PR TITLE
Fixing issue with strings that only have exponents

### DIFF
--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -362,8 +362,10 @@ class string_to_float {
         __ballot_sync(0xffffffff, _warp_lane < num_chars && !is_digit(_c));
       auto const first_non_digit = __ffs(non_digit_mask);
 
-      // first non-digit after location 0 means there is something valid here
-      seen_valid_digit |= first_non_digit > 0;
+      // first non-digit after location 1 means there is something valid here, note ffs is 0 with no set bits,
+      // so 1 is the 0th character is not a digit.
+      // first non-digit of 0 means all digits, and that means we have seen a valid digit as well.
+      seen_valid_digit |= (num_chars > 0 && first_non_digit != 1);
 
       num_chars = min(num_chars, first_non_digit > 0 ? first_non_digit - 1 : num_chars);
 

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -603,7 +603,7 @@ TYPED_TEST(StringToFloatTests, InfNaN)
 
 TYPED_TEST(StringToFloatTests, InvalidValues)
 {
-  cudf::test::strings_column_wrapper in{"A", "null", "na7.62", "e", ".", "", "f"};
+  cudf::test::strings_column_wrapper in{"A", "null", "na7.62", "e", ".", "", "f", "E15"};
 
   auto const valid_iter = cudf::test::iterators::all_nulls();
 


### PR DESCRIPTION
Strings like "E15" were incorrectly being considered valid. This PR fixes that and adds it as a test.

closes #834 