### PR TITLE
Fix memory leaks and test logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,16 @@
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -492,6 +502,7 @@
           <!-- you can turn this off, by passing -DtrimStackTrace=true when running tests -->
           <trimStackTrace>false</trimStackTrace>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <runOrder>alphabetical</runOrder>
           <systemPropertyVariables>
             <ai.rapids.refcount.debug>${ai.rapids.refcount.debug}</ai.rapids.refcount.debug>
             <ai.rapids.cudf.nvtx.enabled>${ai.rapids.cudf.nvtx.enabled}</ai.rapids.cudf.nvtx.enabled>

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,24 +38,26 @@ public class CastStringsTest {
     tb.column(3l, 9l, 4l, 2l, 20l, null, null);
     tb.column(5, 1, 0, 2, 7, null, null);
     tb.column(new Byte[]{2, 3, 4, 5, 9, null, null});
-    Table expected = tb.build();
+    try (Table expected = tb.build()) {
+      Table.TestBuilder tb2 = new Table.TestBuilder();
+      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
+      tb2.column("5", "1  ", "0", "2", "7.1", null, "asdf");
+      tb2.column("2", "3", " 4 ", "5", " 9.2 ", null, "7.8.3");
 
-    Table.TestBuilder tb2 = new Table.TestBuilder();
-    tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
-    tb2.column("5", "1  ", "0", "2", "7.1", null, "asdf");
-    tb2.column("2", "3", " 4 ", "5", " 9.2 ", null, "7.8.3");
-
-    List<ColumnVector> result = new ArrayList<>();
-
-    try (Table origTable = tb2.build()) {
-      for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
-        ColumnVector string_col = origTable.getColumn(i);
-        result.add(CastStrings.toInteger(string_col, false, 
-                   expected.getColumn(i).getType()));
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toInteger(string_col, false,
+              expected.getColumn(i).getType()));
+        }
+        try (Table result_tbl = new Table(
+            result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
       }
-      Table result_tbl = new Table(
-        result.toArray(new ColumnVector[result.size()]));
-      AssertUtils.assertTablesAreEqual(expected, result_tbl);
     }
   }
 
@@ -65,24 +67,26 @@ public class CastStringsTest {
     tb.column(null, 9l, 4l, 2l, 20l, null, null);
     tb.column(5, null, 0, 2, 7, null, null);
     tb.column(new Byte[]{2, 3, null, 5, null, null, null});
-    Table expected = tb.build();
+    try (Table expected = tb.build()) {
+      Table.TestBuilder tb2 = new Table.TestBuilder();
+      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
+      tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
+      tb2.column("2", "3", " 4 ", "5.6", " 9.2 ", null, "7.8.3");
 
-    Table.TestBuilder tb2 = new Table.TestBuilder();
-    tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
-    tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
-    tb2.column("2", "3", " 4 ", "5.6", " 9.2 ", null, "7.8.3");
-
-    List<ColumnVector> result = new ArrayList<>();
-
-    try (Table origTable = tb2.build()) {
-      for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
-        ColumnVector string_col = origTable.getColumn(i);
-        result.add(CastStrings.toInteger(string_col, false, false,
-            expected.getColumn(i).getType()));
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toInteger(string_col, false, false,
+              expected.getColumn(i).getType()));
+        }
+        try (Table result_tbl = new Table(
+            result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
       }
-      Table result_tbl = new Table(
-          result.toArray(new ColumnVector[result.size()]));
-      AssertUtils.assertTablesAreEqual(expected, result_tbl);
     }
   }
 
