### PR TITLE
Disable non-empty nulls assertions 

### DIFF
--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -30,5 +30,5 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -Psource-javadoc \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest \
+  -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
   -DBUILD_TESTS=ON -Dcuda.version=$CUDA_VER

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -26,5 +26,5 @@ PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 ${MVN} verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest \
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
   -DBUILD_TESTS=ON

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -69,7 +69,7 @@ set +e
 ${MVN} verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest \
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
   -DBUILD_TESTS=ON
 verify_status=$?
 set -e

--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
             </goals>
             <configuration>
               <argLine>-da:ai.rapids.cudf.AssertEmptyNulls</argLine>
-              <test>**/ColumnViewNonEmptyNullsTest.java</test>
+              <test>ColumnViewNonEmptyNullsTest</test>
             </configuration>
           </execution>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,18 @@
             <configuration>
               <excludes>
                 <exclude>**/CudaFatalTest.java</exclude>
+                <exclude>**/ColumnViewNonEmptyNullsTest.java</exclude>
               </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>non-empty-null-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <argLine>-da:ai.rapids.cudf.AssertEmptyNulls</argLine>
+              <test>**/ColumnViewNonEmptyNullsTest.java</test>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This PR disables the assertions added in https://github.com/rapidsai/cudf/pull/13071 when performing unit tests

contributes to https://github.com/NVIDIA/spark-rapids/issues/6680
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
