### PR TITLE
Fix default values for stream parameter

### DIFF
--- a/src/main/cpp/.clang-format
+++ b/src/main/cpp/.clang-format
@@ -1,187 +1,132 @@
 ---
-# Reference: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-Language:        Cpp
-# BasedOnStyle:  LLVM
-# no indentation (-2 from indent, which is 2)
-AccessModifierOffset: -2
+# Refer to the following link for the explanation of each params:
+#   http://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+Language: Cpp
+# BasedOnStyle: Google
+AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-# int aaaa = 12;
-# int b    = 23;
-# int ccc  = 23;
-# leaving OFF
-AlignConsecutiveAssignments: false
-# int         aaaa = 12;
-# float       b = 23;
-# std::string ccc = 23;
-# leaving OFF
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: true
 AlignConsecutiveDeclarations: false
-##define A                                                                      \
-#  int aaaa;                                                                    \
-#  int b;                                                                       \
-#  int dddddddddd;
-# leaving ON
-AlignEscapedNewlines: Right
-# int aaa = bbbbbbbbbbbbbbb +
-#           ccccccccccccccc;
-# leaving ON
-AlignOperands:   true
-# true:                                   false:
-# int a;     // My comment a      vs.     int a; // My comment a
-# int b = 2; // comment  b                int b = 2; // comment about b
-# leaving ON
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
 AlignTrailingComments: true
-# squeezes a long declaration's arguments to the next line:
-#true:
-#void myFunction(
-#	int a, int b, int c, int d, int e);
-#
-#false:
-#void myFunction(int a,
-#				int b,
-#				int c,
-#				int d,
-#				int e);
-# leaving ON
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-# changed to ON, as we use short blocks on same lines
 AllowShortBlocksOnASingleLine: true
-# set this to ON, we use this in a few places
 AllowShortCaseLabelsOnASingleLine: true
-# set this to ON
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLambdasOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
-# Deprecated option.
-# PenaltyReturnTypeOnItsOwnLine applies, as we set this to None,
-# where it tries to break after the return type automatically
+# This is deprecated
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
-
-# if all the arguments for a function don't fit in a single line,
-# with a value of "false", it'll split each argument into different lines
-BinPackArguments: true
-BinPackParameters: true
-
-# if this is set to Custom, the BraceWrapping flags apply
-BreakBeforeBraces: Custom
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments:  false
+BinPackParameters: false
 BraceWrapping:
-  AfterClass:      false
+  AfterClass:            false
   AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
+  AfterEnum:             false
+  AfterFunction:         false
+  AfterNamespace:        false
+  AfterObjCDeclaration:  false
+  AfterStruct:           false
+  AfterUnion:            false
+  AfterExternBlock:      false
+  BeforeCatch:           false
+  BeforeElse:            false
+  IndentBraces:          false
+  # disabling the below splits, else, they'll just add to the vertical length of source files!
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-
-# will break after operators when a line is too long
+BreakAfterJavaFieldAnnotations: false
 BreakBeforeBinaryOperators: None
-# not in docs.. so that's nice
+BreakBeforeBraces: WebKit
 BreakBeforeInheritanceComma: false
