### PR TITLE
Adding IP6 characters into valid character list for URI parsing

### DIFF
--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -44,8 +44,8 @@ constexpr bool is_valid_character(char ch, bool alphanum_only)
     if (ch >= 'A' && ch <= 'Z') return true;               // A-Z
     if (ch >= 'a' && ch <= 'z') return true;               // a-z
   } else {
-    if (ch >= '!' && ch <= ';' && ch != '"') return true;  // 0-9 and !#%&'()*+,-./
-    if (ch >= '=' && ch <= 'Z' && ch != '>') return true;  // A-Z and =?@
+    if (ch >= '!' && ch <= ':' && ch != '"') return true;  // 0-9 and !#%&'()*+,-./:
+    if (ch >= '=' && ch <= ']' && ch != '>') return true;  // A-Z and =?@[]
     if (ch >= '_' && ch <= 'z' && ch != '`') return true;  // a-z and _
   }
   return false;

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -39,15 +39,12 @@ namespace {
 // utility to validate a character is valid in a URI
 constexpr bool is_valid_character(char ch, bool alphanum_only)
 {
-  if (alphanum_only) {
-    if (ch >= '-' && ch <= '9' && ch != '/') return true;  // 0-9 and .-
-    if (ch >= 'A' && ch <= 'Z') return true;               // A-Z
-    if (ch >= 'a' && ch <= 'z') return true;               // a-z
-  } else {
-    if (ch >= '!' && ch <= ':' && ch != '"') return true;  // 0-9 and !#%&'()*+,-./:
-    if (ch >= '=' && ch <= ']' && ch != '>') return true;  // A-Z and =?@[]
-    if (ch >= '_' && ch <= 'z' && ch != '`') return true;  // a-z and _
-  }
+  return alphanum_only ? (ch >= '-' && ch <= '9' && ch != '/') ||    // 0-9 and .-
+                           (ch >= 'A' && ch <= 'Z') ||               // A-Z
+                           (ch >= 'a' && ch <= 'z')                  // a-z
+                       : (ch >= '!' && ch <= ':' && ch != '"') ||    // 0-9 and !#%&'()*+,-./:
+                           (ch >= '=' && ch <= ']' && ch != '>') ||  // A-Z and =?@[]
+                           (ch >= '_' && ch <= 'z' && ch != '`');    // a-z and _
   return false;
 }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -25,6 +25,27 @@ import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
 
 public class ParseURITest {
+  void buildExpectedAndRun(String[] testData) {
+    String[] expectedStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String scheme = null;
+      try {
+        URI uri = new URI(testData[i]);
+        scheme = uri.getScheme();
+      } catch (URISyntaxException ex) {
+        // leave the scheme null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the scheme null if URI is null
+      }
+      expectedStrings[i] = scheme;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
+      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
   @Test
   void parseURIToProtocolSparkTest() {
     String[] testData = {"https://nvidia.com/https&#://nvidia.com",
@@ -51,24 +72,7 @@ public class ParseURITest {
       "",
       null};
 
-    String[] expectedStrings = new String[testData.length];
-    for (int i=0; i<testData.length; i++) {
-      String scheme = null;
-      try {
-        URI uri = new URI(testData[i]);
-        scheme = uri.getScheme();
-      } catch (URISyntaxException ex) {
-        // leave the scheme null if URI is invalid
-      } catch (NullPointerException ex) {
-        // leave the scheme null if URI is null
-      }
-      expectedStrings[i] = scheme;
-    }
-    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
-      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
-      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
-      AssertUtils.assertColumnsAreEqual(expected, result);
-    }
+    buildExpectedAndRun(testData);
   }
 
   @Test
@@ -76,24 +80,7 @@ public class ParseURITest {
     String[] testData = {"https://nvidia.com/%4EV%49%44%49%41",
       "http://%77%77%77.%4EV%49%44%49%41.com"};
 
-    String[] expectedStrings = new String[testData.length];
-    for (int i=0; i<testData.length; i++) {
-      String scheme = null;
-      try {
-        URI uri = new URI(testData[i]);
-        scheme = uri.getScheme();
-      } catch (URISyntaxException ex) {
-        // leave the scheme null if URI is invalid
-      } catch (NullPointerException ex) {
-        // leave the scheme null if URI is null
-      }
-      expectedStrings[i] = scheme;
-    }
-    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
-      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
-      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
-      AssertUtils.assertColumnsAreEqual(expected, result);
-    }
+    buildExpectedAndRun(testData);
   }
 
   @Test
@@ -104,24 +91,7 @@ public class ParseURITest {
       "https://192.168.1/",
       "https://280.100.1.1/"};
 
-    String[] expectedStrings = new String[testData.length];
-    for (int i=0; i<testData.length; i++) {
-      String scheme = null;
-      try {
-        URI uri = new URI(testData[i]);
-        scheme = uri.getScheme();
-      } catch (URISyntaxException ex) {
-        // leave the scheme null if URI is invalid
-      } catch (NullPointerException ex) {
-        // leave the scheme null if URI is null
-      }
-      expectedStrings[i] = scheme;
-    }
-    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
-      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
-      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
-      AssertUtils.assertColumnsAreEqual(expected, result);
-    }
+    buildExpectedAndRun(testData);
   }
 
   @Test
