### PR TITLE
Provide a basic API for spark specific RMM handling with some error injection for testing

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(
   src/MapUtilsJni.cpp
   src/NativeParquetJni.cpp
   src/RowConversionJni.cpp
+  src/SparkResourceAdaptorJni.cpp
   src/ZOrderJni.cpp
   src/cast_string.cu
   src/cast_string_to_float.cu

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <exception>
+#include <map>
+#include <set>
+#include <pthread.h>
+
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <cudf_jni_apis.hpp>
+
+namespace {
+
+constexpr char const *RMM_EXCEPTION_CLASS = "ai/rapids/cudf/RmmException";
+
+class thread_state {
+public:
+    bool retry_oom_injected = false;
+    bool split_and_retry_oom_injected = false;
+    long task_id = -1;
+};
+
+template<typename T>
+class rollback {
+public:
+    T on_error;
+
+    rollback(T & on_error): on_error(on_error) {}
+
+    ~rollback() {
+      if (std::uncaught_exceptions() > 0) {
+        on_error();
+      }
+    }
+};
+
+class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
+public:
+  spark_resource_adaptor(JNIEnv *env, rmm::mr::device_memory_resource *mr)
+      : resource{mr} {
+    if (env->GetJavaVM(&jvm) < 0) {
+      throw std::runtime_error("GetJavaVM failed");
+    }
+  }
+
+  rmm::mr::device_memory_resource *get_wrapped_resource() { return resource; }
+
+  bool supports_get_mem_info() const noexcept override { return resource->supports_get_mem_info(); }
+
+  bool supports_streams() const noexcept override { return resource->supports_streams(); }
+
+  void associate_thread_with_task(long thread_id, long task_id) {
+    std::scoped_lock lock(state_mutex);
+    if (threads.find(thread_id) != threads.end()) {
+      throw std::invalid_argument("a thread can only be added if it is in the unknown state");
+    }
+    threads.insert({thread_id, {false, false, task_id}});
+    auto recover = [this, thread_id]() {
+      threads.erase(thread_id);
+    };
+    {
+      rollback rb(recover);
+
+      auto tasks_it = task_to_threads.find(task_id);
+      if (tasks_it == task_to_threads.end()) {
+        task_to_threads.insert({task_id, {thread_id}});
+      } else {
+        tasks_it->second.insert(thread_id);
+      }
+    }
+  }
+
+  void remove_thread_association(long thread_id) {
+    std::scoped_lock lock(state_mutex);
+    auto threads_at = threads.find(thread_id);
+    if (threads_at != threads.end()) {
+      auto task_id = threads_at->second.task_id;
+      if (task_id > 0) {
+        auto task_at = task_to_threads.find(task_id);
+        if (task_at != task_to_threads.end()) {
+          task_at->second.erase(thread_id);
+        }
+      }
+      threads.erase(threads_at);
+    }
+  }
+
+  void force_retry_oom(long thread_id) {
+    std::scoped_lock lock(state_mutex);
+    auto threads_at = threads.find(thread_id);
+    if (threads_at != threads.end()) {
+      threads_at->second.retry_oom_injected = true;
+    } else {
+      throw std::invalid_argument("the thread is not associated with any task.");
+    }
+  }
+
+  void force_split_and_retry_oom(long thread_id) {
+    std::scoped_lock lock(state_mutex);
+    auto threads_at = threads.find(thread_id);
+    if (threads_at != threads.end()) {
+      threads_at->second.split_and_retry_oom_injected = true;
+    } else {
+      throw std::invalid_argument("the thread is not associated with any task.");
+    }
+  }
+
+
+private:
+  rmm::mr::device_memory_resource *const resource;
+  // The state mutex must be held when modifying the state of threads or tasks
+  // it must never be held when calling into the child resource or after returning
+  // from an operation.
+  std::mutex state_mutex;
+  std::map<long, thread_state> threads;
+  std::map<long, std::set<long>> task_to_threads;
+  JavaVM *jvm;
+
+  void *do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override {
+    auto tid = static_cast<long>(pthread_self());
+    {
+      // pre allocate checks
+      auto thread = threads.find(tid);
+      if (thread != threads.end()) {
+        if (thread->second.retry_oom_injected) {
+          thread->second.retry_oom_injected = false;
+          JNIEnv *env = cudf::jni::get_jni_env(jvm);
+          // TODO cache what is needed for this...
+          jclass ex_class = env->FindClass("com/nvidia/spark/rapids/jni/RetryOOM");
+          if (ex_class != nullptr) {
+            env->ThrowNew(ex_class, "OOM injected");
+          }
+          throw cudf::jni::jni_exception("injected RetryOOM");
+        }
+
+        if (thread->second.split_and_retry_oom_injected) {
+          thread->second.split_and_retry_oom_injected = false;
+          JNIEnv *env = cudf::jni::get_jni_env(jvm);
+          // TODO cache what is needed for this...
+          jclass ex_class = env->FindClass("com/nvidia/spark/rapids/jni/SplitAndRetryOOM");
+          if (ex_class != nullptr) {
+            env->ThrowNew(ex_class, "OOM injected");
+          }
+          throw cudf::jni::jni_exception("injected SplitAndRetryOOM");
+        }
+      }
+    }
+    return resource->allocate(num_bytes, stream);
+  }
+
+  void do_deallocate(void *p, std::size_t size, rmm::cuda_stream_view stream) override {
+    resource->deallocate(p, size, stream);
+  }
+
+  std::pair<size_t, size_t> do_get_mem_info(rmm::cuda_stream_view stream) const override {
+    return resource->get_mem_info(stream);
+  }
+};
+
+} // empty namespace
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getCurrentThreadId(
+        JNIEnv *env, jclass) {
+  try {
+    cudf::jni::auto_set_device(env);
+    return static_cast<jlong>(pthread_self());
+  }
+  CATCH_STD(env, 0)
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_createNewAdaptor(
+        JNIEnv *env, jclass, jlong child) {
+  JNI_NULL_CHECK(env, child, "child is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource *>(child);
+    auto ret = new spark_resource_adaptor(env, wrapped);
+    return cudf::jni::ptr_as_jlong(ret);
+  }
+  CATCH_STD(env, 0)
+}
+
+JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_releaseAdaptor(
+        JNIEnv *env, jclass, jlong ptr) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
+    delete mr;
+  }
+  CATCH_STD(env, )
+}
+
+JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_associateThreadWithTask(
+        JNIEnv *env, jclass, jlong ptr, jlong thread_id, jlong task_id) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
+    mr->associate_thread_with_task(thread_id, task_id);
+  }
+  CATCH_STD(env, )
+}
+
+JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_removeThreadAssociation(
+        JNIEnv *env, jclass, jlong ptr, jlong thread_id) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
+    mr->remove_thread_association(thread_id);
+  }
+  CATCH_STD(env, )
+}
+
+JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceRetryOOM(
+        JNIEnv *env, jclass, jlong ptr, jlong thread_id) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
+    mr->force_retry_oom(thread_id);
+  }
+  CATCH_STD(env, )
+}
+
+JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceSplitAndRetryOOM(
+        JNIEnv *env, jclass, jlong ptr, jlong thread_id) {
+  try {
+    cudf::jni::auto_set_device(env);
+    auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
+    mr->force_split_and_retry_oom(thread_id);
+  }
+  CATCH_STD(env, )
+}
+
+
+
+}

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -34,9 +34,9 @@ public:
 };
 
 class rollback {
-    using T = const std::function<void()>;
+    using on_error_type = const std::function<void()>;
 public:
-    rollback(T & on_error): on_error(on_error) {}
+    rollback(on_error_type & on_error): on_error(on_error) {}
 
     ~rollback() {
       if (std::uncaught_exceptions() > 0) {
@@ -44,7 +44,7 @@ public:
       }
     }
 private:
-    T on_error;
+    on_error_type on_error;
 };
 
 class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
