### PR TITLE
Improve quoting of command line arguments for build/run scripts

### DIFF
--- a/build/build-in-docker
+++ b/build/build-in-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,9 +45,9 @@ if [[ "$CCACHE_DISABLE" != "1" ]]; then
   fi
 fi
 
-$SCRIPTDIR/run-in-docker "mvn \
+$SCRIPTDIR/run-in-docker mvn \
     -Dmaven.repo.local=$LOCAL_MAVEN_REPO \
     -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=$CUDF_USE_PER_THREAD_DEFAULT_STREAM \
     -DUSE_GDS=$USE_GDS \
     $_CUDF_CLEAN_SKIP \
-    $*"
+    "$@"

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -50,7 +50,7 @@ if (( $# == 0 )); then
   DOCKER_OPTS="${DOCKER_OPTS} -it"
   RUN_CMD="/bin/bash"
 else
-  RUN_CMD="$*"
+  RUN_CMD="${@@Q}"
 fi
 
 $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --rm \


### PR DESCRIPTION
Fixes #1092.  This adds proper handling of arguments, quoting them when necessary to preserve them through double-parsing by the shell.  Tested this by running a standard build-in-docker command along with one that specifies multiple GPU architectures that failed in the past, e.g.: `build-in-docker -DGPU_ARCHS="75-real;80-real;86-real;90-real" clean install`