### PR TITLE
Merge cudf 23.08 with spark-rapids-jni fixes for hash utility functions that moved.

### DIFF
--- a/src/main/cpp/src/murmur_hash.cu
+++ b/src/main/cpp/src/murmur_hash.cu
@@ -15,9 +15,8 @@
  */
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/hashing.hpp>
-#include <cudf/detail/utilities/hash_functions.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/hashing/detail/hash_functions.cuh>
 #include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 
@@ -86,10 +85,10 @@ struct SparkMurmurHash3_32 {
       // casting byte-to-int, but C++ does not.
       uint32_t k1 = static_cast<uint32_t>(std::to_integer<int8_t>(data[i]));
       k1 *= c1;
-      k1 = cudf::detail::rotate_bits_left(k1, rot_c1);
+      k1 = cudf::hashing::detail::rotate_bits_left(k1, rot_c1);
       k1 *= c2;
       h ^= k1;
-      h = cudf::detail::rotate_bits_left(h, rot_c2);
+      h = cudf::hashing::detail::rotate_bits_left(h, rot_c2);
       h = h * 5 + c3;
     }
     return h;
@@ -106,10 +105,10 @@ struct SparkMurmurHash3_32 {
     for (cudf::size_type i = 0; i < nblocks; i++) {
       uint32_t k1 = getblock32(data, i * BLOCK_SIZE);
       k1 *= c1;
-      k1 = cudf::detail::rotate_bits_left(k1, rot_c1);
+      k1 = cudf::hashing::detail::rotate_bits_left(k1, rot_c1);
       k1 *= c2;
       h ^= k1;
-      h = cudf::detail::rotate_bits_left(h, rot_c2);
+      h = cudf::hashing::detail::rotate_bits_left(h, rot_c2);
       h = h * 5 + c3;
     }
 
@@ -168,14 +167,14 @@ template <>
 spark_hash_value_type __device__ inline SparkMurmurHash3_32<float>::operator()(
   float const& key) const
 {
-  return compute<float>(cudf::detail::normalize_nans(key));
+  return compute<float>(cudf::hashing::detail::normalize_nans(key));
 }
 
 template <>
 spark_hash_value_type __device__ inline SparkMurmurHash3_32<double>::operator()(
   double const& key) const
 {
-  return compute<double>(cudf::detail::normalize_nans(key));
+  return compute<double>(cudf::hashing::detail::normalize_nans(key));
 }
 
 template <>

--- a/src/main/cpp/src/xxhash64.cu
+++ b/src/main/cpp/src/xxhash64.cu
@@ -17,9 +17,8 @@
 #include "hash.cuh"
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/hashing.hpp>
 #include <cudf/detail/utilities/algorithm.cuh>
-#include <cudf/detail/utilities/hash_functions.cuh>
+#include <cudf/hashing/detail/hash_functions.cuh>
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -228,13 +227,13 @@ hash_value_type __device__ inline XXHash_64<uint16_t>::operator()(uint16_t const
 template <>
 hash_value_type __device__ inline XXHash_64<float>::operator()(float const& key) const
 {
-  return compute<float>(cudf::detail::normalize_nans_and_zeros(key));
+  return compute<float>(cudf::hashing::detail::normalize_nans_and_zeros(key));
 }
 
 template <>
 hash_value_type __device__ inline XXHash_64<double>::operator()(double const& key) const
 {
-  return compute<double>(cudf::detail::normalize_nans_and_zeros(key));
+  return compute<double>(cudf::hashing::detail::normalize_nans_and_zeros(key));
 }
 
 template <>


### PR DESCRIPTION

https://github.com/rapidsai/cudf/pull/13681 moved some functions around that broke the murmur and xxhash64 builds in spark-rapids-jni.  This PR merges the cudf branch and the fixes on the jni side.