### PR TITLE
[auto-merge] bot-auto-merge-branch-23.12 to branch-24.02 [skip ci] [bot]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -64,6 +64,7 @@ jobs:
       HaoYang670,\
       NVnavkumar,\
       yinqingh,\
+      thirtiseven,\
       ', format('{0},', github.actor)) && github.event.comment.body == 'build'
     steps:
       - name: Check if comment is issued by authorized person


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-23.12` to create a PR keeping `branch-24.02` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.