### PR TITLE
Add JNI backend for Spark SQL function `conv` for (hexa)decimals

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -117,7 +117,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal
   CATCH_CAST_EXCEPTION(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegerUsingBase(
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersWithBase(
   JNIEnv* env, jclass, jlong input_column, jint base)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
@@ -148,7 +148,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegerUs
   CATCH_CAST_EXCEPTION(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromIntegerUsingBase(
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromIntegersWithBase(
   JNIEnv* env, jclass, jlong input_column, jint base)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
@@ -166,7 +166,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
           return cudf::strings::integers_to_hex(input_view);
         }
         default: {
-          return std::unique_ptr<cudf::column>(nullptr);  // TODO all zeros
+          auto const error_msg = "Bases supported 10, 16; Actual: " + std::to_string(base);
+          throw spark_rapids_jni::cast_error(0, error_msg);
         }
       }
     }();

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -126,7 +126,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersWithBase(
-  JNIEnv* env, jclass, jlong input_column, jint base)
+  JNIEnv* env, jclass, jlong input_column, jint base, jboolean ansi_enabled, jint j_dtype)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   using namespace cudf;
@@ -138,7 +138,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersW
 
     jni::auto_set_device(env);
     auto const zero_scalar   = numeric_scalar<uint64_t>(0);