@@ -92,37 +96,38 @@ public class CastStringsTest {
     tb.column(3l, 9l, 4l, 2l, 20l);
     tb.column(5, 1, 0, 2, 7);
     tb.column(new Byte[]{2, 3, 4, 5, 9});
-    Table expected = tb.build();
+    try (Table expected = tb.build()) {
+      Table.TestBuilder tb2 = new Table.TestBuilder();
+      tb2.column("3", "9", "4", "2", "20");
+      tb2.column("5", "1", "0", "2", "7");
+      tb2.column("2", "3", "4", "5", "9");
 
-    Table.TestBuilder tb2 = new Table.TestBuilder();
-    tb2.column("3", "9", "4", "2", "20");
-    tb2.column("5", "1", "0", "2", "7");
-    tb2.column("2", "3", "4", "5", "9");
-
-    List<ColumnVector> result = new ArrayList<>();
-
-    try (Table origTable = tb2.build()) {
-      for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
-        ColumnVector string_col = origTable.getColumn(i);
-        result.add(CastStrings.toInteger(string_col, true, 
-                   expected.getColumn(i).getType()));
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toInteger(string_col, true,
+              expected.getColumn(i).getType()));
+        }
+        try (Table result_tbl = new Table(
+            result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
       }
-      Table result_tbl = new Table(
-        result.toArray(new ColumnVector[result.size()]));
-      AssertUtils.assertTablesAreEqual(expected, result_tbl);
-    }
+      Table.TestBuilder fail = new Table.TestBuilder();
+      fail.column("asdf", "9.0.2", "- 4e", "b2", "20-fe");
 
-    Table.TestBuilder fail = new Table.TestBuilder();
-    fail.column("asdf", "9.0.2", "- 4e", "b2", "20-fe");
-
-    try {
-        Table failTable = fail.build();
-        CastStrings.toInteger(failTable.getColumn(0), true,
-                              expected.getColumn(0).getType());
+      try (Table failTable = fail.build();
+           ColumnVector cv =
+               CastStrings.toInteger(failTable.getColumn(0), true,
+                   expected.getColumn(0).getType());) {
         fail("Should have thrown");
       } catch (CastException e) {
         assertEquals("asdf", e.getStringWithError());
         assertEquals(0, e.getRowWithError());
+      }
     }
   }
 
