### PR TITLE
Specify basic_file_sink header in SparkResourceAdaptorJni.cpp

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -24,6 +24,7 @@
 #include <cudf_jni_apis.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <spdlog/common.h>
+#include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-jni/issues/1095.

We are using a type in SparkResourceAdaptorJni.cpp that was being pulled in via other headers. Specifying the header dependency directly here. I believe this  should fix the build, but I have other builds going at the moment so I haven't been able to build it.