### PR TITLE
Adds in a metric for computation time lost due to retry.

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -153,6 +153,32 @@ public class RmmSpark {
     associateThreadWithShuffle(getCurrentThreadId());
   }
 
+
+
+  public static void startRetryBlock(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null && sra.isOpen()) {
+        sra.startRetryBlock(threadId);
+      }
+    }
+  }
+
+  public static void currentThreadStartRetryBlock() {
+    startRetryBlock(getCurrentThreadId());
+  }
+
+  public static void endRetryBlock(long threadId) {
+    synchronized (Rmm.class) {
+      if (sra != null && sra.isOpen()) {
+        sra.endRetryBlock(threadId);
+      }
+    }
+  }
+
+  public static void currentThreadEndRetryBlock() {
+    startRetryBlock(getCurrentThreadId());
+  }
+
   /**
    * Remove the given thread ID from any association.
    * @param threadId the ID of the thread that is no longer a part of a task or shuffle
@@ -375,6 +401,22 @@ public class RmmSpark {
     synchronized (Rmm.class) {
       if (sra != null && sra.isOpen()) {
         return sra.getAndResetBlockTime(taskId);
+      } else {
+        // sra is not set so the value is by definition 0
+        return 0;
+      }
+    }
+  }
+
+  /**
+   * Get how long, in nanoseconds, that this task lost in computation time due to retries.
+   * @param taskId the id of the task to get the metric for.
+   * @return the time the task did computation that was lost.
+   */
+  public static long getAndResetComputeTimeLostToRetryNs(long taskId) {
+    synchronized (Rmm.class) {
+      if (sra != null && sra.isOpen()) {
+        return sra.getAndResetComputeTimeLostToRetry(taskId);
       } else {
         // sra is not set so the value is by definition 0
         return 0;

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -83,6 +83,14 @@ public class SparkResourceAdaptor
     associateThreadWithTask(getHandle(), threadId, taskId);
   }
 
+  public void startRetryBlock(long threadId) {
+    startRetryBlock(getHandle(), threadId);
+  }
+
+  public void endRetryBlock(long threadId) {
+    endRetryBlock(getHandle(), threadId);
+  }
+
   /**
    * Associate a thread with shuffle.
    * @param threadId the thread ID to associate (not java thread id).
@@ -174,6 +182,10 @@ public class SparkResourceAdaptor
     return getAndResetBlockTimeInternal(getHandle(), taskId);
   }
 
+  public long getAndResetComputeTimeLostToRetry(long taskId) {
+    return getAndResetComputeTimeLostToRetry(getHandle(), taskId);
+  }
+
   /**
    * Get the ID of the current thread that can be used with the other SparkResourceAdaptor APIs.
    * Don't use the java thread ID. They are not related.
@@ -196,5 +208,7 @@ public class SparkResourceAdaptor
   private static native int getAndResetRetryThrowInternal(long handle, long taskId);
   private static native int getAndResetSplitRetryThrowInternal(long handle, long taskId);
   private static native long getAndResetBlockTimeInternal(long handle, long taskId);
-
+  private static native long getAndResetComputeTimeLostToRetry(long handle, long taskId);
+  private static native void startRetryBlock(long handle, long threadId);
+  private static native void endRetryBlock(long handle, long threadId);
 }


### PR DESCRIPTION
This adds in some new APIs that let us collect a metric for how much time has been spent in a retry block before the retry made us roll it back and start over. I will put up a corresponding change in the plugin to use these new APIs and collect the metric.  This is really helpful in seeing how much time we likely lost and need to redo when a retry happens.  It helped to point out that in one case I have been testing that the retry was causing a lot of lost computation and that we really would have benefitted from https://github.com/NVIDIA/spark-rapids/issues/7868 because we were getting the retry after doing a lot of computation in a very large project statement.

I am hoping that the changes are simple enough I don't need to add comments, but if you cannot follow them I am obviously wrong and am happy to add them. I did the work quickly as a part of debugging an issue so feel free to rip this apart.