@@ -132,57 +137,61 @@ public class CastStringsTest {
     tb.decimal32Column(0,3, 9, 4, 2, 21, null, null);
     tb.decimal64Column(0, 5l, 1l, 0l, 2l, 7l, null, null);
     tb.decimal32Column(-1, 20, 30, 40, 51, 92, null, null);
-    Table expected = tb.build();
+    try (Table expected = tb.build()) {
+      int[] desiredPrecision = new int[]{2, 10, 3};
+      int[] desiredScale = new int[]{0, 0, -1};
 
-    int[] desiredPrecision = new int[] {2, 10, 3};
-    int[] desiredScale = new int[]{0, 0, -1};
+      Table.TestBuilder tb2 = new Table.TestBuilder();
+      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
+      tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
+      tb2.column("2", "3", " 4 ", "5.07", "9.23", null, "7.8.3");
 
-    Table.TestBuilder tb2 = new Table.TestBuilder();
-    tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
-    tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
-    tb2.column("2", "3", " 4 ", "5.07", "9.23", null, "7.8.3");
-
-    List<ColumnVector> result = new ArrayList<>();
-
-    try (Table origTable = tb2.build()) {
-      for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
-        ColumnVector string_col = origTable.getColumn(i);
-        result.add(CastStrings.toDecimal(string_col, false,
-            desiredPrecision[i], desiredScale[i]));
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toDecimal(string_col, false,
+              desiredPrecision[i], desiredScale[i]));
+        }
+        try (Table result_tbl = new Table(
+            result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
       }
-      Table result_tbl = new Table(
-          result.toArray(new ColumnVector[result.size()]));
-      AssertUtils.assertTablesAreEqual(expected, result_tbl);
     }
   }
 
   @Test
   void castToDecimalNoStripTest() {
     Table.TestBuilder tb = new Table.TestBuilder();
-    tb.decimal32Column(0,null, 9, 4, 2, 21, null, null);
+    tb.decimal32Column(0, null, 9, 4, 2, 21, null, null);
     tb.decimal64Column(0, 5l, null, 0l, 2l, 7l, null, null);
     tb.decimal32Column(-1, 20, 30, null, 51, 92, null, null);
-    Table expected = tb.build();
+    try (Table expected = tb.build()) {
+      int[] desiredPrecision = new int[]{2, 10, 3};
+      int[] desiredScale = new int[]{0, 0, -1};
 
-    int[] desiredPrecision = new int[] {2, 10, 3};
-    int[] desiredScale = new int[]{0, 0, -1};
+      Table.TestBuilder tb2 = new Table.TestBuilder();
+      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
+      tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
+      tb2.column("2", "3", " 4 ", "5.07", "9.23", null, "7.8.3");
 
-    Table.TestBuilder tb2 = new Table.TestBuilder();
-    tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
-    tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
-    tb2.column("2", "3", " 4 ", "5.07", "9.23", null, "7.8.3");
-
-    List<ColumnVector> result = new ArrayList<>();
-
-    try (Table origTable = tb2.build()) {
-      for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
-        ColumnVector string_col = origTable.getColumn(i);
-        result.add(CastStrings.toDecimal(string_col, false, false,
-            desiredPrecision[i], desiredScale[i]));
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toDecimal(string_col, false, false,
+              desiredPrecision[i], desiredScale[i]));
+        }
+        try (Table result_tbl = new Table(
+            result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
       }
-      Table result_tbl = new Table(
-          result.toArray(new ColumnVector[result.size()]));
-      AssertUtils.assertTablesAreEqual(expected, result_tbl);
     }
   }
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,8 +152,8 @@ public class DecimalUtilsTest {
   void simpleNegMultiplyTenByTenSparkCompat() {
     // many of the numbers listed here are *NOT* what BigDecimal would 
     // normally spit out. Spark has a bug https://issues.apache.org/jira/browse/SPARK-40129
-    // which causes some of the rounding to be off, so these come directly from
-    // Spark. It should be simple to fix this issue by deleteing code, or bypassing the
+    // which causes some rounding to be off, so these come directly from
+    // Spark. It should be simple to fix this issue by deleting code, or bypassing the
     // first divide step when/if Spark fixes it.
     try (ColumnVector lhs =
              makeDec128Column("3358377338823096511784947656.4650294583",
@@ -208,7 +208,7 @@ public class DecimalUtilsTest {
   @Test
   void intDivideNotOverflow() {
     // Spark doesn't report this as an overflow even though this has obviously overflowed.
-    // Incase of integral divide, it still bases whether a column has overflown by checking the
+    // In case of integral divide, it still bases whether a column has overflown by checking the
     // 128-bit value and not the returned 64-bit value
     try (ColumnVector lhs =
              makeDec128Column("451635271134476686911387864.48", "5313675970270560086329837153.18");
@@ -361,8 +361,8 @@ public class DecimalUtilsTest {
             "-9191008513307131620269245301.1615457290");
         ColumnVector rhs = makeDec128Column("9447850332473678680446404122.5624623187",
             "-9447850332473678680446404122.5624623187");
-        ColumnVector expectedValid = ColumnVector.fromBooleans(true, true)) {
-      Table result = DecimalUtils.add128(lhs, rhs, -10);
+        ColumnVector expectedValid = ColumnVector.fromBooleans(true, true);
+        Table result = DecimalUtils.add128(lhs, rhs, -10)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
     }
   }
@@ -404,8 +404,8 @@ public class DecimalUtilsTest {
             "1333756118336991229799879886.522289520",
             "-2558243183478544783472313244.575638918");
         ColumnVector expectedValid = ColumnVector.fromBooleans(false, false, false, false, false,
-            false, false, false, false, false, false)) {
-      Table result = DecimalUtils.add128(lhs, rhs, -9);
+            false, false, false, false, false, false);
+        Table result = DecimalUtils.add128(lhs, rhs, -9)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
       assertColumnsAreEqual(expected, result.getColumn(1));
     }
@@ -448,8 +448,8 @@ public class DecimalUtilsTest {
             "-6.5479604530576270812849514340029066E+39",
             null);
         ColumnVector expectedValid = ColumnVector.fromBoxedBooleans(false, false, false, false,
-            false, false, false, false, false, null)) {
-      Table result = DecimalUtils.add128(lhs, rhs, 5);
+            false, false, false, false, false, null);
+        Table result = DecimalUtils.add128(lhs, rhs, 5)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
       assertColumnsAreEqual(expected, result.getColumn(1));
     }
@@ -493,8 +493,8 @@ public class DecimalUtilsTest {
             "7770175100125696617964074281.376399082",
             "-1869881956184352298725010129.272506370");
         ColumnVector expectedValid = ColumnVector.fromBoxedBooleans(false, false, false, false,
-            false, false, false, false, false, false)) {
-      Table result = DecimalUtils.add128(lhs, rhs, -9);
+            false, false, false, false, false, false);
+        Table result = DecimalUtils.add128(lhs, rhs, -9)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
       assertColumnsAreEqual(expected, result.getColumn(1));
     }
