### PR TITLE
Followup for null count fixup in row_conversion.cu.

### DIFF
--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -2332,6 +2332,9 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(
         num_rows, num_columns, size_per_row, dev_column_start.data(), dev_column_size.data(),
         dev_output_data.data(), dev_output_nm.data(), child.data<int8_t>());
 
+    // Set null counts, because output_columns are modified via mutable-view,
+    // in the kernel above.
+    // TODO(future): Consider setting null count in the kernel itself.
     for (auto &col : output_columns) {
       col->set_null_count(cudf::null_count(col->view().null_mask(), 0, col->size()));
     }

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -2276,9 +2276,6 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const &input,
     }
   }
 
-  for (auto &col : output_columns) {
-    col->set_null_count(cudf::null_count(col->view().null_mask(), 0, col->size()));
-  }
   return std::make_unique<table>(std::move(output_columns));
 }
 

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -2259,8 +2259,14 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const &input,
     for (int i = 0; i < static_cast<int>(schema.size()); ++i) {
       if (schema[i].id() == type_id::STRING) {
         // stuff real string column
-        auto const null_count = string_row_offset_columns[string_idx]->null_count();
         auto string_data = string_row_offset_columns[string_idx].release()->release();
+        auto const null_count = [&] {
+          auto const &null_mask = *string_data.null_mask;
+          return null_mask.data() ?
+                     cudf::null_count(static_cast<bitmask_type const *>(null_mask.data()), 0,
+                                      num_rows) :
+                     0;
+        }();
         output_columns[i] =
             make_strings_column(num_rows, std::move(string_col_offsets[string_idx]),
                                 std::move(string_data_cols[string_idx]),
@@ -2270,6 +2276,9 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const &input,
     }
   }
 
+  for (auto &col : output_columns) {
+    col->set_null_count(cudf::null_count(col->view().null_mask(), 0, col->size()));
+  }
   return std::make_unique<table>(std::move(output_columns));
 }
 
@@ -2325,6 +2334,9 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(
         num_rows, num_columns, size_per_row, dev_column_start.data(), dev_column_size.data(),
         dev_output_data.data(), dev_output_nm.data(), child.data<int8_t>());
 
+    for (auto &col : output_columns) {
+      col->set_null_count(cudf::null_count(col->view().null_mask(), 0, col->size()));
+    }
     return std::make_unique<table>(std::move(output_columns));
   } else {
     CUDF_FAIL("Only fixed width types are currently supported");

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -2261,6 +2261,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const &input,
         // stuff real string column
         auto string_data = string_row_offset_columns[string_idx].release()->release();
         auto const null_count = [&] {
+          // Null-count not set previously. Calculate, on the fly.
           auto const &null_mask = *string_data.null_mask;
           return null_mask.data() ?
                      cudf::null_count(static_cast<bitmask_type const *>(null_mask.data()), 0,


### PR DESCRIPTION
This is a followup to #1148.

`row_conversion.cu` was modified in https://github.com/rapidsai/cudf/pull/13372 to explicitly calculate null-counts for output columns.

This commit replicates the changes in rapidsai/cudf/pull/13372, and adds explicit null-count calculation for the string offsets column.
