### PR TITLE
Implement timestamp rebase from Julian to Gregorian calendars

### DIFF
--- a/src/main/cpp/src/DateTimeRebaseJni.cpp
+++ b/src/main/cpp/src/DateTimeRebaseJni.cpp
@@ -32,4 +32,17 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeRebase_rebaseGr
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeRebase_rebaseJulianToGregorian(
+    JNIEnv *env, jclass, jlong input) {
+  JNI_NULL_CHECK(env, input, "input column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const input_cv = reinterpret_cast<cudf::column_view const *>(input);
+    auto output = spark_rapids_jni::rebase_julian_to_gregorian(*input_cv);
+    return reinterpret_cast<jlong>(output.release());
+  }
+  CATCH_STD(env, 0);
+}
+
 } // extern "C"

--- a/src/main/cpp/src/datetime_rebase.cu
+++ b/src/main/cpp/src/datetime_rebase.cu
@@ -205,7 +205,7 @@ __device__ __inline__ time_components get_time_components(int64_t micros) {
 // Convert the given number of microseconds since the epoch day 1970-01-01T00:00:00Z to a local
 // date-time in Proleptic Gregorian calendar, reinterpreting the result as in Julian calendar, then
 // compute the number of microseconds since the epoch from that Julian local date-time.
-// This is to match with Apache Spark's `rebaseGregorianToJulianMicros` function with timezone
+// This is to match with Apache Spark's `localRebaseGregorianToJulianMicros` function with timezone
 // fixed to UTC.
 std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const &input,
                                                          rmm::cuda_stream_view stream,
@@ -261,7 +261,11 @@ std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const
   return output;
 }
 
