### PR TITLE
Fix C++ `clang-format` style to preserve grouping in headers [skip ci]

### DIFF
--- a/src/main/cpp/.clang-format
+++ b/src/main/cpp/.clang-format
@@ -133,7 +133,7 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks:   Regroup
+IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '<[[:alnum:]]+>'
     Priority:        0

--- a/src/main/cpp/.clang-format
+++ b/src/main/cpp/.clang-format
@@ -1,3 +1,17 @@
+# =============================================================================
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
 ---
 # Reference: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 Language:        Cpp


### PR DESCRIPTION
Currently, grouping in headers is not allowed:

Before:
```
#include <cudf/lists/lists_column_view.hpp>
#include <cudf/table/table_view.hpp>
#include <cudf/utilities/default_stream.hpp>

#include <thrust/transform.h>

#include <rmm/cuda_stream_view.hpp>

#include <memory>
```

After formatting:
```
#include <memory>

#include <cudf/lists/lists_column_view.hpp>
#include <cudf/table/table_view.hpp>
#include <cudf/utilities/default_stream.hpp>
#include <rmm/cuda_stream_view.hpp>
#include <thrust/transform.h>
```

The formatter should not change the header grouping in the input to respect to "near to far" conventional order. Only headers within each group are sorted alphabetically.