### PR TITLE
Add -DBUILD_TESTS=ON to submodule sync [skip ci]

### DIFF
--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -69,7 +69,8 @@ set +e
 ${MVN} verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest \
+  -DBUILD_TESTS=ON
 verify_status=$?
 set -e
 


### PR DESCRIPTION
fix #1010 

Lets add `-DBUILD_TESTS=ON` to submodule sync first.
we can revisit maven args of pre-merge, nightly, submodule-sync,
maybe try add a common args for all of them later