-// TODO
+// Convert the given number of microseconds since the epoch day 1970-01-01T00:00:00Z to a local
+// date-time in Julian calendar, reinterpreting the result as in Proleptic Gregorian calendar, then
+// compute the number of microseconds since the epoch from that Gregorian local date-time.
+// This is to match with Apache Spark's `localRebaseJulianToGregorianMicros` function with timezone
+// fixed to UTC.
 std::unique_ptr<cudf::column> julian_to_gregorian_micros(cudf::column_view const &input,
                                                          rmm::cuda_stream_view stream,
                                                          rmm::mr::device_memory_resource *mr) {

--- a/src/main/cpp/src/datetime_rebase.cu
+++ b/src/main/cpp/src/datetime_rebase.cu
@@ -33,13 +33,13 @@
 namespace {
 
 // Convert a date in Julian calendar to the number of days since epoch.
+// Follow the implementation of `days_from_julian` from
+// https://howardhinnant.github.io/date_algorithms.html
 __device__ __inline__ auto days_from_julian(cuda::std::chrono::year_month_day const &ymd) {
   auto const month = static_cast<uint32_t>(ymd.month());
   auto const day = static_cast<uint32_t>(ymd.day());
   auto const year = static_cast<int32_t>(ymd.year()) - (month <= 2);
 
-  // Follow the implementation of `days_from_julian` from
-  // https://howardhinnant.github.io/date_algorithms.html
   int32_t const era = (year >= 0 ? year : year - 3) / 4;
   uint32_t const year_of_era = static_cast<uint32_t>(year - era * 4);                    // [0, 3]
   uint32_t const day_of_year = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1; // [0, 365]
@@ -95,6 +95,8 @@ std::unique_ptr<cudf::column> gregorian_to_julian_days(cudf::column_view const &
 }
 
 // Convert a number of Julian days since epoch to local date in Julian calendar.
+// Follow the implementation of `julian_from_days` from
+// https://howardhinnant.github.io/date_algorithms.html
 __device__ cuda::std::chrono::year_month_day julian_from_days(int32_t days) {
   auto const z = days + 719470;
   int32_t const era = (z >= 0 ? z : z - 1460) / 1461;

--- a/src/main/cpp/src/datetime_rebase.cu
+++ b/src/main/cpp/src/datetime_rebase.cu
@@ -38,7 +38,8 @@ __device__ __inline__ auto days_from_julian(cuda::std::chrono::year_month_day co
   auto const day = static_cast<uint32_t>(ymd.day());
   auto const year = static_cast<int32_t>(ymd.year()) - (month <= 2);
 
-  // Follow the implementation from https://howardhinnant.github.io/date_algorithms.html
+  // Follow the implementation of `days_from_julian` from
+  // https://howardhinnant.github.io/date_algorithms.html
   int32_t const era = (year >= 0 ? year : year - 3) / 4;
   uint32_t const year_of_era = static_cast<uint32_t>(year - era * 4);                    // [0, 3]
   uint32_t const day_of_year = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1; // [0, 365]
@@ -89,6 +90,54 @@ std::unique_ptr<cudf::column> gregorian_to_julian_days(cudf::column_view const &
         // Reinterpret year/month/day as in Julian calendar then compute the days since epoch.
         return cudf::timestamp_D{cudf::duration_D{days_from_julian(ymd)}};
       });
+
+  return output;
+}
+
+// Convert a number of Julian days since epoch to local date in Julian calendar.
+__device__ cuda::std::chrono::year_month_day julian_from_days(int32_t days) {
+  auto const z = days + 719470;
+  int32_t const era = (z >= 0 ? z : z - 1460) / 1461;
+  uint32_t const day_of_era = static_cast<uint32_t>(z - era * 1461);   // [0, 1460]
+  uint32_t const year_of_era = (day_of_era - day_of_era / 1460) / 365; // [0, 3]
+  int32_t const year = static_cast<int32_t>(year_of_era) + era * 4;
+  uint32_t const day_of_year = day_of_era - 365 * year_of_era;        // [0, 365]
+  uint32_t const mp = (5 * day_of_year + 2) / 153;                    // [0, 11]
+  uint32_t const month = mp + (mp < 10 ? 3 : -9);                     // [1, 12]
+  uint32_t const day_of_month = day_of_year - (153 * mp + 2) / 5 + 1; // [1, 31]
+
+  return cuda::std::chrono::year_month_day{cuda::std::chrono::year{year + (month <= 2)},
+                                           cuda::std::chrono::month{month},
+                                           cuda::std::chrono::day{day_of_month}};
+}
+
+// Convert the given number of days since the epoch day 1970-01-01 to a local date in Julian
+// calendar, reinterpreting the result as in Proleptic Gregorian calendar, then compute the number
+// of days since the epoch from that Gregorian local date. This is to match with Apache Spark's
+// `localRebaseJulianToGregorianDays` function.
+std::unique_ptr<cudf::column> julian_to_gregorian_days(cudf::column_view const &input,
+                                                       rmm::cuda_stream_view stream,
+                                                       rmm::mr::device_memory_resource *mr) {
+  CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_DAYS,
+               "The input column type must be microsecond timestamp.", std::invalid_argument);
+
+  auto output = cudf::make_timestamp_column(input.type(), input.size(),
+                                            cudf::detail::copy_bitmask(input, stream, mr),
+                                            input.null_count(), stream, mr);
+
+  thrust::transform(rmm::exec_policy(stream), thrust::make_counting_iterator(0),
+                    thrust::make_counting_iterator(input.size()),
+                    output->mutable_view().begin<cudf::timestamp_D>(),
+                    [d_input = input.begin<cudf::timestamp_D>()] __device__(auto const idx) {
+                      auto const days_ts = d_input[idx].time_since_epoch().count();
+                      auto const ymd = julian_from_days(days_ts);
+
+                      // Reinterpret year/month/day as in Gregorian calendar then compute the days
+                      // since epoch.
+                      auto const result =
+                          cuda::std::chrono::local_days{ymd}.time_since_epoch().count();
+                      return cudf::timestamp_D{cudf::duration_D{result}};
+                    });
 
   return output;
 }
@@ -207,6 +256,60 @@ std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const
   return output;
 }
 
+std::unique_ptr<cudf::column> julian_to_gregorian_micros(cudf::column_view const &input,
+                                                         rmm::cuda_stream_view stream,
+                                                         rmm::mr::device_memory_resource *mr) {
+  CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_MICROSECONDS,
+               "The input column type must be microsecond timestamp.", std::invalid_argument);
+
+  auto output = cudf::make_timestamp_column(input.type(), input.size(),
+                                            cudf::detail::copy_bitmask(input, stream, mr),
+                                            input.null_count(), stream, mr);
+
+  thrust::transform(
+      rmm::exec_policy(stream), thrust::make_counting_iterator(0),
+      thrust::make_counting_iterator(input.size()),
+      output->mutable_view().begin<cudf::timestamp_us>(),
+      [d_input = input.begin<cudf::timestamp_us>()] __device__(auto const idx) {
+        // This timestamp corresponds to October 15th, 1582 UTC.
+        // After this day, there is no difference in microsecond values between Gregorian
+        // and Julian calendars.
+        int64_t constexpr last_switch_gregorian_ts = -12219292800000000L;
+
+        auto const micros_ts = d_input[idx].time_since_epoch().count();
+        if (micros_ts >= last_switch_gregorian_ts) {
+          return d_input[idx];
+        }
+
+        // Convert the input into local date-time in Proleptic Gregorian calendar.
+        auto const days_since_epoch = cuda::std::chrono::sys_days(static_cast<cudf::duration_D>(
+            cuda::std::chrono::floor<cuda::std::chrono::days>(cudf::duration_us(micros_ts))));
+        auto const ymd = cuda::std::chrono::year_month_day(days_since_epoch);
+        auto const timeparts = get_time_components(micros_ts);
+
+        auto constexpr julian_end = cuda::std::chrono::year_month_day{
+            cuda::std::chrono::year{1582}, cuda::std::chrono::month{10}, cuda::std::chrono::day{4}};
+        auto constexpr gregorian_start = cuda::std::chrono::year_month_day{
+            cuda::std::chrono::year{1582}, cuda::std::chrono::month{10},
+            cuda::std::chrono::day{15}};
+
+        // Reinterpret the local date-time as in Julian calendar and compute microseconds since
+        // the epoch from that Julian local date-time.
+        // If the input date is outside of both calendars, consider it as it is a local date
+        // given at `gregorian_start` (-141427 Julian days since epoch).
+        auto const julian_days =
+            (ymd > julian_end && ymd < gregorian_start) ? -141427 : days_from_julian(ymd);
+        int64_t result = (julian_days * 24L * 3600L) + (timeparts.hour * 3600L) +
+                         (timeparts.minute * 60L) + timeparts.second;
+        result *= MICROS_PER_SECOND; // to microseconds
+        result += timeparts.subsecond;
+
+        return cudf::timestamp_us{cudf::duration_us{result}};
+      });
+
+  return output;
+}
+
 } // namespace
 
 namespace spark_rapids_jni {
@@ -225,6 +328,22 @@ std::unique_ptr<cudf::column> rebase_gregorian_to_julian(cudf::column_view const
   auto const mr = rmm::mr::get_current_device_resource();
   return type == cudf::type_id::TIMESTAMP_DAYS ? gregorian_to_julian_days(input, stream, mr) :
                                                  gregorian_to_julian_micros(input, stream, mr);
+}
+
+std::unique_ptr<cudf::column> rebase_julian_to_gregorian(cudf::column_view const &input) {
+  auto const type = input.type().id();
+  CUDF_EXPECTS(type == cudf::type_id::TIMESTAMP_DAYS ||
+                   type == cudf::type_id::TIMESTAMP_MICROSECONDS,
+               "The input must be either day or microsecond timestamps to rebase.");
+
+  if (input.size() == 0) {
+    return cudf::empty_like(input);
+  }
+
+  auto const stream = cudf::get_default_stream();
+  auto const mr = rmm::mr::get_current_device_resource();
+  return type == cudf::type_id::TIMESTAMP_DAYS ? julian_to_gregorian_days(input, stream, mr) :
+                                                 julian_to_gregorian_micros(input, stream, mr);
 }
 
 } // namespace spark_rapids_jni