-    auto const res_data_type = data_type(type_id::UINT64);
+    auto const res_data_type = jni::make_data_type(j_dtype, 0);
     auto const input_view{*reinterpret_cast<column_view const*>(input_column)};
     auto const validity_regex_str = [&] {
       switch (base) {

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "cast_string.hpp"
-#include <cudf/replace.hpp>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/replace.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/convert/convert_integers.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -128,7 +128,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegerUs
     auto const uint64_data_type = data_type(type_id::UINT64);
 
     auto const input_view{*reinterpret_cast<column_view const*>(input_column)};
-    auto integer_view  = [&] {
+    auto integer_view = [&] {
       switch (base) {
         case 10: {
           return strings::to_integers(input_view, uint64_data_type);
@@ -148,7 +148,6 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegerUs
   CATCH_CAST_EXCEPTION(env, 0);
 }
 
-
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromIntegerUsingBase(
   JNIEnv* env, jclass, jlong input_column, jint base)
 {
@@ -158,7 +157,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
     cudf::jni::auto_set_device(env);
 
     auto input_view{*reinterpret_cast<cudf::column_view const*>(input_column)};
-    auto result  = [&] {
+    auto result = [&] {
       switch (base) {
         case 10: {
           return cudf::strings::from_integers(input_view);
@@ -167,7 +166,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
           return cudf::strings::integers_to_hex(input_view);
         }
         default: {
-          return std::unique_ptr<cudf::column>(nullptr); // TODO all zeros
+          return std::unique_ptr<cudf::column>(nullptr);  // TODO all zeros
         }
       }
     }();
@@ -175,5 +174,4 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }
-
 }

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <cudf/strings/convert/convert_integers.hpp>
 #include "cast_string.hpp"
+#include <cudf/strings/convert/convert_integers.hpp>
 
 #include "cudf_jni_apis.hpp"
 #include "dtype_utils.hpp"
@@ -113,12 +113,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal
   CATCH_CAST_EXCEPTION(env, 0);
 }
 
-
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_changeRadix(JNIEnv* env,
-                                                                                 jclass,
-                                                                                 jlong input_column,
-                                                                                 jint fromRadix,
-                                                                                 jint toRadix)
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_changeRadix(
+  JNIEnv* env, jclass, jlong input_column, jint fromRadix, jint toRadix)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
@@ -129,12 +125,11 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_changeRadix
     auto const uint64_cv = [&] {
       switch (fromRadix) {
         case 10: {
-          return spark_rapids_jni::string_to_integer(
-            cudf::data_type(cudf::type_id::UINT64),
-            cv,
-            JNI_FALSE,
-            JNI_TRUE,
-            cudf::get_default_stream());
+          return spark_rapids_jni::string_to_integer(cudf::data_type(cudf::type_id::UINT64),
+                                                     cv,
+                                                     JNI_FALSE,
+                                                     JNI_TRUE,
+                                                     cudf::get_default_stream());
         } break;
         case 16: {
           return cudf::strings::hex_to_integers(cv, cudf::data_type(cudf::type_id::UINT64));

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -181,8 +181,8 @@ struct tile_info {
  *
  */
 struct row_batch {
-  size_type num_bytes;                      // number of bytes in this batch
-  size_type row_count;                      // number of rows in the batch
+  size_type num_bytes;                    // number of bytes in this batch
+  size_type row_count;                    // number of rows in the batch
   device_uvector<size_type> row_offsets;  // offsets column of output cudf column
 };
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -103,8 +103,10 @@ public class CastStrings {
   }
 
 
-  public static ColumnVector toIntegersWithBase(ColumnView cv, int base) {
-    return new ColumnVector(toIntegersWithBase(cv.getNativeView(), base));
+  public static ColumnVector toIntegersWithBase(ColumnView cv, int base,
+    boolean ansiEnabled, DType type) {
+    return new ColumnVector(toIntegersWithBase(cv.getNativeView(), base, ansiEnabled,
+      type.getTypeId().getNativeId()));
   }
 
   public static ColumnVector fromIntegersWithBase(ColumnView cv, int base) {
@@ -117,6 +119,7 @@ public class CastStrings {
       int precision, int scale);
   private static native long toFloat(long nativeColumnView, boolean ansi_enabled, int dtype);
   private static native long fromDecimal(long nativeColumnView);
-  private static native long toIntegersWithBase(long nativeColumnView, int base);
+  private static native long toIntegersWithBase(long nativeColumnView, int base,
+    boolean ansiEnabled, int dtype);
   private static native long fromIntegersWithBase(long nativeColumnView, int base);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -82,7 +82,7 @@ public class CastStrings {
 
   /**
    * Convert a decimal column to a string column.
-   * 
+   *
    * @param cv the column data to process
    * @return the converted column
    */
@@ -102,10 +102,16 @@ public class CastStrings {
     return new ColumnVector(toFloat(cv.getNativeView(), ansiMode, type.getTypeId().getNativeId()));
   }
 
+
+  public static ColumnVector changeRadix(ColumnView cv, int fromRadix, int toRadix) {
+    return new ColumnVector(changeRadix(cv.getNativeView(), fromRadix, toRadix));
+  }
+
   private static native long toInteger(long nativeColumnView, boolean ansi_enabled, boolean strip,
       int dtype);
   private static native long toDecimal(long nativeColumnView, boolean ansi_enabled, boolean strip,
       int precision, int scale);
   private static native long toFloat(long nativeColumnView, boolean ansi_enabled, int dtype);
   private static native long fromDecimal(long nativeColumnView);
+  private static native long changeRadix(long nativeColumnView, int fromRadix, int toRadix);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -103,8 +103,12 @@ public class CastStrings {
   }
 
 
-  public static ColumnVector changeRadix(ColumnView cv, int fromRadix, int toRadix) {
-    return new ColumnVector(changeRadix(cv.getNativeView(), fromRadix, toRadix));
+  public static ColumnVector toIntegerUsingBase(ColumnView cv, int base) {
+    return new ColumnVector(toIntegerUsingBase(cv.getNativeView(), base));
+  }
+
+  public static ColumnVector fromIntegerUsingBase(ColumnView cv, int base) {
+    return new ColumnVector(fromIntegerUsingBase(cv.getNativeView(), base));
   }
 
   private static native long toInteger(long nativeColumnView, boolean ansi_enabled, boolean strip,
@@ -113,5 +117,6 @@ public class CastStrings {
       int precision, int scale);
   private static native long toFloat(long nativeColumnView, boolean ansi_enabled, int dtype);
   private static native long fromDecimal(long nativeColumnView);
-  private static native long changeRadix(long nativeColumnView, int fromRadix, int toRadix);
+  private static native long toIntegerUsingBase(long nativeColumnView, int base);
+  private static native long fromIntegerUsingBase(long nativeColumnView, int base);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -103,12 +103,12 @@ public class CastStrings {
   }
 
 
-  public static ColumnVector toIntegerUsingBase(ColumnView cv, int base) {
-    return new ColumnVector(toIntegerUsingBase(cv.getNativeView(), base));
+  public static ColumnVector toIntegersWithBase(ColumnView cv, int base) {
+    return new ColumnVector(toIntegersWithBase(cv.getNativeView(), base));
   }
 
-  public static ColumnVector fromIntegerUsingBase(ColumnView cv, int base) {
-    return new ColumnVector(fromIntegerUsingBase(cv.getNativeView(), base));
+  public static ColumnVector fromIntegersWithBase(ColumnView cv, int base) {
+    return new ColumnVector(fromIntegersWithBase(cv.getNativeView(), base));
   }
 
   private static native long toInteger(long nativeColumnView, boolean ansi_enabled, boolean strip,
@@ -117,6 +117,6 @@ public class CastStrings {
       int precision, int scale);
   private static native long toFloat(long nativeColumnView, boolean ansi_enabled, int dtype);
   private static native long fromDecimal(long nativeColumnView);
-  private static native long toIntegerUsingBase(long nativeColumnView, int base);
-  private static native long fromIntegerUsingBase(long nativeColumnView, int base);
+  private static native long toIntegersWithBase(long nativeColumnView, int base);
+  private static native long fromIntegersWithBase(long nativeColumnView, int base);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -248,7 +248,10 @@ public class CastStringsTest {
         "--5A",
         "   -5Ajunk5A",
         "  5Ajunk5A",
-        "5a"
+        "5a",
+        "05a",
+        "005a",
+        "00-5a"
       ).build();
 
       Table expected = new Table.TestBuilder().column(
@@ -259,7 +262,10 @@ public class CastStringsTest {
         "0",
         "18446744073709551526",
         "90",
-        "90"
+        "90",
+        "90",
+        "90",
+        "0"
       ).column(
         null,
         "0",
@@ -268,7 +274,10 @@ public class CastStringsTest {
         "0",
         "FFFFFFFFFFFFFFA6",
         "5A",
-        "5A"
+        "5A",
+        "5A",
+        "5A",
+        "0"
       ).build();
 
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), 16);

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -202,7 +202,9 @@ public class CastStringsTest {
         "--510",
         "   -510junk510",
         "  510junk510",
-        "510"
+        "510",
+        "00510",
+        "00-510"
       ).build();
 
       Table expected = new Table.TestBuilder().column(
@@ -211,14 +213,18 @@ public class CastStringsTest {
         "0",
         "18446744073709551106",
         "510",
-        "510"
+        "510",
+        "510",
+        "0"
       ).column(
         null,
         "0",
         "0",
         "FFFFFFFFFFFFFE02",
         "1FE",
-        "1FE"
+        "1FE",
+        "1FE",
+        "0"
       ).build();
 
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), 10);

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
 import ai.rapids.cudf.Table;
 
 public class CastStringsTest {
@@ -230,7 +231,8 @@ public class CastStringsTest {
         "0"
       ).build();
 
-      ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), 10);
+      ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), 10, false,
+        DType.UINT64);
       ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10);
       ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16);
     ) {
@@ -289,7 +291,7 @@ public class CastStringsTest {
         "0"
       ).build();
 
-      ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), 16);
+      ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), 16, false, DType.UINT64);
       ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10);
       ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16);
     ) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -198,6 +198,7 @@ public class CastStringsTest {
     try(
       Table input = new Table.TestBuilder().column(
         null,
+        " ",
         "junk-510junk510",
         "--510",
         "   -510junk510",
@@ -209,6 +210,7 @@ public class CastStringsTest {
 
       Table expected = new Table.TestBuilder().column(
         null,
+        null,
         "0",
         "0",
         "18446744073709551106",
@@ -217,6 +219,7 @@ public class CastStringsTest {
         "510",
         "0"
       ).column(
+        null,
         null,
         "0",
         "0",
@@ -231,7 +234,7 @@ public class CastStringsTest {
       ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10);
       ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16);
     ) {
-
+      ai.rapids.cudf.TableDebug.get().debug("intCol", intCol);
       AssertUtils.assertColumnsAreEqual(expected.getColumn(0), decStrCol, "decStrCol");
       AssertUtils.assertColumnsAreEqual(expected.getColumn(1), hexStrCol, "hexStrCol");
     }
@@ -242,6 +245,7 @@ public class CastStringsTest {
     try(
       Table input = new Table.TestBuilder().column(
         null,
+        "junk",
         "0",
         "f",
         "junk-5Ajunk5A",
@@ -256,6 +260,7 @@ public class CastStringsTest {
 
       Table expected = new Table.TestBuilder().column(
         null,
+        null,
         "0",
         "15",
         "0",
@@ -267,6 +272,7 @@ public class CastStringsTest {
         "90",
         "0"
       ).column(
+        null,
         null,
         "0",
         "F",
@@ -284,6 +290,7 @@ public class CastStringsTest {
       ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10);
       ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16);
     ) {
+      ai.rapids.cudf.TableDebug.get().debug("intCol", intCol);
       AssertUtils.assertColumnsAreEqual(expected.getColumn(0), decStrCol, "decStrCol");
       AssertUtils.assertColumnsAreEqual(expected.getColumn(1), hexStrCol, "hexStrCol");
     }

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -255,12 +255,13 @@ public class CastStringsTest {
         "5a",
         "05a",
         "005a",
-        "00-5a"
+        "00-5a",
+        "NzGGImWNRh"
       ).build();
 
       Table expected = new Table.TestBuilder().column(
         null,
-        null,
+        "0",
         "0",
         "15",
         "0",
@@ -270,10 +271,11 @@ public class CastStringsTest {
         "90",
         "90",
         "90",
+        "0",
         "0"
       ).column(
         null,
-        null,
+        "0",
         "0",
         "F",
         "0",
@@ -283,6 +285,7 @@ public class CastStringsTest {
         "5A",
         "5A",
         "5A",
+        "0",
         "0"
       ).build();
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -197,6 +197,7 @@ public class CastStringsTest {
   void baseDec2HexTest() {
     try(
       Table input = new Table.TestBuilder().column(
+        null,
         "junk-510junk510",
         "--510",
         "   -510junk510",
@@ -205,14 +206,16 @@ public class CastStringsTest {
       ).build();
 
       Table expected = new Table.TestBuilder().column(
-        null, // TODO should be "0" to distinguish invalid input from null input
-        null, // TODO should be "0" to distinguish invalid input from null input
+        null,
+        "0",
+        "0",
         "18446744073709551106",
         "510",
         "510"
       ).column(
-        null,  // TODO should be "0" to distinguish invalid input from null input
-        null, // TODO should be "0" to distinguish invalid input from null input
+        null,
+        "0",
+        "0",
         "FFFFFFFFFFFFFE02",
         "1FE",
         "1FE"
@@ -232,6 +235,9 @@ public class CastStringsTest {
   void baseHex2DecTest() {
     try(
       Table input = new Table.TestBuilder().column(
+        null,
+        "0",
+        "f",
         "junk-5Ajunk5A",
         "--5A",
         "   -5Ajunk5A",
@@ -240,14 +246,20 @@ public class CastStringsTest {
       ).build();
 
       Table expected = new Table.TestBuilder().column(
-        null, // TODO should be "0" to distinguish invalid input from null input
-        null, // TODO should be "0" to distinguish invalid input from null input
+        null,
+        "0",
+        "15",
+        "0",
+        "0",
         "18446744073709551526",
         "90",
         "90"
       ).column(
-        null,  // TODO should be "0" to distinguish invalid input from null input
-        null,  // TODO should be "0" to distinguish invalid input from null input
+        null,
+        "0",
+        "F",
+        "0",
+        "0",
         "FFFFFFFFFFFFFFA6",
         "5A",
         "5A"

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.Table;
-import ai.rapids.cudf.TableDebug;
 
 public class CastStringsTest {
   @Test
@@ -199,6 +198,7 @@ public class CastStringsTest {
     try(
       Table input = new Table.TestBuilder().column(
         "junk-510junk510",
+        "--510",
         "   -510junk510",
         "  510junk510",
         "510"
@@ -206,11 +206,13 @@ public class CastStringsTest {
 
       Table expected = new Table.TestBuilder().column(
         null, // TODO should be "0" to distinguish invalid input from null input
+        null, // TODO should be "0" to distinguish invalid input from null input
         "18446744073709551106",
         "510",
         "510"
       ).column(
         null,  // TODO should be "0" to distinguish invalid input from null input
+        null, // TODO should be "0" to distinguish invalid input from null input
         "FFFFFFFFFFFFFE02",
         "1FE",
         "1FE"
@@ -231,6 +233,7 @@ public class CastStringsTest {
     try(
       Table input = new Table.TestBuilder().column(
         "junk-5Ajunk5A",
+        "--5A",
         "   -5Ajunk5A",
         "  5Ajunk5A",
         "5a"
@@ -238,10 +241,12 @@ public class CastStringsTest {
 
       Table expected = new Table.TestBuilder().column(
         null, // TODO should be "0" to distinguish invalid input from null input
+        null, // TODO should be "0" to distinguish invalid input from null input
         "18446744073709551526",
         "90",
         "90"
       ).column(
+        null,  // TODO should be "0" to distinguish invalid input from null input
         null,  // TODO should be "0" to distinguish invalid input from null input
         "FFFFFFFFFFFFFFA6",
         "5A",
@@ -252,9 +257,8 @@ public class CastStringsTest {
       ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10);
       ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16);
     ) {
-      TableDebug.get().debug("intCol", intCol);
       AssertUtils.assertColumnsAreEqual(expected.getColumn(0), decStrCol, "decStrCol");
-      // AssertUtils.assertColumnsAreEqual(expected.getColumn(1), hexStrCol, "hexStrCol");
+      AssertUtils.assertColumnsAreEqual(expected.getColumn(1), hexStrCol, "hexStrCol");
     }
   }
 }


### PR DESCRIPTION
Contributes to NVIDIA/spark-rapids#8511

POC supporting form/to  radices 10 and 16 leveraging existing libcudf API 

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