@@ -505,8 +505,8 @@ public class DecimalUtilsTest {
     try (
         ColumnVector lhs = makeDec128Column("50000000000000000000000000000000000000");
         ColumnVector rhs = makeDec128Column("2");
-        ColumnVector expectedValid = ColumnVector.fromBooleans(true)) {
-      Table result = DecimalUtils.multiply128(lhs, rhs, 0);
+        ColumnVector expectedValid = ColumnVector.fromBooleans(true);
+        Table result = DecimalUtils.multiply128(lhs, rhs, 0)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
     }
   }
@@ -516,8 +516,8 @@ public class DecimalUtilsTest {
     try (
         ColumnVector lhs = makeDec128Column("99999999999999999999999999999999999999");
         ColumnVector rhs = makeDec128Column("1");
-        ColumnVector expectedValid = ColumnVector.fromBooleans(true)) {
-      Table result = DecimalUtils.add128(lhs, rhs, 0);
+        ColumnVector expectedValid = ColumnVector.fromBooleans(true);
+        Table result = DecimalUtils.add128(lhs, rhs, 0)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
     }
   }
@@ -527,8 +527,8 @@ public class DecimalUtilsTest {
     try (
         ColumnVector lhs = makeDec128Column("-99999999999999999999999999999999999999");
         ColumnVector rhs = makeDec128Column("1");
-        ColumnVector expectedValid = ColumnVector.fromBooleans(true)) {
-      Table result = DecimalUtils.subtract128(lhs, rhs, 0);
+        ColumnVector expectedValid = ColumnVector.fromBooleans(true);
+        Table result = DecimalUtils.subtract128(lhs, rhs, 0)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
     }
   }
@@ -571,8 +571,8 @@ public class DecimalUtilsTest {
             "8484593380070321326506943924.036399082",
             "-154984298778579123337137056.852506370");
         ColumnVector expectedValid = ColumnVector.fromBoxedBooleans(false, false, false, false,
-            false, false, false, false, false, false)) {
-      Table result = DecimalUtils.subtract128(lhs, rhs, -9);
+            false, false, false, false, false, false);
+        Table result = DecimalUtils.subtract128(lhs, rhs, -9)) {
       assertColumnsAreEqual(expectedValid, result.getColumn(0));
       assertColumnsAreEqual(expected, result.getColumn(1));
     }


### PR DESCRIPTION
This fixes #949

The memory leaks would not show up in the logs because the logging was accidentally disabled by having too many slf4j loggers and the wrong one was being picked.

The failure was not reproducible because GC is not deterministic when it happens so if GC happened after the leaks, but before an RMM shutdown the failure would not happen.  Also the order of the tests was the default ordering (filesystem) which is different from system to system. I reran the tests with random ordering and saw failures happening in different tests. I set the order to always be alphabetical so at least we will be consistent going forward.

I will be opening one other issue against CUDF where a host memory buffer was being leaked, and to make tests the purposely double free have it in the name so it is simpler to filter them out when looking for issues in the logs.