--- a/src/main/cpp/src/datetime_rebase.cu
+++ b/src/main/cpp/src/datetime_rebase.cu
@@ -205,7 +205,7 @@ __device__ __inline__ time_components get_time_components(int64_t micros) {
 // Convert the given number of microseconds since the epoch day 1970-01-01T00:00:00Z to a local
 // date-time in Proleptic Gregorian calendar, reinterpreting the result as in Julian calendar, then
 // compute the number of microseconds since the epoch from that Julian local date-time.
-// This is to match with Apache Spark's `localRebaseGregorianToJulianMicros` function with timezone
+// This is to match with Apache Spark's `rebaseGregorianToJulianMicros` function with timezone
 // fixed to UTC.
 std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const &input,
                                                          rmm::cuda_stream_view stream,
@@ -264,7 +264,7 @@ std::unique_ptr<cudf::column> gregorian_to_julian_micros(cudf::column_view const
 // Convert the given number of microseconds since the epoch day 1970-01-01T00:00:00Z to a local
 // date-time in Julian calendar, reinterpreting the result as in Proleptic Gregorian calendar, then
 // compute the number of microseconds since the epoch from that Gregorian local date-time.
-// This is to match with Apache Spark's `localRebaseJulianToGregorianMicros` function with timezone
+// This is to match with Apache Spark's `rebaseJulianToGregorianMicros` function with timezone
 // fixed to UTC.
 std::unique_ptr<cudf::column> julian_to_gregorian_micros(cudf::column_view const &input,
                                                          rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/datetime_rebase.hpp
+++ b/src/main/cpp/src/datetime_rebase.hpp
@@ -20,4 +20,6 @@ namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> rebase_gregorian_to_julian(cudf::column_view const &input);
 
+std::unique_ptr<cudf::column> rebase_julian_to_gregorian(cudf::column_view const &input);
+
 } // namespace spark_rapids_jni

--- a/src/main/cpp/tests/datetime_rebase.cpp
+++ b/src/main/cpp/tests/datetime_rebase.cpp
@@ -33,7 +33,7 @@ using micros_col =
 
 struct TimestampRebaseTest : public cudf::test::BaseFixture {};
 
-TEST_F(TimestampRebaseTest, DayTimestamp) {
+TEST_F(TimestampRebaseTest, RebaseDaysToJulian) {
   auto const ts_col = days_col{-719162, -354285, -141714, -141438, -141437, -141432,
                                -141427, -31463,  -31453,  -1,      0,       18335};
 
@@ -60,6 +60,15 @@ TEST_F(TimestampRebaseTest, DayTimestamp) {
                                    -141427, -31463,  -31453,  -1,      0,       18335};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *rebased, cudf::test::debug_output_level::ALL_ERRORS);
   }
+}
+
+TEST_F(TimestampRebaseTest, RebaseDaysToGregorian) {
+  auto const ts_col = days_col{-719164, -354280, -141704, -141428, -141427, -141427,
+                               -141427, -31463,  -31453,  -1,      0,       18335};
+  auto const rebased = spark_rapids_jni::rebase_julian_to_gregorian(ts_col);
+  auto const expected = days_col{-719162, -354285, -141714, -141438, -141427, -141427,
+                                 -141427, -31463,  -31453,  -1,      0,       18335};
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *rebased, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(TimestampRebaseTest, DayTimestampOfNegativeYear) {

--- a/src/main/cpp/tests/datetime_rebase.cpp
+++ b/src/main/cpp/tests/datetime_rebase.cpp
@@ -18,10 +18,8 @@
 //
 
 #include <cudf/strings/convert/convert_datetime.hpp>
-#include <cudf/strings/convert/convert_durations.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/unary.hpp>
-#include <cudf/wrappers/durations.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -71,7 +69,7 @@ TEST_F(TimestampRebaseTest, RebaseDaysToGregorian) {
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *rebased, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
-TEST_F(TimestampRebaseTest, DayTimestampOfNegativeYear) {
+TEST_F(TimestampRebaseTest, RebaseDaysOfNegativeYearsToJulian) {
   // Negative years cannot be parsed by cudf from strings.
   auto const ts_col = days_col{
       -1121294, // -1100-1-1

--- a/src/main/java/com/nvidia/spark/rapids/jni/DateTimeRebase.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DateTimeRebase.java
@@ -31,6 +31,7 @@ public class DateTimeRebase {
    * 1970-01-01T00:00:00Z to a local date-time in Proleptic Gregorian calendar, reinterpreting
    * the result as in Julian calendar, then compute the number of days or microseconds since the
    * epoch from that Julian local date-time.
+   * <p>
    * This is to match with Apache Spark's `localRebaseGregorianToJulianDays` and
    * `rebaseGregorianToJulianMicros` functions with timezone fixed to UTC.
    */
@@ -38,5 +39,21 @@ public class DateTimeRebase {
     return new ColumnVector(rebaseGregorianToJulian(input.getNativeView()));
   }
 
+  /**
+   * Convert the given timestamps as a number of days or microseconds since the epoch instant
+   * 1970-01-01T00:00:00Z to a local date-time in Julian calendar, reinterpreting the result
+   * as in Proleptic Gregorian calendar, then compute the number of days or microseconds since the
+   * epoch from that Gregorian local date-time.
+   * <p>
+   * This is to match with Apache Spark's `localRebaseJulianToGregorianDays` and
+   * `rebaseJulianToGregorianMicros` functions with timezone fixed to UTC.
+   */
+  public static ColumnVector rebaseJulianToGregorian(ColumnView input) {
+    return new ColumnVector(rebaseJulianToGregorian(input.getNativeView()));
+  }
+
+
   private static native long rebaseGregorianToJulian(long nativeHandle);
+
+  private static native long rebaseJulianToGregorian(long nativeHandle);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/DateTimeRebaseTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DateTimeRebaseTest.java
@@ -24,7 +24,7 @@ import ai.rapids.cudf.ColumnVector;
 
 public class DateTimeRebaseTest {
   @Test
-  void dayTimestampTest() {
+  void rebaseDaysToJulianTest() {
     try (ColumnVector input = ColumnVector.timestampDaysFromBoxedInts(-719162, -354285, null,
         -141714, -141438, -141437,
         null, null,
@@ -39,12 +39,28 @@ public class DateTimeRebaseTest {
   }
 
   @Test
-  void microsecondTimestampTest() {
+  void rebaseDaysToGregorianTest() {
+    try (ColumnVector input = ColumnVector.timestampDaysFromBoxedInts(-719164, -354280, null,
+        -141704, -141428, -141427,
+        null, null,
+        -141427, -141427, -31463, -31453, -1, 0, 18335);
+         ColumnVector expected = ColumnVector.timestampDaysFromBoxedInts(-719162, -354285, null,
+             -141714, -141438, -141427,
+             null, null,
+             -141427, -141427, -31463, -31453, -1, 0, 18335);
+         ColumnVector result = DateTimeRebase.rebaseJulianToGregorian(input)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void rebaseMicroToJulian() {
     try (ColumnVector input = ColumnVector.timestampMicroSecondsFromBoxedLongs(-62135593076345679L,
         -30610213078876544L,
         null,
         -12244061221876544L,
         -12220243200000000L,
+        -12219639001448163L,
         -12219292799000001L,
         -45446999900L,
         1L,
@@ -56,12 +72,43 @@ public class DateTimeRebaseTest {
                  null,
                  -12243197221876544L,
                  -12219379200000000L,
+                 -12219207001448163L,
                  -12219292799000001L,
                  -45446999900L,
                  1L,
                  null,
                  1584178381500000L);
          ColumnVector result = DateTimeRebase.rebaseGregorianToJulian(input)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void rebaseMicroToGregorian() {
+    try (ColumnVector input = ColumnVector.timestampMicroSecondsFromBoxedLongs(-62135765876345679L,
+        -30609781078876544L,
+        null,
+        -12243197221876544L,
+        -12219379200000000L,
+        -12219207001448163L,
+        -12219292799000001L,
+        -45446999900L,
+        1L,
+        null,
+        1584178381500000L);
+         ColumnVector expected =
+             ColumnVector.timestampMicroSecondsFromBoxedLongs(-62135593076345679L,
+                 -30610213078876544L,
+                 null,
+                 -12244061221876544L,
+                 -12220243200000000L,
+                 -12219207001448163L,
+                 -12219292799000001L,
+                 -45446999900L,
+                 1L,
+                 null,
+                 1584178381500000L);
+         ColumnVector result = DateTimeRebase.rebaseJulianToGregorian(input)) {
       assertColumnsAreEqual(expected, result);
     }
   }


### PR DESCRIPTION
Support rebasing day/microsecond timestamps from the legacy hybrid (Julian + Gregorian) calendar to Proleptic Gregorian calendar.

Merge checklist:
 * [X] Implementation
 * [X] Unit tests
 * [x] Test with spark-rapids (https://github.com/NVIDIA/spark-rapids/pull/9649, all integration tests pass)