### PR TITLE
Add retry count and block time metrics

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -333,4 +333,52 @@ public class RmmSpark {
       }
     }
   }
+
+  /**
+   * Get the number of retry exceptions that were thrown and reset the metric.
+   * @param taskId the id of the task to get the metric for.
+   * @return the number of times it was thrown or 0 if in the UNKNOWN state.
+   */
+  public static int getAndResetNumRetryThrow(long taskId) {
+    synchronized (Rmm.class) {
+      if (sra != null && sra.isOpen()) {
+        return sra.getAndResetNumRetryThrow(taskId);
+      } else {
+        // sra is not set so the value is by definition 0
+        return 0;
+      }
+    }
+  }
+
+  /**
+   * Get the number of split and retry exceptions that were thrown and reset the metric.
+   * @param taskId the id of the task to get the metric for.
+   * @return the number of times it was thrown or 0 if in the UNKNOWN state.
+   */
+  public static int getAndResetNumSplitRetryThrow(long taskId) {
+    synchronized (Rmm.class) {
+      if (sra != null && sra.isOpen()) {
+        return sra.getAndResetNumSplitRetryThrow(taskId);
+      } else {
+        // sra is not set so the value is by definition 0
+        return 0;
+      }
+    }
+  }
+
+  /**
+   * Get how long, in nanoseconds, that the task was blocked for
+   * @param taskId the id of the task to get the metric for.
+   * @return the time the task was blocked or 0 if in the UNKNOWN state.
+   */
+  public static long getAndResetBlockTimeNs(long taskId) {
+    synchronized (Rmm.class) {
+      if (sra != null && sra.isOpen()) {
+        return sra.getAndResetBlockTime(taskId);
+      } else {
+        // sra is not set so the value is by definition 0
+        return 0;
+      }
+    }
+  }
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -162,6 +162,18 @@ public class SparkResourceAdaptor
     return RmmSparkThreadState.fromNativeId(getStateOf(getHandle(), threadId));
   }
 
+  public int getAndResetNumRetryThrow(long taskId) {
+    return getAndResetRetryThrowInternal(getHandle(), taskId);
+  }
+
+  public int getAndResetNumSplitRetryThrow(long taskId) {
+    return getAndResetSplitRetryThrowInternal(getHandle(), taskId);
+  }
+
+  public long getAndResetBlockTime(long taskId) {
+    return getAndResetBlockTimeInternal(getHandle(), taskId);
+  }
+
   /**
    * Get the ID of the current thread that can be used with the other SparkResourceAdaptor APIs.
    * Don't use the java thread ID. They are not related.
@@ -181,4 +193,8 @@ public class SparkResourceAdaptor
   private static native void forceCudfException(long handle, long threadId, int numTimes);
   private static native void blockThreadUntilReady(long handle);
   private static native int getStateOf(long handle, long threadId);
+  private static native int getAndResetRetryThrowInternal(long handle, long taskId);
+  private static native int getAndResetSplitRetryThrowInternal(long handle, long taskId);
+  private static native long getAndResetBlockTimeInternal(long handle, long taskId);
+
 }


### PR DESCRIPTION
This adds in some basic retry metrics. This is the first part of https://github.com/NVIDIA/spark-rapids/issues/7880 I will probably file a follow on issue for other metrics, but this should provide the basic metrics that we need at a minimum.