### PR TITLE
Handle Decimal-128 Multiplication For Newer Spark Versions

### DIFF
--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -19,8 +19,13 @@
 
 extern "C" {
 
-JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_multiply128(
-  JNIEnv* env, jclass, jlong j_view_a, jlong j_view_b, jint j_product_scale)
+JNIEXPORT jlongArray JNICALL
+Java_com_nvidia_spark_rapids_jni_DecimalUtils_multiply128(JNIEnv* env,
+                                                          jclass,
+                                                          jlong j_view_a,
+                                                          jlong j_view_b,
+                                                          jint j_product_scale,
+                                                          bool cast_interim_result)
 {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
@@ -30,7 +35,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_multi
     auto view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
     auto scale  = static_cast<int>(j_product_scale);
     return cudf::jni::convert_table_for_return(
-      env, cudf::jni::multiply_decimal128(*view_a, *view_b, scale));
+      env, cudf::jni::multiply_decimal128(*view_a, *view_b, scale, cast_interim_result));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -681,11 +681,11 @@ struct dec128_multiplier {
 
     int mult_scale = a_scale + b_scale;
 
-    // Spark does some really odd things that I personally think are a bug
-    // https://issues.apache.org/jira/browse/SPARK-40129
-    // But to match Spark we need to first round the result to a precision of 38
-    // and this is specific to the value in the result of the multiply.
-    // Then we need to round the result to the final scale that we care about.
+    // According to https://issues.apache.org/jira/browse/SPARK-40129
+    // and https://issues.apache.org/jira/browse/SPARK-45786, Spark has a bug in versions 3.2.4, 3.3.3, 3.4.1, 3.5.0
+    // and 4.0.0
+    // The bug is fixed for later versions but to match the legacy behavior we need to first round the result to a
+    // precision of 38 then we need to round the result to the final scale that we care about.
     if (cast_interim_result) {
       int first_div_precision = dec_precision - 38;
       if (first_div_precision > 0) {

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -682,10 +682,10 @@ struct dec128_multiplier {
     int mult_scale = a_scale + b_scale;
 
     // According to https://issues.apache.org/jira/browse/SPARK-40129
-    // and https://issues.apache.org/jira/browse/SPARK-45786, Spark has a bug in versions 3.2.4, 3.3.3, 3.4.1, 3.5.0
-    // and 4.0.0
-    // The bug is fixed for later versions but to match the legacy behavior we need to first round the result to a
-    // precision of 38 then we need to round the result to the final scale that we care about.
+    // and https://issues.apache.org/jira/browse/SPARK-45786, Spark has a bug in
+    // versions 3.2.4, 3.3.3, 3.4.1, 3.5.0 and 4.0.0 The bug is fixed for later versions but to
+    // match the legacy behavior we need to first round the result to a precision of 38 then we need
+    // to round the result to the final scale that we care about.
     if (cast_interim_result) {
       int first_div_precision = dec_precision - 38;
       if (first_div_precision > 0) {

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -975,7 +975,7 @@ namespace cudf::jni {
 std::unique_ptr<cudf::table> multiply_decimal128(cudf::column_view const& a,
                                                  cudf::column_view const& b,
                                                  int32_t product_scale,
-                                                 bool const& cast_interim_result,
+                                                 bool const cast_interim_result,
                                                  rmm::cuda_stream_view stream)
 {
   CUDF_EXPECTS(a.type().id() == cudf::type_id::DECIMAL128, "not a DECIMAL128 column");

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -680,22 +680,22 @@ struct dec128_multiplier {
     int dec_precision = precision10(product);
 
     int const mult_scale = [&]() {
-        // According to https://issues.apache.org/jira/browse/SPARK-40129
-        // and https://issues.apache.org/jira/browse/SPARK-45786, Spark has a bug in
-        // versions 3.2.4, 3.3.3, 3.4.1, 3.5.0 and 4.0.0 The bug is fixed for later versions but to
-        // match the legacy behavior we need to first round the result to a precision of 38 then we need
-        // to round the result to the final scale that we care about.
-        if (cast_interim_result) {
-          int first_div_precision = dec_precision - 38;
-          if (first_div_precision > 0) {
-            auto const first_div_scale_divisor = pow_ten(first_div_precision).as_128_bits();
-            product                            = divide_and_round(product, first_div_scale_divisor);
+      // According to https://issues.apache.org/jira/browse/SPARK-40129
+      // and https://issues.apache.org/jira/browse/SPARK-45786, Spark has a bug in
+      // versions 3.2.4, 3.3.3, 3.4.1, 3.5.0 and 4.0.0 The bug is fixed for later versions but to
+      // match the legacy behavior we need to first round the result to a precision of 38 then we
+      // need to round the result to the final scale that we care about.
+      if (cast_interim_result) {
+        int first_div_precision = dec_precision - 38;
+        if (first_div_precision > 0) {
+          auto const first_div_scale_divisor = pow_ten(first_div_precision).as_128_bits();
+          product                            = divide_and_round(product, first_div_scale_divisor);
 
-            // a_scale and b_scale are negative. first_div_precision is not
-            return a_scale + b_scale + first_div_precision;
-          }
+          // a_scale and b_scale are negative. first_div_precision is not
+          return a_scale + b_scale + first_div_precision;
         }
-        return a_scale + b_scale;
+      }
+      return a_scale + b_scale;
     }();
 
     int exponent = prod_scale - mult_scale;

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -677,8 +677,6 @@ struct dec128_multiplier {
 
     chunked256 product = multiply(a, b);
 
-    int dec_precision = precision10(product);
-
     int const mult_scale = [&]() {
       // According to https://issues.apache.org/jira/browse/SPARK-40129
       // and https://issues.apache.org/jira/browse/SPARK-45786, Spark has a bug in
@@ -686,7 +684,7 @@ struct dec128_multiplier {
       // match the legacy behavior we need to first round the result to a precision of 38 then we
       // need to round the result to the final scale that we care about.
       if (cast_interim_result) {
-        int first_div_precision = dec_precision - 38;
+        auto const first_div_precision = precision10(product) - 38;
         if (first_div_precision > 0) {
           auto const first_div_scale_divisor = pow_ten(first_div_precision).as_128_bits();
           product                            = divide_and_round(product, first_div_scale_divisor);
@@ -724,7 +722,7 @@ struct dec128_multiplier {
  private:
   // output column for overflow detected
   bool* const overflows;
-  bool cast_interim_result;
+  bool const cast_interim_result;
 
   // input data for multiply
   __int128_t const* const a_data;

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -30,7 +30,7 @@ std::unique_ptr<cudf::table> multiply_decimal128(
   cudf::column_view const& a,
   cudf::column_view const& b,
   int32_t product_scale,
-  bool const& cast_interim_result,
+  bool const cast_interim_result,
   rmm::cuda_stream_view stream = cudf::get_default_stream());
 
 std::unique_ptr<cudf::table> divide_decimal128(

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -30,6 +30,7 @@ std::unique_ptr<cudf::table> multiply_decimal128(
   cudf::column_view const& a,
   cudf::column_view const& b,
   int32_t product_scale,
+  bool const& cast_interim_result,
   rmm::cuda_stream_view stream = cudf::get_default_stream());
 
 std::unique_ptr<cudf::table> divide_decimal128(

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -29,15 +29,21 @@ public class DecimalUtils {
    * Multiply two DECIMAL128 columns together into a DECIMAL128 product rounded to the specified
    * scale with overflow detection. This method considers a precision greater than 38 as overflow
    * even if the number still fits in a 128-bit representation.
-   * @param a factor input, must match row count of the other factor input
-   * @param b factor input, must match row count of the other factor input
+   *
+   * WARNING: This method has a bug which we match with Spark versions before 3.4.2,
+   * 4.0.0, 3.5.1. Consider the following example using Decimal with a precision of 38 and scale of 10:
+   * -8533444864753048107770677711.1312637916 * -12.0000000000 = 102401338377036577293248132533.575166
+   * while the actual answer based on Java BigDecimal is 102401338377036577293248132533.575165
+   *
+   * @param a            factor input, must match row count of the other factor input
+   * @param b            factor input, must match row count of the other factor input
    * @param productScale scale to use for the product type
    * @return table containing a boolean column and a DECIMAL128 product column of the specified
-   *         scale. The boolean value will be true if an overflow was detected for that row's
-   *         DECIMAL128 product value. A null input row will result in a corresponding null output
-   *         row.
+   * scale. The boolean value will be true if an overflow was detected for that row's
+   * DECIMAL128 product value. A null input row will result in a corresponding null output
+   * row.
    */
-  public static Table mul128(ColumnView a, ColumnView b, int productScale) {
+  public static Table multiply128(ColumnView a, ColumnView b, int productScale) {
     return new Table(multiply128(a.getNativeView(), b.getNativeView(), productScale, false));
   }
 
@@ -46,21 +52,23 @@ public class DecimalUtils {
    * scale with overflow detection. This method considers a precision greater than 38 as overflow
    * even if the number still fits in a 128-bit representation.
    *
-   * WARNING: This method has a bug which we match with Spark versions before 3.4.2, 4.0.0, 3.5.1. Consider the
-   * following example using Decimal with a precision of 38 and scale of 10:
+   * WARNING: With interimCast set to  true, this method has a bug which we match with Spark versions before 3.4.2,
+   * 4.0.0, 3.5.1. Consider the following example using Decimal with a precision of 38 and scale of 10:
    * -8533444864753048107770677711.1312637916 * -12.0000000000 = 102401338377036577293248132533.575166
    * while the actual answer based on Java BigDecimal is 102401338377036577293248132533.575165
    *
    * @param a factor input, must match row count of the other factor input
    * @param b factor input, must match row count of the other factor input
    * @param productScale scale to use for the product type
+   * @param interimCast whether to cast the result of the division to 38 precision before casting it again to the final
+   *                    precision
    * @return table containing a boolean column and a DECIMAL128 product column of the specified
    *         scale. The boolean value will be true if an overflow was detected for that row's
    *         DECIMAL128 product value. A null input row will result in a corresponding null output
    *         row.
    */
-  public static Table multiply128(ColumnView a, ColumnView b, int productScale) {
-    return new Table(multiply128(a.getNativeView(), b.getNativeView(), productScale, true));
+  public static Table multiply128(ColumnView a, ColumnView b, int productScale, boolean interimCast) {
+    return new Table(multiply128(a.getNativeView(), b.getNativeView(), productScale, interimCast));
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -44,7 +44,7 @@ public class DecimalUtils {
    * row.
    */
   public static Table multiply128(ColumnView a, ColumnView b, int productScale) {
-    return new Table(multiply128(a.getNativeView(), b.getNativeView(), productScale, false));
+    return new Table(multiply128(a.getNativeView(), b.getNativeView(), productScale, true));
   }
 
   /**

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -87,6 +87,22 @@ public class DecimalUtilsTest {
   }
 
   @Test
+  void multiply128WithoutInterimCast() {
+    try (ColumnVector lhs =
+                 makeDec128Column("-8533444864753048107770677711.1312637916");
+         ColumnVector rhs =
+                 makeDec128Column("-12.0000000000");
+         ColumnVector expectedBasic =
+                 makeDec128Column("102401338377036577293248132533.575165");
+         ColumnVector expectedValid =
+                 ColumnVector.fromBooleans(false);
+         Table found = DecimalUtils.mul128(lhs, rhs, -6)) {
+      assertColumnsAreEqual(expectedValid, found.getColumn(0));
+      assertColumnsAreEqual(expectedBasic, found.getColumn(1));
+    }
+  }
+
+  @Test
   void largePosMultiplyTenByTen() {
     try (ColumnVector lhs =
              makeDec128Column("577694940161436285811555447.3103121126");

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -96,7 +96,7 @@ public class DecimalUtilsTest {
                  makeDec128Column("102401338377036577293248132533.575165");
          ColumnVector expectedValid =
                  ColumnVector.fromBooleans(false);
-         Table found = DecimalUtils.mul128(lhs, rhs, -6)) {
+         Table found = DecimalUtils.multiply128(lhs, rhs, -6, false)) {
       assertColumnsAreEqual(expectedValid, found.getColumn(0));
       assertColumnsAreEqual(expectedBasic, found.getColumn(1));
     }

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -88,14 +88,10 @@ public class DecimalUtilsTest {
 
   @Test
   void multiply128WithoutInterimCast() {
-    try (ColumnVector lhs =
-                 makeDec128Column("-8533444864753048107770677711.1312637916");
-         ColumnVector rhs =
-                 makeDec128Column("-12.0000000000");
-         ColumnVector expectedBasic =
-                 makeDec128Column("102401338377036577293248132533.575165");
-         ColumnVector expectedValid =
-                 ColumnVector.fromBooleans(false);
+    try (ColumnVector lhs = makeDec128Column("-8533444864753048107770677711.1312637916");
+         ColumnVector rhs = makeDec128Column("-12.0000000000");
+         ColumnVector expectedBasic = makeDec128Column("102401338377036577293248132533.575165");
+         ColumnVector expectedValid = ColumnVector.fromBooleans(false);
          Table found = DecimalUtils.multiply128(lhs, rhs, -6, false)) {
       assertColumnsAreEqual(expectedValid, found.getColumn(0));
       assertColumnsAreEqual(expectedBasic, found.getColumn(1));


### PR DESCRIPTION
This PR adds a new method for multiplying two Decimal 128-bit numbers without casting the interim result before casting to the scale the final answer is expected to be in. 

When multiplying two decimal numbers with a precision of 38, earlier versions of Spark are capped by the precision of 38 which causes the answer to be casted twice essentially, once right after multiplication and once before reporting the final answer which leads to the answer being inaccurate. 

For more details please look at the Spark [issue](https://issues.apache.org/jira/browse/SPARK-40129) which explains the issue in greater detail. 

**Changes Made:**
* Added a boolean param to control whether to apply the interim cast.
* Added a new `multiply128` method that takes in interimCast boolean. 
* Added a warning to the old method to highlight that it knowingly adds a bug to the multiplication to match Spark versions

**Tests:**
* Added a unit test


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