-# This will break inheritance list and align on colon,
-# it also places each inherited class in a different line.
-# Leaving ON
-BreakInheritanceList: BeforeColon
-
-#
-#true:
-#veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription
-#	? firstValue
-#	: SecondValueVeryVeryVeryVeryLong;
-#
-#false:
-#veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription ?
-#	firstValue :
-#	SecondValueVeryVeryVeryVeryLong;
-BreakBeforeTernaryOperators: false
-
+BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: true
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
-# So the line lengths in cudf are not following a limit, at the moment.
-# Usually it's a long comment that makes the line length inconsistent.
-# Command I used to find max line lengths (from cpp directory):
-#   find include src tests|grep "\." |xargs -I{} bash -c "awk '{print length}' {} | sort -rn | head -1"|sort -n
-# I picked 100, as it seemed somewhere around median
-ColumnLimit:     100
-# TODO: not aware of any of these at this time
-CommentPragmas:  '^ IWYU pragma:'
-# So it doesn't put subsequent namespaces in the same line
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-# TODO: adds spaces around the element list
-# in initializer: vector<T> x{ {}, ..., {} }
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# Kept the below 2 to be the same as `IndentWidth` to keep everything uniform
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-# } // namespace a => useful
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks:   Regroup
-IncludeCategories:
-  - Regex:           '<[[:alnum:]]+>'
-    Priority:        0
-  - Regex:           '<[[:alnum:].]+>'
-    Priority:        1
-  - Regex:           '<.*>'
-    Priority:        2
-  - Regex:           '.*/.*'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        4
-# if a header matches this in an include group, it will be moved up to the
-# top of the group.
-IncludeIsMainRegex: '(Test)?$'
+IncludeBlocks: Preserve
+IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
+ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-
-# Penalties: leaving unchanged for now
-# https://stackoverflow.com/questions/26635370/in-clang-format-what-do-the-penalties-do
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-# As currently set, we don't see return types being
-# left on their own line, leaving at 60
-PenaltyReturnTypeOnItsOwnLine: 60
-
-# char* foo vs char *foo, picking Right aligned
-PointerAlignment: Right
-ReflowComments:  true
-# leaving ON, but this could be something to turn OFF
-SortIncludes:    true
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+# Enabling comment reflow causes doxygen comments to be messed up in their formats!
+ReflowComments: true
+SortIncludes: true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
@@ -191,14 +136,20 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
-...
+Standard: c++17
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+# Be consistent with indent-width, even for people who use tab for indentation!
+TabWidth: 2
+UseTab: Never

--- a/src/main/cpp/.clang-format
+++ b/src/main/cpp/.clang-format
@@ -1,132 +1,187 @@
 ---
-# Refer to the following link for the explanation of each params:
-#   http://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
-Language: Cpp
-# BasedOnStyle: Google
-AccessModifierOffset: -1
+# Reference: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+Language:        Cpp
+# BasedOnStyle:  LLVM
+# no indentation (-2 from indent, which is 2)
+AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
-AlignConsecutiveBitFields: true
+# int aaaa = 12;
+# int b    = 23;
+# int ccc  = 23;
+# leaving OFF
+AlignConsecutiveAssignments: false
+# int         aaaa = 12;
+# float       b = 23;
+# std::string ccc = 23;
+# leaving OFF
 AlignConsecutiveDeclarations: false
-AlignConsecutiveMacros: true
-AlignEscapedNewlines: Left
-AlignOperands: true
+##define A                                                                      \
+#  int aaaa;                                                                    \
+#  int b;                                                                       \
+#  int dddddddddd;
+# leaving ON
+AlignEscapedNewlines: Right
+# int aaa = bbbbbbbbbbbbbbb +
+#           ccccccccccccccc;
+# leaving ON
+AlignOperands:   true
+# true:                                   false:
+# int a;     // My comment a      vs.     int a; // My comment a
+# int b = 2; // comment  b                int b = 2; // comment about b
+# leaving ON
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
+# squeezes a long declaration's arguments to the next line:
+#true:
+#void myFunction(
+#	int a, int b, int c, int d, int e);
+#
+#false:
+#void myFunction(int a,
+#				int b,
+#				int c,
+#				int d,
+#				int e);
+# leaving ON
 AllowAllParametersOfDeclarationOnNextLine: true
+# changed to ON, as we use short blocks on same lines
 AllowShortBlocksOnASingleLine: true
+# set this to ON, we use this in a few places
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortEnumsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLambdasOnASingleLine: true
+# set this to ON
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-# This is deprecated
+# Deprecated option.
+# PenaltyReturnTypeOnItsOwnLine applies, as we set this to None,
+# where it tries to break after the return type automatically
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments:  false
-BinPackParameters: false
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+
+# if all the arguments for a function don't fit in a single line,
+# with a value of "false", it'll split each argument into different lines
+BinPackArguments: true
+BinPackParameters: true
+
+# if this is set to Custom, the BraceWrapping flags apply
+BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterClass:            false
+  AfterClass:      false
   AfterControlStatement: false
