### PR TITLE
Ensure columns have valid null counts.

### DIFF
--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -2256,11 +2256,12 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const &input,
     for (int i = 0; i < static_cast<int>(schema.size()); ++i) {
       if (schema[i].id() == type_id::STRING) {
         // stuff real string column
+        auto const null_count = string_row_offset_columns[string_idx]->null_count();
         auto string_data = string_row_offset_columns[string_idx].release()->release();
-        output_columns[i] = make_strings_column(num_rows, std::move(string_col_offsets[string_idx]),
-                                                std::move(string_data_cols[string_idx]),
-                                                std::move(*string_data.null_mask.release()),
-                                                cudf::UNKNOWN_NULL_COUNT);
+        output_columns[i] =
+            make_strings_column(num_rows, std::move(string_col_offsets[string_idx]),
+                                std::move(string_data_cols[string_idx]),
+                                std::move(*string_data.null_mask.release()), null_count);
         string_idx++;
       }
     }


### PR DESCRIPTION
This is in prep for https://github.com/rapidsai/cudf/issues/11968 and https://github.com/rapidsai/cudf/pull/13372.

`libcudf` will soon require that all CUDF columns are created with a known null-count. `UNKNOWN_NULL_COUNT` will no longer be supported, or even available as a code constant.

This change replicates part of https://github.com/rapidsai/cudf/pull/13355, as it applies to `row_conversion.cu`. The (single) reference to the unknown-null-count is replaced with a pre-calculated value.