### PR TITLE
Update to latest cudf changes on branch-23.02

### DIFF
--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,8 +202,8 @@ std::unique_ptr<cudf::column> interleave_bits(
      });
   
   auto offset_begin = thrust::make_constant_iterator(data_type_size * num_columns);
-  auto offsets_column = cudf::strings::detail::make_offsets_child_column(
-    offset_begin, offset_begin + num_rows, stream, mr);
+  auto offsets_column = std::get<0>(cudf::detail::make_offsets_child_column(
+    offset_begin, offset_begin + num_rows, stream, mr));
 
   return cudf::make_lists_column(num_rows,
     std::move(offsets_column),


### PR DESCRIPTION
This fixes the submodule sync update failure reported in #867.  rapidsai/cudf#12382 changed `make_offsets_child_column` to relocate which namespace it was in and now returns the size along with the offsets column.  The use in zorder.cu was updated to use the new namespace location and extract the column from the new result type.