### PR TITLE
Log injected exceptions to spdlog

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -845,17 +845,20 @@ private:
       if (thread->second.retry_oom_injected > 0) {
         thread->second.retry_oom_injected--;
         thread->second.num_times_retry_throw++;
+        log_status("INJECTED_RETRY_OOM", thread_id, thread->second.task_id, thread->second.state);
         throw_java_exception(RETRY_OOM_CLASS, "injected RetryOOM");
       }
 
       if (thread->second.cudf_exception_injected > 0) {
         thread->second.cudf_exception_injected--;
+        log_status("INJECTED_CUDF_EXCEPTION", thread_id, thread->second.task_id, thread->second.state);
         throw_java_exception(CUDF_EXCEPTION_CLASS, "injected CudfException");
       }
 
       if (thread->second.split_and_retry_oom_injected > 0) {
         thread->second.split_and_retry_oom_injected--;
         thread->second.num_times_split_retry_throw++;
+        log_status("INJECTED_SPLIT_AND_RETRY_OOM", thread_id, thread->second.task_id, thread->second.state);
         throw_java_exception(SPLIT_AND_RETRY_OOM_CLASS, "injected SplitAndRetryOOM");
       }
 


### PR DESCRIPTION
Adds a log message when throwing an injected exception. Note it doesn't log for all exceptions, as the idea is to detect in the tests whether we were able to fake an OOM happening. That said, if folks see value in logging this for all exceptions, we can, and I can unify the code a bit.

I have not run this at all, but I am running a build in the background.