@@ -134,23 +104,6 @@ public class ParseURITest {
       "https://[::1]",
       "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"};
     
-    String[] expectedStrings = new String[testData.length];
-    for (int i=0; i<testData.length; i++) {
-      String scheme = null;
-      try {
-        URI uri = new URI(testData[i]);
-        scheme = uri.getScheme();
-      } catch (URISyntaxException ex) {
-        // leave the scheme null if URI is invalid
-      } catch (NullPointerException ex) {
-        // leave the scheme null if URI is null
-      }
-      expectedStrings[i] = scheme;
-    }
-    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
-      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
-      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
-      AssertUtils.assertColumnsAreEqual(expected, result);
-    }
+    buildExpectedAndRun(testData);
   }
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -26,7 +26,7 @@ import ai.rapids.cudf.ColumnVector;
 
 public class ParseURITest {
   @Test
-  void parseURIToProtocolTest() {
+  void parseURIToProtocolSparkTest() {
     String[] testData = {"https://nvidia.com/https&#://nvidia.com",
       "https://http://www.nvidia.com",
       "filesystemmagicthing://bob.yaml",
@@ -50,6 +50,89 @@ public class ParseURITest {
       "http//www.nvidia.com/q",
       "",
       null};
+
+    String[] expectedStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String scheme = null;
+      try {
+        URI uri = new URI(testData[i]);
+        scheme = uri.getScheme();
+      } catch (URISyntaxException ex) {
+        // leave the scheme null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the scheme null if URI is null
+      }
+      expectedStrings[i] = scheme;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
+      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void parseURIToProtocolUTF8Test() {
+    String[] testData = {"https://nvidia.com/%4EV%49%44%49%41",
+      "http://%77%77%77.%4EV%49%44%49%41.com"};
+
+    String[] expectedStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String scheme = null;
+      try {
+        URI uri = new URI(testData[i]);
+        scheme = uri.getScheme();
+      } catch (URISyntaxException ex) {
+        // leave the scheme null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the scheme null if URI is null
+      }
+      expectedStrings[i] = scheme;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
+      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void parseURIToProtocolIP4Test() {
+    String[] testData = {"https://192.168.1.100/",
+      "https://192.168.1.100:8443/",
+      "https://192.168.1.100.5/",
+      "https://192.168.1/",
+      "https://280.100.1.1/"};
+
+    String[] expectedStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String scheme = null;
+      try {
+        URI uri = new URI(testData[i]);
+        scheme = uri.getScheme();
+      } catch (URISyntaxException ex) {
+        // leave the scheme null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the scheme null if URI is null
+      }
+      expectedStrings[i] = scheme;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expected = ColumnVector.fromStrings(expectedStrings);
+      ColumnVector result = ParseURI.parseURIProtocol(v0)) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void parseURIToProtocolIP6Test() {
+    String[] testData = {"https://[fe80::]",
+      "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+      "https://[2001:0DB8:85A3:0000:0000:8A2E:0370:7334]",
+      "https://[2001:db8::1:0]",
+      "http://[2001:db8::2:1]",
+      "https://[::1]",
+      "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"};
     
     String[] expectedStrings = new String[testData.length];
     for (int i=0; i<testData.length; i++) {


### PR DESCRIPTION
It was noted in review of the plugin changes to [add support for `parse_url`](https://github.com/NVIDIA/spark-rapids/pull/9481#discussion_r1365679557) that IP6 wasn't properly validating. This change fixes that to bring the kernel in line with Spark on IP6 addresses.