### PR TITLE
Update default gcc to 11 and support cuda 12 build

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,4 +74,4 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -e VERBOSE \
   $DOCKER_OPTS \
   $SPARK_IMAGE_NAME \
-  scl enable devtoolset-9 "$RUN_CMD"
+  scl enable devtoolset-11 "$RUN_CMD"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 ###
 ARG CUDA_VERSION=11.8.0
 FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
-ARG DEVTOOLSET_VERSION=9
+ARG DEVTOOLSET_VERSION=11
 ### Install basic requirements
 RUN yum install -y centos-release-scl
 RUN yum install -y devtoolset-${DEVTOOLSET_VERSION} rh-python38 epel-release

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,7 @@ pipeline {
                     container('gpu') {
                         timeout(time: 3, unit: 'HOURS') { // step only timeout for test run
                             common.resolveIncompatibleDriverIssue(this)
-                            sh 'scl enable devtoolset-9 "ci/premerge-build.sh"'
+                            sh 'scl enable devtoolset-11 "ci/premerge-build.sh"'
                         }
                     }
                 }

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -22,6 +22,7 @@ nvidia-smi
 git submodule update --init --recursive
 
 MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
+CUDA_VERSION=${CUDA_VERSION:-`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 USE_GDS=${USE_GDS:-ON}
 ${MVN} clean package ${MVN_MIRROR}  \
@@ -29,4 +30,4 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest \
-  -DBUILD_TESTS=ON
+  -DBUILD_TESTS=ON -Dcuda.version=$CUDA_VERSION

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -22,7 +22,7 @@ nvidia-smi
 git submodule update --init --recursive
 
 MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
-CUDA_VERSION=${CUDA_VERSION:-`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
+CUDA_VER=${CUDA_VER:-`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 USE_GDS=${USE_GDS:-ON}
 ${MVN} clean package ${MVN_MIRROR}  \
@@ -30,4 +30,4 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest \
-  -DBUILD_TESTS=ON -Dcuda.version=$CUDA_VERSION
+  -DBUILD_TESTS=ON -Dcuda.version=$CUDA_VER

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -22,7 +22,8 @@ nvidia-smi
 git submodule update --init --recursive
 
 MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
-CUDA_VER=${CUDA_VER:-`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
+# cuda11 or cuda12
+CUDA_VER=${CUDA_VER:-cuda`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 USE_GDS=${USE_GDS:-ON}
 ${MVN} clean package ${MVN_MIRROR}  \

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 # NOTE:
 #     this script is for jenkins only, and should not be used for local development
 #     run with ci/Dockerfile in jenkins:
-#         scl enable devtoolset-9 rh-python38 "ci/submodule-sync.sh"
+#         scl enable devtoolset-11 rh-python38 "ci/submodule-sync.sh"
 
 set -ex
 


### PR DESCRIPTION
related to https://github.com/rapidsai/ops/issues/2568 and https://github.com/rapidsai/cudf/pull/12881

To support cuda 12 build,
upgrade gcc version to 11 and build w/ cuda classifier

convert to draft first, will update submodule ref later w/ cudf-side updates

