### PR TITLE
Adding non-ansi decimal to string conversion

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -153,6 +153,7 @@ add_library(
   src/RowConversionJni.cpp
   src/SparkResourceAdaptorJni.cpp
   src/ZOrderJni.cpp
+  src/cast_decimal_to_string.cu
   src/cast_string.cu
   src/cast_string_to_float.cu
   src/decimal_utils.cu

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -46,8 +46,7 @@ constexpr char const* JNI_CAST_ERROR_CLASS = "com/nvidia/spark/rapids/jni/CastEx
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toInteger(
-  JNIEnv* env, jclass, jlong input_column, jboolean ansi_enabled, jboolean strip,
-  jint j_dtype)
+  JNIEnv* env, jclass, jlong input_column, jboolean ansi_enabled, jboolean strip, jint j_dtype)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
@@ -56,15 +55,19 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toInteger(
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_integer(
-      cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, strip, 
-      cudf::get_default_stream()));
+      cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, strip, cudf::get_default_stream()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toDecimal(
-  JNIEnv* env, jclass, jlong input_column, jboolean ansi_enabled, jboolean strip,
-  jint precision, jint scale)
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_jni_CastStrings_toDecimal(JNIEnv* env,
+                                                       jclass,
+                                                       jlong input_column,
+                                                       jboolean ansi_enabled,
+                                                       jboolean strip,
+                                                       jint precision,
+                                                       jint scale)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
@@ -89,6 +92,22 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toFloat(
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::string_to_float(
       cudf::jni::make_data_type(j_dtype, 0), scv, ansi_enabled, cudf::get_default_stream()));
