### PR TITLE
Pin urllib3<2.0 to resolve requests lib issue for CI scripts [skip ci]

### DIFF
--- a/.github/workflows/action-helper/Dockerfile
+++ b/.github/workflows/action-helper/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ WORKDIR /
 COPY python /python
 COPY entrypoint.sh .
 RUN chmod -R +x /python /entrypoint.sh
-RUN pip install requests
+# pin urllib3<2.0 for https://github.com/psf/requests/issues/6432
+RUN pip install requests "urllib3<2.0"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -29,7 +29,8 @@ RUN yum install -y devtoolset-${DEVTOOLSET_VERSION} rh-python38 epel-release
 RUN yum install -y zlib-devel maven tar wget patch ninja-build
 # require git 2.18+ to keep consistent submodule operations
 RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && yum install -y git
-RUN scl enable rh-python38 "pip install requests"
+# pin urllib3<2.0 for https://github.com/psf/requests/issues/6432
+RUN scl enable rh-python38 "pip install requests 'urllib3<2.0'"
 
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir /usr/local/rapids && mkdir /rapids && chmod 777 /usr/local/rapids && chmod 777 /rapids


### PR DESCRIPTION
To fix latest py requests (minor version upgrade) but requires urllib3>2.0 issue

```
[2023-05-04T21:06:22.593Z]     raise ImportError(

[2023-05-04T21:06:22.593Z] ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips  26 Jan 2017. See: https://github.com/urllib3/urllib3/issues/2168
```