### PR TITLE
Pre-merge docker build stage to support containerd runtime [skip ci]

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -151,7 +151,7 @@ pipeline {
                         if (TEMP_IMAGE_BUILD) {
                             PREMERGE_TAG = "centos7-cuda11.8.0-blossom-dev-${BUILD_TAG}"
                             IMAGE_PREMERGE = "${ARTIFACTORY_NAME}/sw-spark-docker-local/plugin-jni:${PREMERGE_TAG}"
-                            docker.build(IMAGE_PREMERGE, "-f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE .")
+                            docker.build(IMAGE_PREMERGE, "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE .")
                             uploadDocker(IMAGE_PREMERGE)
                         }
                     }


### PR DESCRIPTION
Internal kubernetes for CI has been upgraded to 1.22 and use containerd runtime to replace docker runtime.

As Kubernetes is deprecating support docker runtime,
add --network=host to docker build stage to workaround docker build in DinD pod on kube 1.22 cluster.

verified in internal ENV