### PR TITLE
Remove dependency of cudf detail/hash_functions.cuh

### DIFF
--- a/src/main/cpp/src/hash.cuh
+++ b/src/main/cpp/src/hash.cuh
@@ -28,6 +28,30 @@ namespace spark_rapids_jni {
 constexpr int64_t DEFAULT_XXHASH64_SEED = 42;
 
 /**
+ * Normalization of floating point NaNs, passthrough for all other values.
+ */
+template <typename T>
+T __device__ inline normalize_nans(T const& key)
+{
+  if constexpr (cudf::is_floating_point<T>()) {
+    if (std::isnan(key)) { return std::numeric_limits<T>::quiet_NaN(); }
+  }
+  return key;
+}
+
+/**
+ * Normalization of floating point NaNs and zeros, passthrough for all other values.
+ */
+template <typename T>
+T __device__ inline normalize_nans_and_zeros(T const& key)
+{
+  if constexpr (cudf::is_floating_point<T>()) {
+    if (key == T{0.0}) { return T{0.0}; }
+  }
+  return normalize_nans(key);
+}
+
+/**
  * @brief Converts a cudf decimal128 value to a java bigdecimal value.
  *
  * @param key The cudf decimal value

--- a/src/main/cpp/src/xxhash64.cu
+++ b/src/main/cpp/src/xxhash64.cu
@@ -18,7 +18,6 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/utilities/algorithm.cuh>
-#include <cudf/hashing/detail/hash_functions.cuh>
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -227,13 +226,13 @@ hash_value_type __device__ inline XXHash_64<uint16_t>::operator()(uint16_t const
 template <>
 hash_value_type __device__ inline XXHash_64<float>::operator()(float const& key) const
 {
-  return compute<float>(cudf::hashing::detail::normalize_nans_and_zeros(key));
+  return compute<float>(spark_rapids_jni::normalize_nans_and_zeros(key));
 }
 
 template <>
 hash_value_type __device__ inline XXHash_64<double>::operator()(double const& key) const
 {
-  return compute<double>(cudf::hashing::detail::normalize_nans_and_zeros(key));
+  return compute<double>(spark_rapids_jni::normalize_nans_and_zeros(key));
 }
 
 template <>


### PR DESCRIPTION

Fixes build breakage. 

We were including `detail/hash-functions.cuh` for `normalize_nans()` `normalize_nans_and_zeros()` and `rotate_bits_left()`.  This PR removes that dependency by duplicating the functions over into the jni itself.