+  }
+  CATCH_CAST_EXCEPTION(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal(JNIEnv* env,
+                                                                                 jclass,
+                                                                                 jlong input_column)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+
+    cudf::column_view cv{*reinterpret_cast<cudf::column_view const*>(input_column)};
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::decimal_to_non_ansi_string(cv, cudf::get_default_stream()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cast_string.hpp"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/strings/detail/convert/int_to_string.cuh>
+#include <cudf/strings/detail/converters.hpp>
+#include <cudf/strings/detail/strings_children.cuh>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/generate.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/optional.h>
+#include <thrust/transform.h>
+
+#include <cuda/std/climits>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+using namespace cudf;
+
+namespace spark_rapids_jni {
+
+namespace detail {
+namespace {
+constexpr int max_zeros = 5;
+
+template <typename DecimalType>
+struct decimal_to_non_ansi_string_fn {
+  column_device_view d_decimals;
+  offset_type* d_offsets{};
+  char* d_chars{};
+
+  /**
+   * @brief Calculates the size of the string required to convert the element, in base-10 format.
+   *
+   * Output format is [-]integer.fraction
+   */
+  __device__ int32_t compute_output_size(DecimalType value)
+  {
+    auto const scale = d_decimals.type().scale();
+
+    if (scale >= 0) return strings::detail::count_digits(value) + scale;
+
+    auto const abs_value = numeric::detail::abs(value);
+    auto const exp_ten   = numeric::detail::exp10<DecimalType>(-scale);
+    auto const fraction  = strings::detail::count_digits(abs_value % exp_ten);
+    auto const num_zeros = std::max(0, (-scale - fraction));
+
+    return value == 0 && num_zeros > max_zeros && scale < 0
+             ? static_cast<int32_t>(value < 0) +                       // sign if negative
+                 strings::detail::count_digits(abs_value / exp_ten) +  // integer
+                 2 +                                                   // E-
+                 strings::detail::count_digits(num_zeros + 1)
+             :  // number of zeros
+
+             static_cast<int32_t>(value < 0) +                       // sign if negative
+               strings::detail::count_digits(abs_value / exp_ten) +  // integer
+               1 +                                                   // decimal point
+               num_zeros +                                           // zeros padding
+               fraction;                                             // size of fraction
+  }
+
+  /**
+   * @brief Converts a decimal element into a string.
+   *
+   * The value is converted into base-10 digits [0-9]
+   * plus the decimal point and a negative sign prefix.
+   */
+  __device__ void decimal_to_non_ansi_string(size_type idx)
+  {
+    auto const value = d_decimals.element<DecimalType>(idx);
+    auto const scale = d_decimals.type().scale();
+    char* d_buffer   = d_chars + d_offsets[idx];
+
+    if (scale >= 0) {
+      d_buffer += strings::detail::integer_to_string(value, d_buffer);
+      thrust::generate_n(thrust::seq, d_buffer, scale, []() { return '0'; });  // add zeros
+      return;
+    }
+
+    // scale < 0
+    // write format:   [-]integer.fraction
+    // where integer  = abs(value) / (10^abs(scale))
+    //       fraction = abs(value) % (10^abs(scale))
+    if (value < 0) *d_buffer++ = '-';  // add sign
+    auto const abs_value = numeric::detail::abs(value);
+    auto const exp_ten   = numeric::detail::exp10<DecimalType>(-scale);
+    auto const num_zeros =
+      std::max(0, (-scale - strings::detail::count_digits(abs_value % exp_ten)));
+
+    if (value == 0 && num_zeros > max_zeros) {
+      *d_buffer++ = '0';
+      *d_buffer++ = 'E';
+      *d_buffer++ = '-';
+      d_buffer += strings::detail::integer_to_string(num_zeros + 1, d_buffer);
+      return;
+    }
+
+    d_buffer +=
+      strings::detail::integer_to_string(abs_value / exp_ten, d_buffer);  // add the integer part
+    *d_buffer++ = '.';                                                    // add decimal point
+
+    thrust::generate_n(thrust::seq, d_buffer, num_zeros, []() { return '0'; });  // add zeros
+    d_buffer += num_zeros;
+
+    strings::detail::integer_to_string(abs_value % exp_ten, d_buffer);  // add the fraction part
+  }
+
+  __device__ void operator()(size_type idx)
+  {
+    if (d_decimals.is_null(idx)) {
+      if (d_chars == nullptr) { d_offsets[idx] = 0; }
+      return;
+    }
+    if (d_chars != nullptr) {
+      decimal_to_non_ansi_string(idx);
+    } else {
+      d_offsets[idx] = compute_output_size(d_decimals.element<DecimalType>(idx));
+    }
+  }
+};
+
+/**
+ * @brief The dispatcher functor for converting fixed-point values into strings.
+ */
+struct dispatch_decimal_to_non_ansi_string_fn {
+  template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
+  std::unique_ptr<column> operator()(column_view const& input,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::mr::device_memory_resource* mr) const
+  {
+    using DecimalType = device_storage_type_t<T>;  // underlying value type
+
+    auto const d_column = column_device_view::create(input, stream);
+
+    auto [offsets, chars] = strings::detail::make_strings_children(
+      decimal_to_non_ansi_string_fn<DecimalType>{*d_column}, input.size(), stream, mr);
+
+    return make_strings_column(input.size(),
+                               std::move(offsets),
+                               std::move(chars),
+                               input.null_count(),
+                               cudf::detail::copy_bitmask(input, stream, mr));
+  }
+
+  template <typename T, std::enable_if_t<not cudf::is_fixed_point<T>()>* = nullptr>
+  std::unique_ptr<column> operator()(column_view const&,
+                                     rmm::cuda_stream_view,
+                                     rmm::mr::device_memory_resource*) const
+  {
+    CUDF_FAIL("Values for decimal_to_non_ansi_string function must be a decimal type.");
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<column> decimal_to_non_ansi_string(column_view const& input,
+                                                   rmm::cuda_stream_view stream,
+                                                   rmm::mr::device_memory_resource* mr)
+{
+  if (input.is_empty()) return make_empty_column(type_id::STRING);
+  return type_dispatcher(input.type(), dispatch_decimal_to_non_ansi_string_fn{}, input, stream, mr);
+}
+
+}  // namespace detail
+
+// external API
+
+std::unique_ptr<column> decimal_to_non_ansi_string(column_view const& input,
+                                                   rmm::cuda_stream_view stream,
+                                                   rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::decimal_to_non_ansi_string(input, stream, mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -102,6 +102,9 @@ struct decimal_to_non_ansi_string_fn {
    * isn't an issue here because Spark will not use the full range of values and will never cause
    * this issue.
    *
+   * @note Code follows the Java method of decimal to string outlined here:
+   * https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
+   *
    * The value is converted into base-10 digits [0-9]
    * plus the decimal point and a negative sign prefix.
    */

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -59,6 +59,8 @@ struct decimal_to_non_ansi_string_fn {
   /**
    * @brief Calculates the size of the string required to convert the element, in base-10 format.
    *
+   * @note This code does not properly handle a max negative decimal value and will overflow. This isn't an issue here because Spark will not use the full range of values and will never cause this issue.
+   *
    * Output format is [-]integer.fraction
    */
   __device__ int32_t compute_output_size(DecimalType value)
@@ -88,6 +90,8 @@ struct decimal_to_non_ansi_string_fn {
 
   /**
    * @brief Converts a decimal element into a string.
+   *
+   * @note This code does not properly handle a max negative decimal value and will overflow. This isn't an issue here because Spark will not use the full range of values and will never cause this issue.
    *
    * The value is converted into base-10 digits [0-9]
    * plus the decimal point and a negative sign prefix.

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -115,4 +115,9 @@ std::unique_ptr<cudf::column> string_to_float(
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
+  cudf::column_view const& input,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -48,6 +48,9 @@ endfunction(ConfigureTest)
 ConfigureTest(CAST_STRING
     cast_string.cpp)
 
+ConfigureTest(CAST_DECIMAL_TO_STRING
+    cast_decimal_to_string.cpp)
+
 ConfigureTest(ROW_CONVERSION
     row_conversion.cpp)
 

--- a/src/main/cpp/tests/cast_decimal_to_string.cpp
+++ b/src/main/cpp/tests/cast_decimal_to_string.cpp
@@ -149,4 +149,12 @@ TYPED_TEST(DecimalToStringTests, javaToString)
     auto const expected = test::strings_column_wrapper{"-1.23E-10"};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
+  {
+    auto const scale = scale_type{-8};
+    auto const input = fp_wrapper{{507688528}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"5.07688528"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
 }

--- a/src/main/cpp/tests/cast_decimal_to_string.cpp
+++ b/src/main/cpp/tests/cast_decimal_to_string.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cast_string.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/table_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf/strings/convert/convert_floats.hpp>
+
+#include <limits>
+#include <rmm/device_uvector.hpp>
+
+using namespace cudf;
+
+template <typename T>
+struct DecimalToStringTests : public test::BaseFixture {
+};
+
+TYPED_TEST_SUITE(DecimalToStringTests, cudf::test::FixedPointTypes);
+
+TYPED_TEST(DecimalToStringTests, Simple)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = device_storage_type_t<decimalXX>;
+  using fp_wrapper = test::fixed_point_column_wrapper<RepType>;
+
+  auto const scale = scale_type{0};
+  auto const input = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, scale};
+  auto const result =
+    spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+  auto const expected =
+    test::strings_column_wrapper{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TYPED_TEST(DecimalToStringTests, ScientificEdge)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = device_storage_type_t<decimalXX>;
+  using fp_wrapper = test::fixed_point_column_wrapper<RepType>;
+
+  {
+    auto const scale = scale_type{-6};
+    auto const input = fp_wrapper{{0, 100000000}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"0.000000", "100.000000"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{-7};
+    auto const input = fp_wrapper{{0, 100000000}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"0E-7", "10.0000000"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{-8};
+    auto const input = fp_wrapper{{0, 1000000000}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"0E-8", "10.00000000"};
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+}

--- a/src/main/cpp/tests/cast_decimal_to_string.cpp
+++ b/src/main/cpp/tests/cast_decimal_to_string.cpp
@@ -85,3 +85,68 @@ TYPED_TEST(DecimalToStringTests, ScientificEdge)
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
 }
+
+TYPED_TEST(DecimalToStringTests, javaToString)
+{
+  using namespace numeric;
+  using decimalXX  = TypeParam;
+  using RepType    = device_storage_type_t<decimalXX>;
+  using fp_wrapper = test::fixed_point_column_wrapper<RepType>;
+
+  {
+    auto const scale = scale_type{0};
+    auto const input = fp_wrapper{{123, -123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"123", "-123"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{1};
+    auto const input = fp_wrapper{{123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"1.23E+3"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{3};
+    auto const input = fp_wrapper{{123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"1.23E+5"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{-1};
+    auto const input = fp_wrapper{{123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"12.3"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{-5};
+    auto const input = fp_wrapper{{123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"0.00123"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{-10};
+    auto const input = fp_wrapper{{123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"1.23E-8"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+  {
+    auto const scale = scale_type{-12};
+    auto const input = fp_wrapper{{-123}, scale};
+    auto const result =
+      spark_rapids_jni::decimal_to_non_ansi_string(input, cudf::get_default_stream());
+    auto const expected = test::strings_column_wrapper{"-1.23E-10"};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+  }
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -81,6 +81,16 @@ public class CastStrings {
   }
 
   /**
+   * Convert a decimal column to a string column.
+   * 
+   * @param cv the column data to process
+   * @return the converted column
+   */
+  public static ColumnVector fromDecimal(ColumnView cv) {
+    return new ColumnVector(fromDecimal(cv.getNativeView()));
+  }
+
+  /**
    * Convert a string column to a given floating-point type column.
    *
    * @param cv the column data to process.
@@ -97,4 +107,5 @@ public class CastStrings {
   private static native long toDecimal(long nativeColumnView, boolean ansi_enabled, boolean strip,
       int precision, int scale);
   private static native long toFloat(long nativeColumnView, boolean ansi_enabled, int dtype);
+  private static native long fromDecimal(long nativeColumnView);
 }


### PR DESCRIPTION
This change adds a custom kernel for decimal to string conversion. This is identical to the cudf kernel with the exception of a zero with more than 5 decimal places. Spark < 3.4 creates a string in scientific notation for this case as described in https://github.com/NVIDIA/spark-rapids/issues/7870
 
This is the kernel side of the work and doesn't close that issue. There will be a PR on the plugin side to change the default behavior based on spark version and configuration.