### PR TITLE
Add new API to RmmSpark and do some cleanup from last review

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -118,6 +118,13 @@ public class SparkResourceAdaptor
   }
 
   /**
+   * Block the current thread until the resource adaptor thinks it is ready to continue.
+   */
+  public void blockThreadUntilReady() {
+    blockThreadUntilReady(getHandle());
+  }
+
+  /**
    * Get the ID of the current thread that can be used with the other SparkResourceAdaptor APIs.
    * Don't use the java thread ID. They are not related.
    */
@@ -133,4 +140,5 @@ public class SparkResourceAdaptor
   private static native void threadDoneWithShuffle(long handle, long threadId);
   private static native void forceRetryOOM(long handle, long threadId);
   private static native void forceSplitAndRetryOOM(long handle, long threadId);
+  private static native void blockThreadUntilReady(long handle);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
@@ -60,6 +60,8 @@ public class RmmSparkTest {
       // Force an exception
       RmmSpark.forceRetryOOM(threadId);
       assertThrows(RetryOOM.class, () -> Rmm.alloc(100).close());
+      // Verify that injecting OOM does not cause the block to actually happen
+      RmmSpark.blockThreadUntilReady();
 
       // Allocate something small and verify that it works...
       Rmm.alloc(100).close();
@@ -67,6 +69,8 @@ public class RmmSparkTest {
       // Force another exception
       RmmSpark.forceSplitAndRetryOOM(threadId);
       assertThrows(SplitAndRetryOOM.class, () -> Rmm.alloc(100).close());
+      // Verify that injecting OOM does not cause the block to actually happen
+      RmmSpark.blockThreadUntilReady();
 
       // Allocate something small and verify that it works...
       Rmm.alloc(100).close();


### PR DESCRIPTION
This adds a new API to RmmSpark so that we can recover from a retry attempt without acquiring any spillable memory handles.

It also addresses the concerns about `rollback` by getting rid of it.