### PR TITLE
Add in a GpuOOM exception so running out of GPU memory is not a fatal to Spark

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuOOM.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuOOM.java
@@ -17,16 +17,16 @@
 package com.nvidia.spark.rapids.jni;
 
 /**
- * A special version of an out of memory error that indicates we ran out of memory, but should
- * roll back to a point when all memory for the task is spillable and then retry the operation
- * with the input data split to make it ideally use less GPU memory overall.
+ * A special version of an out of memory error that indicates we ran out of GPU memory. This is
+ * mostly to avoid a fatal error that would force the worker process to restart. This should be
+ * recoverable on the GPU.
  */
-public class SplitAndRetryOOM extends GpuOOM {
-  public SplitAndRetryOOM() {
+public class GpuOOM extends RuntimeException {
+  public GpuOOM() {
     super();
   }
 
-  public SplitAndRetryOOM(String message) {
+  public GpuOOM(String message) {
     super(message);
   }
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/RetryOOM.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RetryOOM.java
@@ -20,7 +20,7 @@ package com.nvidia.spark.rapids.jni;
  * A special version of an out of memory error that indicates we ran out of memory, but should
  * roll back to a point when all memory for the task is spillable and then retry the operation.
  */
-public class RetryOOM extends OutOfMemoryError {
+public class RetryOOM extends GpuOOM {
   public RetryOOM() {
     super();
   }


### PR DESCRIPTION
In Spark if an OutOfMemory error is thrown, then the entire executor is torn down. This is not technically required when it is GPU memory that we ran out of. The upside is that if the task is setup correctly and memory can be recovered from it, other tasks in the same process will not be killed, and shuffle data will not be lost.  But if memory ends up being leaked by a task, then it is more likely to cause other tasks and even possibly later jobs to fail.