### PR TITLE
Added way to throw multiple RetryOOMs and an injection point for CudfException

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -134,14 +134,9 @@ private:
   std::map<long, std::set<long>> task_to_threads;
   JavaVM *jvm;
 
-  void throw_java_exception(const char * ex_class_name, const char* msg) {
+  void throw_java_exception(const char* ex_class_name, const char* msg) {
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
-    //TODO: we may want to cache these in the future
-    jclass ex_class = env->FindClass(ex_class_name);
-    if (ex_class != nullptr) {
-      env->ThrowNew(ex_class, msg);
-    }
-    throw cudf::jni::jni_exception(msg);
+    cudf::jni::throw_java_exception(env, ex_class_name, msg);
   }
 
   void *do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override {

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -136,6 +136,7 @@ private:
 
   void throw_java_exception(const char * ex_class_name, const char* msg) {
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
+    //TODO: we may want to cache these in the future
     jclass ex_class = env->FindClass(ex_class_name);
     if (ex_class != nullptr) {
       env->ThrowNew(ex_class, msg);

--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -239,9 +239,18 @@ public class RmmSpark {
    * @param threadId the ID of the thread to throw the exception (not java thread id).
    */
   public static void forceRetryOOM(long threadId) {
+    forceRetryOOM(threadId, 1);
+  }
+
+  /**
+   * Force the thread with the given ID to throw a RetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numOOMs the number of times the RetryOOM should be thrown
+   */
+  public static void forceRetryOOM(long threadId, int numOOMs) {
     synchronized (Rmm.class) {
       if (sra != null) {
-        sra.forceRetryOOM(threadId);
+        sra.forceRetryOOM(threadId, numOOMs);
       } else {
         throw new IllegalStateException("RMM has not been configured for OOM injection");
       }
@@ -253,9 +262,43 @@ public class RmmSpark {
    * @param threadId the ID of the thread to throw the exception (not java thread id).
    */
   public static void forceSplitAndRetryOOM(long threadId) {
+    forceSplitAndRetryOOM(threadId, 1);
+  }
+
+  /**
+   * Force the thread with the given ID to throw a SplitAndRetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numOOMs the number of times the SplitAndRetryOOM should be thrown
+   */
+  public static void forceSplitAndRetryOOM(long threadId, int numOOMs) {
     synchronized (Rmm.class) {
       if (sra != null) {
-        sra.forceSplitAndRetryOOM(threadId);
+        sra.forceSplitAndRetryOOM(threadId, numOOMs);
+      } else {
+        throw new IllegalStateException("RMM has not been configured for OOM injection");
+      }
+    }
+  }
+
+  /**
+   * Force the thread with the given ID to throw a CudfException on their next allocation attempt.
+   * This is to simulate a cuDF exception being thrown from a kernel and test retry handling code.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   */
+  public static void forceCudfException(long threadId) {
+    forceCudfException(threadId, 1);
+  }
+
+  /**
+   * Force the thread with the given ID to throw a CudfException on their next allocation attempt.
+   * This is to simulate a cuDF exception being thrown from a kernel and test retry handling code.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numTimes the number of times the CudfException should be thrown
+   */
+  public static void forceCudfException(long threadId, int numTimes) {
+    synchronized (Rmm.class) {
+      if (sra != null) {
+        sra.forceCudfException(threadId, numTimes);
       } else {
         throw new IllegalStateException("RMM has not been configured for OOM injection");
       }

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -104,17 +104,28 @@ public class SparkResourceAdaptor
   /**
    * Force the thread with the given ID to throw a RetryOOM on their next allocation attempt.
    * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numOOMs the number of times the RetryOOM should be thrown
    */
-  public void forceRetryOOM(long threadId) {
-    forceRetryOOM(getHandle(), threadId);
+  public void forceRetryOOM(long threadId, int numOOMs) {
+    forceRetryOOM(getHandle(), threadId, numOOMs);
   }
 
   /**
    * Force the thread with the given ID to throw a SplitAndRetryOOM on their next allocation attempt.
    * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numOOMs the number of times the SplitAndRetryOOM should be thrown
    */
-  public void forceSplitAndRetryOOM(long threadId) {
-    forceSplitAndRetryOOM(getHandle(), threadId);
+  public void forceSplitAndRetryOOM(long threadId, int numOOMs) {
+    forceSplitAndRetryOOM(getHandle(), threadId, numOOMs);
+  }
+
+  /**
+   * Force the thread with the given ID to throw a SplitAndRetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numTimes the number of times the CudfException should be thrown
+   */
+  public void forceCudfException(long threadId, int numTimes) {
+    forceCudfException(getHandle(), threadId, numTimes);
   }
 
   /**
@@ -138,7 +149,8 @@ public class SparkResourceAdaptor
   private static native void taskDone(long handle, long taskId);
   private static native void threadCouldBlockOnShuffle(long handle, long threadId);
   private static native void threadDoneWithShuffle(long handle, long threadId);
-  private static native void forceRetryOOM(long handle, long threadId);
-  private static native void forceSplitAndRetryOOM(long handle, long threadId);
+  private static native void forceRetryOOM(long handle, long threadId, int numOOMs);
+  private static native void forceSplitAndRetryOOM(long handle, long threadId, int numOOMs);
+  private static native void forceCudfException(long handle, long threadId, int numTimes);
   private static native void blockThreadUntilReady(long handle);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
@@ -119,6 +119,7 @@ public class RmmSparkTest {
     }
   }
 
+  @Test
   public void testCudfException() {
     Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024);
     RmmSpark.setEventHandler(new BaseRmmEventHandler());

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.jni;
 
+import ai.rapids.cudf.CudfException;
 import ai.rapids.cudf.Rmm;
 import ai.rapids.cudf.RmmAllocationMode;
 import ai.rapids.cudf.RmmEventHandler;
@@ -71,6 +72,71 @@ public class RmmSparkTest {
       assertThrows(SplitAndRetryOOM.class, () -> Rmm.alloc(100).close());
       // Verify that injecting OOM does not cause the block to actually happen
       RmmSpark.blockThreadUntilReady();
+
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+    } finally {
+      RmmSpark.removeThreadAssociation(threadId);
+    }
+  }
+
+  @Test
+  public void testInsertMultipleOOMs() {
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024);
+    RmmSpark.setEventHandler(new BaseRmmEventHandler());
+    long threadId = RmmSpark.getCurrentThreadId();
+    long taskid = 0; // This is arbitrary
+    RmmSpark.associateThreadWithTask(threadId, taskid);
+    try {
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+
+      // Force an exception
+      int numRetryOOMs = 3;
+      RmmSpark.forceRetryOOM(threadId, numRetryOOMs);
+      for (int i = 0; i < numRetryOOMs; i++) {
+        assertThrows(RetryOOM.class, () -> Rmm.alloc(100).close());
+        // Verify that injecting OOM does not cause the block to actually happen
+        RmmSpark.blockThreadUntilReady();
+      }
+
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+
+      // Force another exception
+      int numSplitAndRetryOOMs = 5;
+      RmmSpark.forceSplitAndRetryOOM(threadId, numSplitAndRetryOOMs);
+      for (int i = 0; i < numSplitAndRetryOOMs; i++) {
+        assertThrows(SplitAndRetryOOM.class, () -> Rmm.alloc(100).close());
+        // Verify that injecting OOM does not cause the block to actually happen
+        RmmSpark.blockThreadUntilReady();
+      }
+
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+    } finally {
+      RmmSpark.removeThreadAssociation(threadId);
+    }
+  }
+
+  public void testCudfException() {
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024);
+    RmmSpark.setEventHandler(new BaseRmmEventHandler());
+    long threadId = RmmSpark.getCurrentThreadId();
+    long taskid = 0; // This is arbitrary
+    RmmSpark.associateThreadWithTask(threadId, taskid);
+    try {
+      // Allocate something small and verify that it works...
+      Rmm.alloc(100).close();
+
+      // Force an exception
+      int numCudfExceptions = 3;
+      RmmSpark.forceCudfException(threadId, numCudfExceptions);
+      for (int i = 0; i < numCudfExceptions; i++) {
+        assertThrows(CudfException.class, () -> Rmm.alloc(100).close());
+        // Verify that injecting OOM does not cause the block to actually happen
+        RmmSpark.blockThreadUntilReady();
+      }
 
       // Allocate something small and verify that it works...
       Rmm.alloc(100).close();


### PR DESCRIPTION
This adds a `numOOMs` argument to `forceRetryOOM` and `forceSplitAndRetryOOM`. It also adds a `forceCudfException` to throw something other than the OOM exceptions, such that we can test that we can handle other types of exceptions gracefully.