-  AfterEnum:             false
-  AfterFunction:         false
-  AfterNamespace:        false
-  AfterObjCDeclaration:  false
-  AfterStruct:           false
-  AfterUnion:            false
-  AfterExternBlock:      false
-  BeforeCatch:           false
-  BeforeElse:            false
-  IndentBraces:          false
-  # disabling the below splits, else, they'll just add to the vertical length of source files!
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-BreakAfterJavaFieldAnnotations: false
+
+# will break after operators when a line is too long
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: WebKit
+# not in docs.. so that's nice
 BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: true
+# This will break inheritance list and align on colon,
+# it also places each inherited class in a different line.
+# Leaving ON
+BreakInheritanceList: BeforeColon
+
+#
+#true:
+#veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription
+#	? firstValue
+#	: SecondValueVeryVeryVeryVeryLong;
+#
+#false:
+#veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription ?
+#	firstValue :
+#	SecondValueVeryVeryVeryVeryLong;
+BreakBeforeTernaryOperators: false
+
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
-BreakInheritanceList: BeforeColon
+BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: true
-ColumnLimit: 100
-CommentPragmas: '^ IWYU pragma:'
+# So the line lengths in cudf are not following a limit, at the moment.
+# Usually it's a long comment that makes the line length inconsistent.
+# Command I used to find max line lengths (from cpp directory):
+#   find include src tests|grep "\." |xargs -I{} bash -c "awk '{print length}' {} | sort -rn | head -1"|sort -n
+# I picked 100, as it seemed somewhere around median
+ColumnLimit:     100
+# TODO: not aware of any of these at this time
+CommentPragmas:  '^ IWYU pragma:'
+# So it doesn't put subsequent namespaces in the same line
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-# Kept the below 2 to be the same as `IndentWidth` to keep everything uniform
-ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 2
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+# TODO: adds spaces around the element list
+# in initializer: vector<T> x{ {}, ..., {} }
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat: false
+DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
+# } // namespace a => useful
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks: Preserve
-IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '<[[:alnum:]]+>'
+    Priority:        0
+  - Regex:           '<[[:alnum:].]+>'
+    Priority:        1
+  - Regex:           '<.*>'
+    Priority:        2
+  - Regex:           '.*/.*'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        4
+# if a header matches this in an include group, it will be moved up to the
+# top of the group.
+IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Never
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+
+# Penalties: leaving unchanged for now
+# https://stackoverflow.com/questions/26635370/in-clang-format-what-do-the-penalties-do
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-RawStringFormats:
-  - Language: Cpp
-    Delimiters:
-      - cc
-      - CC
-      - cpp
-      - Cpp
-      - CPP
-      - 'c++'
-      - 'C++'
-    CanonicalDelimiter: ''
-  - Language: TextProto
-    Delimiters:
-      - pb
-      - PB
-      - proto
-      - PROTO
-    EnclosingFunctions:
-      - EqualsProto
-      - EquivToProto
-      - PARSE_PARTIAL_TEXT_PROTO
-      - PARSE_TEST_PROTO
-      - PARSE_TEXT_PROTO
-      - ParseTextOrDie
-      - ParseTextProtoOrDie
-    CanonicalDelimiter: ''
-    BasedOnStyle: google
-# Enabling comment reflow causes doxygen comments to be messed up in their formats!
-ReflowComments: true
-SortIncludes: true
+# As currently set, we don't see return types being
+# left on their own line, leaving at 60
+PenaltyReturnTypeOnItsOwnLine: 60
+
+# char* foo vs char *foo, picking Right aligned
+PointerAlignment: Right
+ReflowComments:  true
+# leaving ON, but this could be something to turn OFF
+SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
@@ -136,20 +191,14 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
-SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles: false
-SpacesInConditionalStatement: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++17
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
-# Be consistent with indent-width, even for people who use tab for indentation!
-TabWidth: 2
-UseTab: Never
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -26,29 +26,39 @@
 
 namespace cudf::jni {
 
-std::unique_ptr<cudf::table>
-multiply_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t product_scale,
-                    rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> multiply_decimal128(
+  cudf::column_view const& a,
+  cudf::column_view const& b,
+  int32_t product_scale,
+  rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table>
-divide_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
-                  rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> divide_decimal128(
+  cudf::column_view const& a,
+  cudf::column_view const& b,
+  int32_t quotient_scale,
+  rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table>
-integer_divide_decimal128(cudf::column_view const &a, cudf::column_view const &b,
-                          int32_t quotient_scale,
-                          rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> integer_divide_decimal128(
+  cudf::column_view const& a,
+  cudf::column_view const& b,
+  int32_t quotient_scale,
+  rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table>
-remainder_decimal128(cudf::column_view const &a, cudf::column_view const &b,
-                     int32_t remainder_scale,
-                     rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> remainder_decimal128(
+  cudf::column_view const& a,
+  cudf::column_view const& b,
+  int32_t remainder_scale,
+  rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table>
-add_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
-               rmm::cuda_stream_view stream = cudf::get_default_stream());
+std::unique_ptr<cudf::table> add_decimal128(
+  cudf::column_view const& a,
+  cudf::column_view const& b,
+  int32_t quotient_scale,
+  rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table>
-sub_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
-               rmm::cuda_stream_view stream = cudf::get_default_stream());
-} // namespace cudf::jni
+std::unique_ptr<cudf::table> sub_decimal128(
+  cudf::column_view const& a,
+  cudf::column_view const& b,
+  int32_t quotient_scale,
+  rmm::cuda_stream_view stream = cudf::get_default_stream());
+}  // namespace cudf::jni

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,45 +16,39 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+//
 #include <rmm/cuda_stream_view.hpp>
 
+//
 #include <cstddef>
 
 namespace cudf::jni {
 
-std::unique_ptr<cudf::table> multiply_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t product_scale,
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::table>
+multiply_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t product_scale,
+                    rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> divide_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t quotient_scale,
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::table>
+divide_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
+                  rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> integer_divide_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t quotient_scale,
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::table>
+integer_divide_decimal128(cudf::column_view const &a, cudf::column_view const &b,
+                          int32_t quotient_scale,
+                          rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> remainder_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t remainder_scale,
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::table>
+remainder_decimal128(cudf::column_view const &a, cudf::column_view const &b,
+                     int32_t remainder_scale,
+                     rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> add_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t quotient_scale,
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+std::unique_ptr<cudf::table>
+add_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
+               rmm::cuda_stream_view stream = cudf::get_default_stream());
 
-std::unique_ptr<cudf::table> sub_decimal128(
-  cudf::column_view const& a,
-  cudf::column_view const& b,
-  int32_t quotient_scale,
-  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
-}  // namespace cudf::jni
+std::unique_ptr<cudf::table>
+sub_decimal128(cudf::column_view const &a, cudf::column_view const &b, int32_t quotient_scale,
+               rmm::cuda_stream_view stream = cudf::get_default_stream());
+} // namespace cudf::jni

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -18,10 +18,8 @@
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-//
 #include <rmm/cuda_stream_view.hpp>
 
-//
 #include <cstddef>
 
 namespace cudf::jni {

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -18,9 +18,12 @@
 
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 
+//
 #include <rmm/cuda_stream_view.hpp>
 
+//
 #include <memory>
 
 namespace spark_rapids_jni {
@@ -33,9 +36,9 @@ namespace spark_rapids_jni {
  * @param mr Memory resource for returned column
  * @return std::unique_ptr<column> String column of protocols parsed.
  */
-std::unique_ptr<cudf::column> parse_uri_to_protocol(
-  cudf::strings_column_view const& input,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<cudf::column>
+parse_uri_to_protocol(cudf::strings_column_view const &input,
+                      rmm::cuda_stream_view stream = cudf::get_default_stream(),
+                      rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
-}  // namespace spark_rapids_jni
+} // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -34,9 +34,9 @@ namespace spark_rapids_jni {
  * @param mr Memory resource for returned column
  * @return std::unique_ptr<column> String column of protocols parsed.
  */
-std::unique_ptr<cudf::column>
-parse_uri_to_protocol(cudf::strings_column_view const &input,
-                      rmm::cuda_stream_view stream = cudf::get_default_stream(),
-                      rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<cudf::column> parse_uri_to_protocol(
+  cudf::strings_column_view const& input,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-} // namespace spark_rapids_jni
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -20,10 +20,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-//
 #include <rmm/cuda_stream_view.hpp>
 
-//
 #include <memory>
 
 namespace spark_rapids_jni {

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -27,25 +27,27 @@
 namespace spark_rapids_jni {
 
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized(
-    cudf::table_view const &tbl,
-    // TODO need something for validity
-    rmm::cuda_stream_view stream = cudf::get_default_stream(),
-    rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+  cudf::table_view const& tbl,
+  // TODO need something for validity
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-std::vector<std::unique_ptr<cudf::column>>
-convert_to_rows(cudf::table_view const &tbl,
-                // TODO need something for validity
-                rmm::cuda_stream_view stream = cudf::get_default_stream(),
-                rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+std::vector<std::unique_ptr<cudf::column>> convert_to_rows(
+  cudf::table_view const& tbl,
+  // TODO need something for validity
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
-    cudf::lists_column_view const &input, std::vector<cudf::data_type> const &schema,
-    rmm::cuda_stream_view stream = cudf::get_default_stream(),
-    rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+  cudf::lists_column_view const& input,
+  std::vector<cudf::data_type> const& schema,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-std::unique_ptr<cudf::table>
-convert_from_rows(cudf::lists_column_view const &input, std::vector<cudf::data_type> const &schema,
-                  rmm::cuda_stream_view stream = cudf::get_default_stream(),
-                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<cudf::table> convert_from_rows(
+  cudf::lists_column_view const& input,
+  std::vector<cudf::data_type> const& schema,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-} // namespace spark_rapids_jni
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,36 +16,39 @@
 
 #pragma once
 
-#include <memory>
-
+//
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+//
 #include <rmm/cuda_stream_view.hpp>
+
+//
+#include <memory>
 
 namespace spark_rapids_jni {
 
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized(
-  cudf::table_view const& tbl,
-  // TODO need something for validity
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+    cudf::table_view const &tbl,
+    // TODO need something for validity
+    rmm::cuda_stream_view stream = cudf::get_default_stream(),
+    rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
-std::vector<std::unique_ptr<cudf::column>> convert_to_rows(
-  cudf::table_view const& tbl,
-  // TODO need something for validity
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::vector<std::unique_ptr<cudf::column>>
+convert_to_rows(cudf::table_view const &tbl,
+                // TODO need something for validity
+                rmm::cuda_stream_view stream = cudf::get_default_stream(),
+                rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
-  cudf::lists_column_view const& input,
-  std::vector<cudf::data_type> const& schema,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+    cudf::lists_column_view const &input, std::vector<cudf::data_type> const &schema,
+    rmm::cuda_stream_view stream = cudf::get_default_stream(),
+    rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
-std::unique_ptr<cudf::table> convert_from_rows(
-  cudf::lists_column_view const& input,
-  std::vector<cudf::data_type> const& schema,
-  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<cudf::table>
+convert_from_rows(cudf::lists_column_view const &input, std::vector<cudf::data_type> const &schema,
+                  rmm::cuda_stream_view stream = cudf::get_default_stream(),
+                  rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource());
 
-}  // namespace spark_rapids_jni
+} // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -16,15 +16,12 @@
 
 #pragma once
 
-//
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-//
 #include <rmm/cuda_stream_view.hpp>
 
-//
 #include <memory>
 
 namespace spark_rapids_jni {


### PR DESCRIPTION
This changes the default values for stream parameter in various APIs. We should switch to use `cudf::get_default_stream()` which is consistent throughout the library (it will be either `rmm::cuda_stream_default` or `rmm::cuda_stream_per_thread`). Using only `rmm::cuda_stream_default` may lead to mixed use of `rmm::cuda_stream_default` and `rmm::cuda_stream_per_thread` in the same place.