### PR TITLE
Moves the lock around do_deallocate to protect threads.find

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1174,6 +1174,8 @@ private:
     resource->deallocate(p, size, stream);
     // deallocate success
     if (size > 0) {
+      std::unique_lock<std::mutex> lock(state_mutex);
+
       auto tid = static_cast<long>(pthread_self());
       auto thread = threads.find(tid);
       if (thread != threads.end()) {
@@ -1182,7 +1184,6 @@ private:
         log_status("DEALLOC", tid, -2, thread_state::UNKNOWN);
       }
 
-      std::unique_lock<std::mutex> lock(state_mutex);
       for (auto thread = threads.begin(); thread != threads.end(); thread++) {
         // Only update state for _other_ threads. We update only other threads, for the case
         // where we are handling a free from the recursive case: when an allocation/free 


### PR DESCRIPTION
This fixes a place where `do_deallocate` was using the STL container `threads` outside of a lock that is used in every other function I can find (I audited the rest of the usage).

Thanks to @revans2 and @jlowe they helped find this code because it looks to be pointed at by the hs_err_pid files we are getting in the crash reports (like this https://github.com/NVIDIA/spark-rapids/issues/8235).

We'd like to push this and run the CI pipelines to see if we have been able to fix.