### PR TITLE
Fix an issue where RmmSpark could deadlock if UCX shuffle is used

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -441,6 +441,7 @@ public:
           throw std::invalid_argument(ss.str());
         }
       }
+      check_and_update_for_bufn(lock);
     } else {
       throw std::invalid_argument("the thread is not associated with any task/shuffle");
     }


### PR DESCRIPTION
This was found with the fuzz testing in https://github.com/NVIDIA/spark-rapids-jni/pull/977

essentially it shows up if the shuffle thread is already blocked and then the task thread says that it might block on shuffle, and that task thread was the last task thread before block until further notice would be needed to break a deadlock.  This adds the block until further notice checks after a task says it may block on shuffle.