### PR TITLE
Add arm64 build support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,18 +71,19 @@ settings. If an explicit reconfigure of libcudf is needed (e.g.: when changing c
 The following build properties can be set on the Maven command-line (e.g.: `-DCPP_PARALLEL_LEVEL=4`)
 to control aspects of the build:
 
-|Property Name                       |Description                            | Default |
-|------------------------------------|---------------------------------------|---------|
-|`CPP_PARALLEL_LEVEL`                |Parallelism of the C++ builds          | 10      |
-|`GPU_ARCHS`                         |CUDA architectures to target           | RAPIDS  |
-|`CUDF_USE_PER_THREAD_DEFAULT_STREAM`|CUDA per-thread default stream         | ON      |
-|`RMM_LOGGING_LEVEL`                 |RMM logging control                    | OFF     |
-|`USE_GDS`                           |Compile with GPU Direct Storage support| OFF     |
-|`BUILD_TESTS`                       |Compile tests                          | OFF     |
-|`BUILD_BENCHMARKS`                  |Compile benchmarks                     | OFF     |
-|`libcudf.build.configure`           |Force libcudf build to configure       | false   |
-|`libcudf.clean.skip`                |Whether to skip cleaning libcudf build | true    |
-|`submodule.check.skip`              |Whether to skip checking git submodules| false   |
+| Property Name                        | Description                             | Default |
+|--------------------------------------|-----------------------------------------|---------|
+| `CPP_PARALLEL_LEVEL`                 | Parallelism of the C++ builds           | 10      |
+| `GPU_ARCHS`                          | CUDA architectures to target            | RAPIDS  |
+| `CUDF_USE_PER_THREAD_DEFAULT_STREAM` | CUDA per-thread default stream          | ON      |
+| `RMM_LOGGING_LEVEL`                  | RMM logging control                     | OFF     |
+| `USE_GDS`                            | Compile with GPU Direct Storage support | OFF     |
+| `BUILD_TESTS`                        | Compile tests                           | OFF     |
+| `BUILD_BENCHMARKS`                   | Compile benchmarks                      | OFF     |
+| `BUILD_FAULTINJ`                     | Compile fault injection                 | ON      |
+| `libcudf.build.configure`            | Force libcudf build to configure        | false   |
+| `libcudf.clean.skip`                 | Whether to skip cleaning libcudf build  | true    |
+| `submodule.check.skip`               | Whether to skip checking git submodules | false   |
 
 
 ### Local testing of cross-repo contributions cudf, spark-rapids-jni, and spark-rapids

--- a/ci/Dockerfile.multi
+++ b/ci/Dockerfile.multi
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+###
+# JNI CI image for multi-platform build
+#
+# Arguments: CUDA_VERSION=11.8.0
+#
+###
+ARG CUDA_VERSION=11.8.0
+ARG OS_RELEASE=8
+# multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
+# check available offcial arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
+FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
+ARG TOOLSET_VERSION=11
+### Install basic requirements
+RUN dnf install -y scl-utils
+RUN dnf install -y gcc-toolset-${TOOLSET_VERSION} python39
+RUN dnf --enablerepo=powertools install -y zlib-devel maven tar wget patch ninja-build
+# require git 2.18+ to keep consistent submodule operations
+RUN dnf install -y git
+## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
+RUN mkdir /usr/local/rapids && mkdir /rapids && chmod 777 /usr/local/rapids && chmod 777 /rapids
+
+# 3.22.3+: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
+ARG CMAKE_VERSION=3.26.4
+# default as arm64 release
+ARG CMAKE_ARCH=aarch64
+# aarch64 cmake for arm build
+RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
+   tar zxf cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
+   rm cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz
+ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
+
+# ccache for interactive builds
+ARG CCACHE_VERSION=4.6
+RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
+   tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
+   rm ccache-${CCACHE_VERSION}.tar.gz && \
+   cd ccache-${CCACHE_VERSION} && \
+   mkdir build && \
+   cd build && \
+   scl enable gcc-toolset-${TOOLSET_VERSION} \
+      "cmake .. \
+         -DCMAKE_BUILD_TYPE=Release \
+         -DZSTD_FROM_INTERNET=ON \
+         -DREDIS_STORAGE_BACKEND=OFF && \
+      cmake --build . --parallel 4 --target install" && \
+   cd ../.. && \
+   rm -rf ccache-${CCACHE_VERSION}
+
+## install a version of boost that is needed for arrow/parquet to work
+RUN cd /usr/local && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz && \
+  tar -xzf boost_1_79_0.tar.gz && \
+  rm boost_1_79_0.tar.gz && \
+  cd boost_1_79_0 && \
+  ./bootstrap.sh --prefix=/usr/local && \
+  ./b2 install --prefix=/usr/local --with-filesystem --with-system && \
+   cd /usr/local && \
+   rm -rf boost_1_79_0
+
+# disable cuda container constraints to allow running w/ elder drivers on data-center GPUs
+ENV NVIDIA_DISABLE_REQUIRE="true"

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -26,10 +26,22 @@ MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
 CUDA_VER=${CUDA_VER:-cuda`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 USE_GDS=${USE_GDS:-ON}
+USE_SANITIZER=${USE_SANITIZER:-ON}
+BUILD_FAULTINJ=${BUILD_FAULTINJ:-ON}
+ARM64=${ARM64:-false}
+
+profiles="source-javadoc"
+if [ "${ARM64}" == "true" ]; then
+  profiles="${profiles},arm64"
+  USE_GDS="OFF"
+  USE_SANITIZER="OFF"
+  BUILD_FAULTINJ="OFF"
+fi
+
 ${MVN} clean package ${MVN_MIRROR}  \
-  -Psource-javadoc \
+  -P${profiles} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
-  -DBUILD_TESTS=ON -Dcuda.version=$CUDA_VER \
-  -DUSE_SANITIZER=ON
+  -DBUILD_TESTS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -Dcuda.version=$CUDA_VER \
+  -DUSE_SANITIZER=${USE_SANITIZER}

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,11 @@
     <USE_GDS>OFF</USE_GDS>
     <BUILD_TESTS>OFF</BUILD_TESTS>
     <BUILD_BENCHMARKS>OFF</BUILD_BENCHMARKS>
+    <BUILD_FAULTINJ>ON</BUILD_FAULTINJ>
     <ai.rapids.cudf.nvtx.enabled>false</ai.rapids.cudf.nvtx.enabled>
     <ai.rapids.refcount.debug>false</ai.rapids.refcount.debug>
     <cuda.version>cuda11</cuda.version>
+    <jni.classifier>${cuda.version}</jni.classifier>
     <cudf.path>${project.basedir}/thirdparty/cudf</cudf.path>
     <hadoop.version>3.2.4</hadoop.version>
     <junit.version>5.8.1</junit.version>
@@ -332,6 +334,12 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>arm64</id>
+      <properties>
+        <jni.classifier>${cuda.version}-arm64</jni.classifier>
+      </properties>
+    </profile>
   </profiles>
 
   <build>
@@ -441,6 +449,7 @@
                   <arg value="-DUSE_GDS=${USE_GDS}"/>
                   <arg value="-DBUILD_TESTS=${BUILD_TESTS}"/>
                   <arg value="-DBUILD_BENCHMARKS=${BUILD_BENCHMARKS}"/>
+                  <arg value="-DBUILD_FAULTINJ=${BUILD_FAULTINJ}"/>
                 </exec>
                 <exec dir="${native.build.path}"
                       failonerror="true"
@@ -493,7 +502,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>
         <configuration>
-          <classifier>${cuda.version}</classifier>
+          <classifier>${jni.classifier}</classifier>
         </configuration>
         <executions>
           <execution>

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -43,6 +43,7 @@ option(CUDF_USE_PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream"
 option(USE_GDS "Build with GPUDirect Storage (GDS)/cuFile support" OFF)
 option(BUILD_TESTS "Configure CMake to build tests" OFF)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
+option(BUILD_FAULTINJ "Configure CMake to build fault injection" ON)
 
 message(
   VERBOSE "SPARK_RAPIDS_JNI: Build with per-thread default stream:
@@ -50,6 +51,7 @@ message(
 )
 message(VERBOSE "SPARK_RAPIDS_JNI: Configure CMake to build tests: ${BUILD_TESTS}")
 message(VERBOSE "SPARK_RAPIDS_JNI: Configure CMake to build (nvbench) benchmarks: ${BUILD_BENCHMARKS}")
+message(VERBOSE "SPARK_RAPIDS_JNI: Configure CMake to build fault injection: ${BUILD_FAULTINJ}")
 
 set(SPARK_RAPIDS_JNI_CXX_FLAGS "")
 set(SPARK_RAPIDS_JNI_CUDA_FLAGS "")
@@ -57,6 +59,7 @@ set(SPARK_RAPIDS_JNI_CXX_DEFINITIONS "")
 set(SPARK_RAPIDS_JNI_CUDA_DEFINITIONS "")
 set(SPARK_RAPIDS_JNI_BUILD_TESTS ${BUILD_TESTS})
 set(SPARK_RAPIDS_JNI_BUILD_BENCHMARKS ${BUILD_BENCHMARKS})
+set(SPARK_RAPIDS_JNI_BUILD_FAULTINJ ${BUILD_FAULTINJ})
 
 # Set RMM logging level
 set(RMM_LOGGING_LEVEL
@@ -277,4 +280,6 @@ if(SPARK_RAPIDS_JNI_BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif()
 
-add_subdirectory(faultinj)
+if(SPARK_RAPIDS_JNI_BUILD_FAULTINJ)
+  add_subdirectory(faultinj)
+endif()


### PR DESCRIPTION
This PR is still in progress but want get more feedbacks in advance.

To re-enable build support for arm,
1. Build on internal ARM instance in blossom cluster
2. Provide artifacts w/ classifiers like cuda11-arm64, cuda12-arm64
3. Use dockerhub/cuda rockylinux image for arm and update corresponding tools to support the build and test (since there is no official arm support for centos7)
4. Disabled faultinj build https://github.com/NVIDIA/spark-rapids-jni/issues/1368
5. Would not run sanitizer check as it failed core dump in arm ENV (currently do not have time to check the details) https://github.com/NVIDIA/spark-rapids-jni/issues/1388

In this case, our plugin jar build would also need to be updated to support release w/ <cuda>-arm64 classifiers.
So the final releases would be like,
```
Default jar (maven required):
rapids-4-spark_2.12-<version>.jar (x86 cuda11 one)
X86 jars:
rapids-4-spark_2.12-<version>-cuda11.jar 
rapids-4-spark_2.12-<version>-cuda12.jar 
ARM64 jars:
rapids-4-spark_2.12-<version>-cuda11-arm64.jar 
rapids-4-spark_2.12-<version>-cuda12-arm64.jar 
```


