### PR TITLE
Upmerge to the latest CUDF and fix compile errors

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -628,8 +628,11 @@ std::unique_ptr<cudf::column> from_json(cudf::column_view const &input,
   auto structs_col = cudf::make_structs_column(num_pairs, std::move(out_keys_vals), 0,
                                                rmm::device_buffer{}, stream, mr);
 
+  auto offsets = std::make_unique<cudf::column>(std::move(list_offsets), 
+              rmm::device_buffer{}, 0);
+
   return cudf::make_lists_column(
-      input.size(), std::make_unique<cudf::column>(std::move(list_offsets)), std::move(structs_col),
+      input.size(), std::move(offsets), std::move(structs_col),
       input.null_count(), cudf::detail::copy_bitmask(input, stream, mr), stream, mr);
 }
 

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -1886,10 +1886,13 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
                    auto const offset_count = batch_info.row_batches[batch].row_offsets.size();
                    auto offsets = std::make_unique<column>(
                        data_type{type_id::INT32}, (size_type)offset_count,
-                       batch_info.row_batches[batch].row_offsets.release());
+                       batch_info.row_batches[batch].row_offsets.release(),
+                       rmm::device_buffer{}, 0);
                    auto data = std::make_unique<column>(data_type{type_id::INT8},
                                                         batch_info.row_batches[batch].num_bytes,
-                                                        std::move(output_buffers[batch]));
+                                                        std::move(output_buffers[batch]),
+                                                        rmm::device_buffer{},
+                                                        0);
 
                    return make_lists_column(
                        batch_info.row_batches[batch].row_count, std::move(offsets), std::move(data),

--- a/src/main/cpp/tests/cast_string.cpp
+++ b/src/main/cpp/tests/cast_string.cpp
@@ -240,7 +240,8 @@ TYPED_TEST(StringToIntegerTests, Overflow)
 
 TYPED_TEST(StringToIntegerTests, Empty)
 {
-  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{});
+  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{},
+          rmm::device_buffer{}, 0);
 
   auto result = spark_rapids_jni::string_to_integer(data_type{type_to_id<TypeParam>()},
                                                     strings_column_view{empty->view()},
@@ -541,7 +542,8 @@ TEST_F(StringToDecimalTests, Edges)
 
 TEST_F(StringToDecimalTests, Empty)
 {
-  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{});
+  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{},
+          rmm::device_buffer{}, 0);
 
   auto const result = spark_rapids_jni::string_to_decimal(
     8, 2, strings_column_view{empty->view()}, false, true, cudf::get_default_stream());
@@ -696,7 +698,8 @@ TYPED_TEST(StringToFloatTests, TrickyValues)
 
 TYPED_TEST(StringToFloatTests, Empty)
 {
-  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{});
+  auto empty = std::make_unique<column>(data_type{type_id::STRING}, 0, rmm::device_buffer{},
+          rmm::device_buffer{}, 0);
 
   auto const result = spark_rapids_jni::string_to_float(data_type{type_to_id<TypeParam>()},
                                                         strings_column_view{empty->view()},


### PR DESCRIPTION
This upmerges to the latest 23.06 CUDF and fixes the compile errors in our code that showed up with it.

I will be testing this on our plugin too, but I wanted to get this up and started to unblock people.