### PR TITLE
Detect recursion in pre_allocate and skip state transitions

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1393,11 +1393,8 @@ JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_get
   CATCH_STD(env, 0)
 }
 
-JNIEXPORT jint JNICALL
-Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetRetryThrowInternal(JNIEnv *env,
-                                                                                    jclass,
-                                                                                    jlong ptr,
-                                                                                    jlong task_id) {
+JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetRetryThrowInternal(
+    JNIEnv *env, jclass, jlong ptr, jlong task_id) {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
   try {
     cudf::jni::auto_set_device(env);

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1169,9 +1169,8 @@ private:
           throw;
         }
       } catch (const std::exception &e) {
-        if (!post_alloc_failed(tid, false, likely_spill)) {
-          throw;
-        }
+        post_alloc_failed(tid, false, likely_spill);
+        throw;
       }
     }
     // we should never reach this point, but just in case

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1116,14 +1116,7 @@ private:
     bool ret = true;
     if (!likely_spill && thread != threads.end()) {
       switch (thread->second.state) {
-        case TASK_ALLOC_FREE: 
-          if (is_oom) {
-            transition(thread->second, thread_state::TASK_BLOCKED);
-          } else {
-            // don't block unless it is OOM
-            transition(thread->second, thread_state::TASK_RUNNING);
-          }
-          break;
+        case TASK_ALLOC_FREE: transition(thread->second, thread_state::TASK_RUNNING); break;
         case TASK_ALLOC:
           if (is_oom) {
             transition(thread->second, thread_state::TASK_BLOCKED);

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
@@ -797,7 +797,7 @@ public class RmmSparkTest {
         RmmSpark.removeThreadAssociation(threadId);
       }
     });
-    assertEquals(1, rmmEventHandler.getAllocationCount());
+    assertEquals(11, rmmEventHandler.getAllocationCount());
   }
 
   @Test


### PR DESCRIPTION
Due to some of the recent null_count changes in cuDF I am seeing a case I didn't cover well while implementing https://github.com/NVIDIA/spark-rapids/issues/7672.

In summary, I've come to the realization that it's really brittle to assume that cuDF operations on columns won't require allocations from the default per-device memory resource. Because the work in https://github.com/NVIDIA/spark-rapids/issues/7672 is looking to spill (handling an allocation failure), it means we could allocate while we are trying to spill. Note this didn't happen before because prior to this we would just cudaMemcpy the contiguous buffer, which we no longer have.

This change is to fix two exceptions that the state machine can raise if we are setting up a spill while we are already handling an allocation failure:

```
ai.rapids.cudf.CudfException: thread 139871119120128 in unexpected state pre alloc TASK_ALLOC_FREE
```
and

```
ai.rapids.cudf.CudfException: thread 140005702866688 in unexpected state pre alloc TASK_ALLOC
```

`TASK_ALLOC` makes perfect sense to me. We were allocating and failed due to OOM, so we called into the spill code. Then we ended up back in the same place, so we are still in `TASK_ALLOC`. This should be a pass-through and we should not transition states given this recursive call.

`TASK_ALLOC_FREE`, if I understand it correctly, can happen due to a race condition. All threads that were in `TASK_ALLOC` will go to `TASK_ALLOC_FREE` once a free succeeds in any thread, so we should treat this as a special case here, because we wouldn't have transitioned to `TASK_ALLOC_FREE` unless we were also in this recursive scenario.
