### PR TITLE
Add 'dropLeadingZeros' parameter for integer to hexadecimal conversion

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -109,8 +109,9 @@ public class CastStrings {
       type.getTypeId().getNativeId()));
   }
 
-  public static ColumnVector fromIntegersWithBase(ColumnView cv, int base) {
-    return new ColumnVector(fromIntegersWithBase(cv.getNativeView(), base));
+  public static ColumnVector fromIntegersWithBase(ColumnView cv, int base,
+    boolean dropLeadingZeros) {
+    return new ColumnVector(fromIntegersWithBase(cv.getNativeView(), base, dropLeadingZeros));
   }
 
   private static native long toInteger(long nativeColumnView, boolean ansi_enabled, boolean strip,
@@ -121,5 +122,6 @@ public class CastStrings {
   private static native long fromDecimal(long nativeColumnView);
   private static native long toIntegersWithBase(long nativeColumnView, int base,
     boolean ansiEnabled, int dtype);
-  private static native long fromIntegersWithBase(long nativeColumnView, int base);
+  private static native long fromIntegersWithBase(long nativeColumnView, int base,
+    boolean dropLeadingZeros);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -109,6 +109,44 @@ public class CastStrings {
       type.getTypeId().getNativeId()));
   }
 
+  /**
+   * Returns a new strings column converting integer column to the desired base i.e. base 10
+   * or base 16 (hexadecimal characters). The hexadecimal value will be returned with the leading
+   * zeros dropped
+   *
+   * Example:
+   * input = [123, -1, 0, 27, 342718233]
+   * s = fromIntegersWithBase(input, 16)
+   * s is [ '4D2', 'FFFFFFFF', '0', '1B', '146D7719']
+   * s = fromIntegersWithBase(input, 10)
+   * s is ['123', '-1', '0', '27', '342718233']
+   *
+   * @param cv input column to be converted
+   * @param base base that we want to convert to
+   * @return a new String ColumnVector
+   */
+  public static ColumnVector fromIntegersWithBase(ColumnView cv, int base) {
+    return new ColumnVector(fromIntegersWithBase(cv.getNativeView(), base, true));
+  }
+
+  /**
+   * Returns a new strings column converting integer column to the desired base i.e. base 10
+   * or base 16 (hexadecimal characters).
+   *
+   * Example:
+   * input = [123, -1, 0, 27, 342718233]
+   * s = fromIntegersWithBase(input, 16, false)
+   * s is [ '04D2', 'FFFFFFFF', '00', '1B', '146D7719']
+   * s = fromIntegersWithBase(input, 16, true)
+   * s is [ '4D2', 'FFFFFFFF', '0', '1B', '146D7719']
+   * s = fromIntegersWithBase(input, 10, false)
+   * s is ['123', '-1', '0', '27', '342718233']
+   *
+   * @param cv input column to be converted
+   * @param base base that we want to convert to
+   * @param dropLeadingZeros whether we want to drop the leading zeros e.g. 'E' instead of '0E'
+   * @return a new String ColumnVector
+   */
   public static ColumnVector fromIntegersWithBase(ColumnView cv, int base,
     boolean dropLeadingZeros) {
     return new ColumnVector(fromIntegersWithBase(cv.getNativeView(), base, dropLeadingZeros));

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -193,13 +193,17 @@ public class CastStringsTest {
     }
   }
 
-  private void baseConversionHelper(Table input, Table expected, int fromBase,
+  private void testRoundTripToBase10And16(Table input, Table expected, int fromBase,
     boolean dropLeadingZeros) {
     try(
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), fromBase, false,
         DType.UINT64);
-      ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10, dropLeadingZeros);
-      ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16, dropLeadingZeros);
+      // Deliberately not passing the value of dropLeadingZeros so we can test both
+      // functions in the API
+      ColumnVector decStrCol = dropLeadingZeros ? CastStrings.fromIntegersWithBase(intCol, 10)
+          : CastStrings.fromIntegersWithBase(intCol, 10, false);
+      ColumnVector hexStrCol = dropLeadingZeros ? CastStrings.fromIntegersWithBase(intCol, 16)
+          : CastStrings.fromIntegersWithBase(intCol, 16, false)
     ) {
       AssertUtils.assertColumnsAreEqual(expected.getColumn(0), decStrCol, "decStrCol");
       AssertUtils.assertColumnsAreEqual(expected.getColumn(1), hexStrCol, "hexStrCol");
@@ -207,7 +211,7 @@ public class CastStringsTest {
   }
 
   private void convTestInternal(Table input, Table expected, int fromBase) {
-    baseConversionHelper(input, expected, fromBase, true);
+    testRoundTripToBase10And16(input, expected, fromBase, true);
   }
 
   @Test
@@ -230,7 +234,7 @@ public class CastStringsTest {
         ).build()
     )
     {
-      baseConversionHelper(input, expected, 10, true);
+      testRoundTripToBase10And16(input, expected, 10, true);
     }
   }
 
@@ -254,7 +258,7 @@ public class CastStringsTest {
         ).build()
     )
     {
-      baseConversionHelper(input, expected, 10, false);
+      testRoundTripToBase10And16(input, expected, 10, false);
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -193,15 +193,44 @@ public class CastStringsTest {
     }
   }
 
-  private void convTestInternal(Table input, Table expected, int fromBase) {
+  private void baseConversionHelper(Table input, Table expected, int fromBase,
+    boolean dropLeadingZeros) {
     try(
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), fromBase, false,
         DType.UINT64);
-      ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10);
-      ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16);
+      ColumnVector decStrCol = CastStrings.fromIntegersWithBase(intCol, 10, dropLeadingZeros);
+      ColumnVector hexStrCol = CastStrings.fromIntegersWithBase(intCol, 16, dropLeadingZeros);
     ) {
       AssertUtils.assertColumnsAreEqual(expected.getColumn(0), decStrCol, "decStrCol");
       AssertUtils.assertColumnsAreEqual(expected.getColumn(1), hexStrCol, "hexStrCol");
+    }
+  }
+
+  private void convTestInternal(Table input, Table expected, int fromBase) {
+    baseConversionHelper(input, expected, fromBase, true);
+  }
+
+  @Test
+  void baseDec2HexTestNoDropLeadingZeros() {
+    try (
+        Table input = new Table.TestBuilder().column(
+            "14",
+            "2621",
+            "50"
+        ).build();
+
+        Table expected = new Table.TestBuilder().column(
+            "14",
+            "2621",
+            "50"
+        ).column(
+            "0E",
+            "0A3D",
+            "32"
+        ).build()
+    )
+    {
+      baseConversionHelper(input, expected, 10, false);
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -211,6 +211,30 @@ public class CastStringsTest {
   }
 
   @Test
+  void baseDec2HexTestDropLeadingZeros() {
+    try (
+        Table input = new Table.TestBuilder().column(
+            "14",
+            "2621",
+            "50"
+        ).build();
+
+        Table expected = new Table.TestBuilder().column(
+            "14",
+            "2621",
+            "50"
+        ).column(
+            "E",
+            "A3D",
+            "32"
+        ).build()
+    )
+    {
+      baseConversionHelper(input, expected, 10, true);
+    }
+  }
+
+  @Test
   void baseDec2HexTestNoDropLeadingZeros() {
     try (
         Table input = new Table.TestBuilder().column(


### PR DESCRIPTION
This PR adds a boolean parameter `dropLeadingZeros` to control whether we want to drop leading zeros while converting an integer column to a hex column. e.g 14 -> '0E' or 'E'

Testing: 
   Junit tests were added

Fixes #1444 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
