### PR TITLE
[BUG] fix docker modified check in premerge [skip ci]

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -141,9 +141,10 @@ pipeline {
                     container('cpu') {
                         // check if pre-merge dockerfile modified
                         def dockerfileModified = sh(returnStdout: true,
-                            script: 'BASE=$(git --no-pager log --oneline -1 | awk \'{ print $NF }\'); ' +
-                                'git --no-pager diff --name-only HEAD $(git merge-base HEAD $BASE) ' +
-                                "-- ${PREMERGE_DOCKERFILE} || true")
+script: """BASE=\$(git --no-pager log --oneline -1 | awk \'{ print \$NF }\')
+git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true""").trim()
+                        echo "$dockerfileModified"
+
                         if (!dockerfileModified?.trim()) {
                             TEMP_IMAGE_BUILD = false
                         }


### PR DESCRIPTION
first found at https://github.com/NVIDIA/spark-rapids/pull/9366

The jenkins shell suddenly does not support using $(cmd) to generate value.
Change it to use """ wrapper to solve the issue