### PR TITLE
Fixing potential overflow in array read in string to float cast

### DIFF
--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -194,6 +194,8 @@ class string_to_float {
     compute_validity(_valid, _except);
   }
 
+  static constexpr int max_safe_digits = 19;
+
  private:
   // shuffle down to remove whitespace
   __device__ void remove_leading_whitespace()
@@ -319,7 +321,6 @@ class string_to_float {
 
     // have we seen a valid digit yet?
     bool seen_valid_digit         = false;
-    constexpr int max_safe_digits = 19;
     do {
       int num_chars = _blen - _bpos;
 
@@ -603,7 +604,9 @@ __global__ void string_to_float_kernel(T* out,
   size_type const row = tid / 32;
   if (row >= num_rows) { return; }
 
-  __shared__ uint64_t ipow[19];
+  // one more than max safe digits to ensure that we can reference
+  // max_safe_digits into the array.
+  __shared__ uint64_t ipow[string_to_float<T, block_size>::max_safe_digits + 1];
   if (threadIdx.x == 0) {
     ipow[0]  = 1;
     ipow[1]  = 10;
@@ -624,6 +627,7 @@ __global__ void string_to_float_kernel(T* out,
     ipow[16] = 10000000000000000;
     ipow[17] = 100000000000000000;
     ipow[18] = 1000000000000000000;
+    ipow[19] = 10000000000000000000;
   }
   __syncthreads();
 


### PR DESCRIPTION
String to float cast would read into undefined memory if there were >= 19 digits in the string. This ultimately wasn't an issue in our test because the number of digits read to that point was 0, so the math was `(0 * undef) + ...`. Fixing it by creating a constant where the outer code can read it as well to ensure that it is large enough to handle the values.

Fixes #1574 