@@ -207,6 +207,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_rel
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_associateThreadWithTask(
         JNIEnv *env, jclass, jlong ptr, jlong thread_id, jlong task_id) {
+  JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
   try {
     cudf::jni::auto_set_device(env);
     auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
@@ -217,6 +218,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_ass
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_removeThreadAssociation(
         JNIEnv *env, jclass, jlong ptr, jlong thread_id) {
+  JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
   try {
     cudf::jni::auto_set_device(env);
     auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
@@ -227,6 +229,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_rem
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceRetryOOM(
         JNIEnv *env, jclass, jlong ptr, jlong thread_id) {
+  JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
   try {
     cudf::jni::auto_set_device(env);
     auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
@@ -237,6 +240,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_for
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceSplitAndRetryOOM(
         JNIEnv *env, jclass, jlong ptr, jlong thread_id) {
+  JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
   try {
     cudf::jni::auto_set_device(env);
     auto mr = reinterpret_cast<spark_resource_adaptor *>(ptr);
@@ -244,7 +248,5 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_for
   }
   CATCH_STD(env, )
 }
-
-
 
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/RetryOOM.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RetryOOM.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+/**
+ * A special version of an out of memory error that indicates we ran out of memory, but should
+ * roll back to a point when all memory for the task is spillable and then retry the operation.
+ */
+public class RetryOOM extends OutOfMemoryError {
+  public RetryOOM() {
+    super();
+  }
+
+  public RetryOOM(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.Rmm;
+import ai.rapids.cudf.RmmDeviceMemoryResource;
+import ai.rapids.cudf.RmmEventHandler;
+import ai.rapids.cudf.RmmEventHandlerResourceAdaptor;
+import ai.rapids.cudf.RmmException;
+import ai.rapids.cudf.RmmTrackingResourceAdaptor;
+
+/**
+ * Initialize RMM in ways that are specific to Spark.
+ */
+public class RmmSpark {
+
+  private static volatile SparkResourceAdaptor sra = null;
+
+  /**
+   * Set the event handler in a way that Spark wants it. For now this is the same as RMM, but in
+   * the future it is likely to change.
+   */
+  public static void setEventHandler(RmmEventHandler handler) throws RmmException {
+    synchronized (Rmm.class) {
+      // TODO RmmException constructor is not public, so we have to use a different one, or we will
+      //  need something else...
+      if (!Rmm.isInitialized()) {
+        throw new RuntimeException("RMM has not been initialized");
+      }
+      RmmDeviceMemoryResource deviceResource = Rmm.getCurrentDeviceResource();
+      if (deviceResource instanceof RmmEventHandlerResourceAdaptor ||
+          deviceResource instanceof SparkResourceAdaptor) {
+        throw new RuntimeException("Another event handler is already set");
+      }
+      RmmTrackingResourceAdaptor<RmmDeviceMemoryResource> tracker = Rmm.getTracker();
+      if (tracker == null) {
+        // This is just to be safe it should always be true if this is initialized.
+        throw new RuntimeException("A tracker must be set for the event handler to work");
+      }
+      RmmEventHandlerResourceAdaptor<RmmDeviceMemoryResource> eventHandler =
+          new RmmEventHandlerResourceAdaptor<>(deviceResource, tracker, handler, false);
+      sra = new SparkResourceAdaptor(eventHandler);
+      boolean success = false;
+      try {
+        Rmm.setCurrentDeviceResource(sra, deviceResource, false);
+        success = true;
+      } finally {
+        if (!success) {
+          sra.releaseWrapped();
+          eventHandler.releaseWrapped();
+        }
+      }
+    }
+  }
+
+  /**
+   * Clears the active RMM event handler and anything else that is needed for spark to behave
+   * properly.
+   */
+  public static void clearEventHandler() throws RmmException {
+    synchronized (Rmm.class) {
+      RmmDeviceMemoryResource deviceResource = Rmm.getCurrentDeviceResource();
+      if (deviceResource != null && deviceResource instanceof SparkResourceAdaptor) {
+        SparkResourceAdaptor sra = (SparkResourceAdaptor) deviceResource;
+        RmmEventHandlerResourceAdaptor<RmmDeviceMemoryResource> event = sra.getWrapped();
+        boolean success = false;
+        try {
+          Rmm.setCurrentDeviceResource(event.getWrapped(), sra, false);
+          success = true;
+        } finally {
+          if (success) {
+            RmmSpark.sra = null;
+            sra.releaseWrapped();
+            event.releaseWrapped();
+          }
+        }
+      }
+    }
+  }
+
+  public static long getCurrentThreadId() {
+    return SparkResourceAdaptor.getCurrentThreadId();
+  }
+
+  /**
+   * Associate a thread with a given task id.
+   * @param threadId the thread ID to use
+   * @param taskId the task ID this thread is associated with.
+   */
+  public static void associateThreadWithTask(long threadId, long taskId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.associateThreadWithTask(threadId, taskId);
+      }
+    }
+  }
+
+  /**
+   * Associate a thread with shuffle.
+   * @param threadId the thread ID to associate (not java thread id).
+   */
+  public static void associateThreadWithShuffle(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.associateThreadWithShuffle(threadId);
+      }
+    }
+  }
+
+  /**
+   * Remove the given thread ID from any association.
+   * @param threadId the ID of the thread that is no longer a part of a task or shuffle
+   *                 (not java thread id).
+   */
+  public static void removeThreadAssociation(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.removeThreadAssociation(threadId);
+      }
+    }
+  }
+
+  /**
+   * Indicate that a given task is done and if there are any threads still associated with it
+   * then they should also be removed.
+   * @param taskId the ID of the task that has completed.
+   */
+  public static void taskDone(long taskId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.taskDone(taskId);
+      }
+    }
+  }
+
+  /**
+   * Indicate that the given thread could block on shuffle.
+   * @param threadId the id of the thread that could block (not java thread id).
+   */
+  public static void threadCouldBlockOnShuffle(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.threadCouldBlockOnShuffle(threadId);
+      }
+    }
+  }
+
+  /**
+   * Indicate that the current thread could block on shuffle.
+   */
+  public static void threadCouldBlockOnShuffle() {
+    threadCouldBlockOnShuffle(getCurrentThreadId());
+  }
+
+  /**
+   * Indicate that the given thread can no longer block on shuffle.
+   * @param threadId the ID of the thread that o longer can block on shuffle (not java thread id).
+   */
+  public static void threadDoneWithShuffle(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.threadDoneWithShuffle(threadId);
+      }
+    }
+  }
+
+  /**
+   * Indicate that the current thread can no longer block on shuffle.
+   */
+  public static void threadDoneWithShuffle() {
+    threadDoneWithShuffle(getCurrentThreadId());
+  }
+
+  /**
+   * Force the thread with the given ID to throw a RetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   */
+  public static void forceRetryOOM(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.forceRetryOOM(threadId);
+      } else {
+        throw new IllegalStateException("RMM has not been configured for OOM injection");
+      }
+    }
+  }
+
+  /**
+   * Force the thread with the given ID to throw a SplitAndRetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   */
+  public static void forceSplitAndRetryOOM(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.forceSplitAndRetryOOM(threadId);
+      } else {
+        throw new IllegalStateException("RMM has not been configured for OOM injection");
+      }
+    }
+  }
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -35,9 +35,9 @@ public class RmmSpark {
    * the future it is likely to change.
    */
   public static void setEventHandler(RmmEventHandler handler) throws RmmException {
+    // synchronize with RMM not RmmSpark to stay in sync with Rmm itself.
     synchronized (Rmm.class) {
-      // TODO RmmException constructor is not public, so we have to use a different one, or we will
-      //  need something else...
+      // RmmException constructor is not public, so we have to use a different exception
       if (!Rmm.isInitialized()) {
         throw new RuntimeException("RMM has not been initialized");
       }
@@ -72,6 +72,7 @@ public class RmmSpark {
    * properly.
    */
   public static void clearEventHandler() throws RmmException {
+    // synchronize with RMM not RmmSpark to stay in sync with Rmm itself.
     synchronized (Rmm.class) {
       RmmDeviceMemoryResource deviceResource = Rmm.getCurrentDeviceResource();
       if (deviceResource != null && deviceResource instanceof SparkResourceAdaptor) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.NativeDepsLoader;
+import ai.rapids.cudf.RmmDeviceMemoryResource;
+import ai.rapids.cudf.RmmEventHandlerResourceAdaptor;
+import ai.rapids.cudf.RmmWrappingDeviceMemoryResource;
+
+public class SparkResourceAdaptor
+    extends RmmWrappingDeviceMemoryResource<RmmEventHandlerResourceAdaptor<RmmDeviceMemoryResource>> {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  private long handle = 0;
+
+  /**
+   * Create a new tracking resource adaptor.
+   * @param wrapped the memory resource to track allocations. This should not be reused.
+   */
+  public SparkResourceAdaptor(RmmEventHandlerResourceAdaptor<RmmDeviceMemoryResource> wrapped) {
+    super(wrapped);
+    handle = createNewAdaptor(wrapped.getHandle());
+  }
+
+  @Override
+  public long getHandle() {
+    return handle;
+  }
+
+  @Override
+  public void close() {
+    if (handle != 0) {
+      releaseAdaptor(handle);
+      handle = 0;
+    }
+    super.close();
+  }
+
+  /**
+   * Associate a thread with a given task id.
+   * @param threadId the thread ID to use (not java thread id)
+   * @param taskId the task ID this thread is associated with.
+   */
+  public void associateThreadWithTask(long threadId, long taskId) {
+    associateThreadWithTask(getHandle(), threadId, taskId);
+  }
+
+  /**
+   * Associate a thread with shuffle.
+   * @param threadId the thread ID to associate (not java thread id).
+   */
+  public void associateThreadWithShuffle(long threadId) {
+    associateThreadWithShuffle(getHandle(), threadId);
+  }
+
+  /**
+   * Remove the given thread ID from any association.
+   * @param threadId the ID of the thread that is no longer a part of a task or shuffle (not java thread id).
+   */
+  public void removeThreadAssociation(long threadId) {
+    removeThreadAssociation(getHandle(), threadId);
+  }
+
+  /**
+   * Indicate that a given task is done and if there are any threads still associated with it
+   * then they should also be removed.
+   * @param taskId the ID of the task that has completed.
+   */
+  public void taskDone(long taskId) {
+    taskDone(getHandle(), taskId);
+  }
+
+  /**
+   * Indicate that the given thread could block on shuffle.
+   * @param threadId the id of the thread that could block (not java thread id).
+   */
+  public void threadCouldBlockOnShuffle(long threadId) {
+    threadCouldBlockOnShuffle(getHandle(), threadId);
+  }
+
+  /**
+   * Indicate that the given thread can no longer block on shuffle.
+   * @param threadId the ID of the thread that o longer can block on shuffle (not java thread id).
+   */
+  public void threadDoneWithShuffle(long threadId) {
+    threadDoneWithShuffle(getHandle(), threadId);
+  }
+
+  /**
+   * Force the thread with the given ID to throw a RetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   */
+  public void forceRetryOOM(long threadId) {
+    forceRetryOOM(getHandle(), threadId);
+  }
+
+  /**
+   * Force the thread with the given ID to throw a SplitAndRetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   */
+  public void forceSplitAndRetryOOM(long threadId) {
+    forceSplitAndRetryOOM(getHandle(), threadId);
+  }
+
+  /**
+   * Get the ID of the current thread that can be used with the other SparkResourceAdaptor APIs.
+   * Don't use the java thread ID. They are not related.
+   */
+  public static native long getCurrentThreadId();
+
+  private native static long createNewAdaptor(long wrappedHandle);
+  private native static void releaseAdaptor(long handle);
+  private static native void associateThreadWithTask(long handle, long threadId, long taskId);
+  private static native void associateThreadWithShuffle(long handle, long threadId);
+  private static native void removeThreadAssociation(long handle, long threadId);
+  private static native void taskDone(long handle, long taskId);
+  private static native void threadCouldBlockOnShuffle(long handle, long threadId);
+  private static native void threadDoneWithShuffle(long handle, long threadId);
+  private static native void forceRetryOOM(long handle, long threadId);
+  private static native void forceSplitAndRetryOOM(long handle, long threadId);
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/SplitAndRetryOOM.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SplitAndRetryOOM.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+/**
+ * A special version of an out of memory error that indicates we ran out of memory, but should
+ * roll back to a point when all memory for the task is spillable and then retry the operation
+ * with the input data split to make it ideally use less GPU memory overall.
+ */
+public class SplitAndRetryOOM extends OutOfMemoryError {
+  public SplitAndRetryOOM() {
+    super();
+  }
+
+  public SplitAndRetryOOM(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.Rmm;
+import ai.rapids.cudf.RmmAllocationMode;
+import ai.rapids.cudf.RmmEventHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RmmSparkTest {
+  @BeforeEach
+  public void setup() {
+    if (Rmm.isInitialized()) {
+      Rmm.shutdown();
+    }
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (Rmm.isInitialized()) {
+      Rmm.shutdown();
+    }
+  }
+
+  @Test
+  public void testBasicInitAndTeardown() {
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024);
+    RmmSpark.setEventHandler(new BaseRmmEventHandler());
+  }
+
+  @Test
+  public void testInsertOOMs() {
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024);
+    RmmSpark.setEventHandler(new BaseRmmEventHandler());
+    long threadId = RmmSpark.getCurrentThreadId();
+    long taskid = 0; // This is arbitrary
+    RmmSpark.associateThreadWithTask(threadId, taskid);
+    try {
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+
+      // Force an exception
+      RmmSpark.forceRetryOOM(threadId);
+      assertThrows(RetryOOM.class, () -> Rmm.alloc(100).close());
+
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+
+      // Force another exception
+      RmmSpark.forceSplitAndRetryOOM(threadId);
+      assertThrows(SplitAndRetryOOM.class, () -> Rmm.alloc(100).close());
+
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+    } finally {
+      RmmSpark.removeThreadAssociation(threadId);
+    }
+  }
+
+  private static class BaseRmmEventHandler implements RmmEventHandler {
+    @Override
+    public long[] getAllocThresholds() {
+      return null;
+    }
+
+    @Override
+    public long[] getDeallocThresholds() {
+      return null;
+    }
+
+    @Override
+    public void onAllocThreshold(long totalAllocSize) {
+    }
+
+    @Override
+    public void onDeallocThreshold(long totalAllocSize) {
+    }
+
+    @Override
+    public boolean onAllocFailure(long sizeRequested, int retryCount) {
+      // This is just a test for now, no spilling...
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
This really is just an initial patch to let others start making changes to the spark rapids plugin in relation to reliability.

It adds in some new OOM errors that can be caught for specific situations and also provides a way to inject them for unit tests.

Actually doing something beyond injecting the errors will come later on.  Please note that the API might change slightly as time goes on as well.