### PR TITLE
[WIP] Specify recoverWithNulls in from_json

### DIFF
--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -636,9 +636,12 @@ std::unique_ptr<cudf::column> from_json(cudf::column_view const& input,
   // Tokenize the input json strings.
   static_assert(sizeof(SymbolT) == sizeof(char),
                 "Invalid internal data for nested json tokenizer.");
+
+  cudf::io::json_reader_options reader_options{};
+  reader_options.set_recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
   auto const [tokens, token_indices] = cudf::io::json::detail::get_token_stream(
     cudf::device_span<char const>{unified_json_buff.data(), unified_json_buff.size()},
-    cudf::io::json_reader_options{},
+    reader_options,
     stream,
     rmm::mr::get_current_device_resource());
 


### PR DESCRIPTION
cuDF now allows us to specify a recovery mode when parsing JSON. The default mode throws an exception when invalid JSON is encountered, and there is now a `RECOVER_WITH_NULL` option, which should return a null value for each invalid JSON row in a column.

This PR specifies this option in `map_utils::from_json`. However, this is not working as expected, and I am creating this PR for discussion purposes.

The included test fails with:

```
ai.rapids.cudf.CudfException: CUDF failure at:/home/andy/git/nvidia/spark-rapids-jni/src/main/cpp/src/map_utils.cu:146: JSON Parser encountered an invalid format at location 109
        at com.nvidia.spark.rapids.jni.MapUtils.extractRawMapFromJsonString(Native Method)
        at com.nvidia.spark.rapids.jni.MapUtils.extractRawMapFromJsonString(MapUtils.java:49)
        at com.nvidia.spark.rapids.jni.MapUtilsTest.testFromJsonInvalidRows(MapUtilsTest.java:97)
```

