### PR TITLE
Adding query support to parseURI

### DIFF
--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -47,4 +47,18 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseHost(JNIE
   }
   CATCH_STD(env, 0);
 }
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQuery(JNIEnv* env,
+                                                                             jclass,
+                                                                             jlong input_column)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    return cudf::jni::ptr_as_jlong(spark_rapids_jni::parse_uri_to_query(*input).release());
+  }
+  CATCH_STD(env, 0);
+}
 }

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -52,4 +52,17 @@ std::unique_ptr<cudf::column> parse_uri_to_host(
   rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+/**
+ * @brief Parse query and copy from the input string column to the output char buffer.
+ *
+ * @param input Input string column of URIs to parse
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column
+ * @return std::unique_ptr<column> String column of queries parsed.
+ */
+std::unique_ptr<cudf::column> parse_uri_to_query(
+  cudf::strings_column_view const& input,
+  rmm::cuda_stream_view stream        = rmm::cuda_stream_default,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 }  // namespace spark_rapids_jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/ParseURI.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ParseURI.java
@@ -49,7 +49,18 @@ public class ParseURI {
     return new ColumnVector(parseHost(uriColumn.getNativeView()));
   }
 
+  /**
+   * Parse query for each URI from the incoming column.
+   *
+   * @param URIColumn The input strings column in which each row contains a URI.
+   * @return A string column with query data extracted.
+   */
+  public static ColumnVector parseURIQuery(ColumnView uriColumn) {
+    assert uriColumn.getType().equals(DType.STRING) : "Input type must be String";
+    return new ColumnVector(parseQuery(uriColumn.getNativeView()));
+  }
+
   private static native long parseProtocol(long jsonColumnHandle);
   private static native long parseHost(long jsonColumnHandle);
-
+  private static native long parseQuery(long jsonColumnHandle);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -25,9 +25,8 @@ import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
 
 public class ParseURITest {
-  void buildExpectedAndRun(String[] testData) {
+  void testProtocol(String[] testData) {
     String[] expectedProtocolStrings = new String[testData.length];
-    String[] expectedHostStrings = new String[testData.length];
     for (int i=0; i<testData.length; i++) {
       String scheme = null;
       try {
@@ -38,6 +37,18 @@ public class ParseURITest {
       } catch (NullPointerException ex) {
         // leave the scheme null if URI is null
       }
+      expectedProtocolStrings[i] = scheme;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expectedProtocol = ColumnVector.fromStrings(expectedProtocolStrings);
+      ColumnVector protocolResult = ParseURI.parseURIProtocol(v0)) {
+      AssertUtils.assertColumnsAreEqual(expectedProtocol, protocolResult);
+    }
+  }
+
+  void testHost(String[] testData) {
+    String[] expectedHostStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
       String host = null;
       try {
         URI uri = new URI(testData[i]);
@@ -48,25 +59,45 @@ public class ParseURITest {
         // leave the host null if URI is null
       }
 
-      expectedProtocolStrings[i] = scheme;
       expectedHostStrings[i] = host;
     }
     try (ColumnVector v0 = ColumnVector.fromStrings(testData);
-      ColumnVector expectedProtocol = ColumnVector.fromStrings(expectedProtocolStrings);
       ColumnVector expectedHost = ColumnVector.fromStrings(expectedHostStrings);
-      ColumnVector protocolResult = ParseURI.parseURIProtocol(v0);
       ColumnVector hostResult = ParseURI.parseURIHost(v0)) {
-      AssertUtils.assertColumnsAreEqual(expectedProtocol, protocolResult);
       AssertUtils.assertColumnsAreEqual(expectedHost, hostResult);
     }
   }
-  
+
+  void testQuery(String[] testData) {
+    String[] expectedQueryStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String query = null;
+      try {
+        URI uri = new URI(testData[i]);
+        query = uri.getQuery();
+      } catch (URISyntaxException ex) {
+        // leave the query null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the query null if URI is null
+      }
+
+      expectedQueryStrings[i] = query;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expectedQuery = ColumnVector.fromStrings(expectedQueryStrings);
+      ColumnVector queryResult = ParseURI.parseURIQuery(v0)) {
+      AssertUtils.assertColumnsAreEqual(expectedQuery, queryResult);
+    }
+  }
+
   @Test
-  void parseURIToProtocolSparkTest() {
+  void parseURISparkTest() {
     String[] testData = {
       "https://nvidia.com/https&#://nvidia.com",
       "https://http://www.nvidia.com",
-      "http://www.nvidia.com/object.php?object=ะก-\320%9Fะฑ-ะฟ-ะก\321%82\321%80ะตะป\321%8Cะฝะฐ-\321%83ะป-\320%97ะฐะฒะพะด\321%81ะบะฐ\321%8F.html&sid=5",
+      // commented out until https://github.com/NVIDIA/spark-rapids/issues/10036 is fixed
+      //"http://www.nvidia.com/object.php?object=ะก-Ð%9Fะฑ-ะฟ-ะกÑ%82Ñ%80ะตะปÑ%8Cะฝะฐ-Ñ%83ะป-Ð%97ะฐะฒะพะดÑ%81ะบะฐÑ%8F.htm",
+      "http://www.nvidia.com/object.php?object=ะก-Ðะฑ-ะฟ-ะกÑÑะตะปÑ%20ะฝะฐ-Ñะป-ÐะฐะฒะพะดÑะบะฐÑ.htm",
       "filesystemmagicthing://bob.yaml",
       "nvidia.com:8080",
       "http://thisisinvalid.data/due/to-the_character%s/inside*the#url`~",
@@ -104,29 +135,32 @@ public class ParseURITest {
       "http://[::2:3:4:5:6:7:8]",
       "http://[fe80::7:8%eth0]",
       "http://[fe80::7:8%1]",
-      "http://www.nvidia.com/object.php?object=ะก-\320%9Fะฑ-ะฟ-ะก\321%82\321%80ะตะป\321%8Cะฝะฐ-\321%83ะป-\320%97ะฐะฒะพะด\321%81ะบะฐ\321%8F.html&sid=5",
       "http://www.nvidia.com/picshow.asp?id=106&mnid=5080&classname=\271\253ืฐฦช",
       "http://-.~_!$&'()*+,;=:%40:80%2f::::::@nvidia.com:443",
       "http://userid:password@nvidia.com:8080/",
       "",
       null};
 
-    buildExpectedAndRun(testData);
+    testProtocol(testData);
+    testHost(testData);
+    testQuery(testData);
   }
 
   @Test
-  void parseURIToProtocolUTF8Test() {
+  void parseURIUTF8Test() {
     String[] testData = {
       "https:// /path/to/file",
       "https://nvidia.com/%4EV%49%44%49%41",
       "http://%77%77%77.%4EV%49%44%49%41.com",
       "http://✪↩d⁚f„⁈.ws/123"};
 
-    buildExpectedAndRun(testData);
+    testProtocol(testData);
+    testHost(testData);
+    testQuery(testData);
   }
 
   @Test
-  void parseURIToProtocolIP4Test() {
+  void parseURIIP4Test() {
     String[] testData = {
       "https://192.168.1.100/",
       "https://192.168.1.100:8443/",
@@ -134,11 +168,14 @@ public class ParseURITest {
       "https://192.168.1/",
       "https://280.100.1.1/",
       "https://182.168..100/path/to/file"};
-    buildExpectedAndRun(testData);
+
+    testProtocol(testData);
+    testHost(testData);
+    testQuery(testData);
   }
 
   @Test
-  void parseURIToProtocolIP6Test() {
+  void parseURIIP6Test() {
     String[] testData = {
       "https://[fe80::]",
       "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
@@ -160,6 +197,8 @@ public class ParseURITest {
       "http://[fe80::7:8%1]",
     };
     
-    buildExpectedAndRun(testData);
+    testProtocol(testData);
+    testHost(testData);
+    testQuery(testData);
   }
 }


### PR DESCRIPTION
This is the next step in the `parse_uri` support. This adds support to return the entire query. The only real difference from other support is the addition of `url_decode`. It was found that Spark decodes hex-escaped entries in the query, so this was added to support that. Possible optimization later to roll that logic into the parse kernel to remove the temp allocation.

This also brought to light a difference between cudf and Spark with decoding. Invalid UTF-8 characters are replaced in Spark with a replacement UTF-8 character and cudf will write invalid UTF-8 characters into the output. For example, `%9F` is an invalid UTF-8 character and the output of this code differs from Spark. The decision was made to file #10036 and move forward with this change. It is invalid to have this character in the string according to the RFC to begin with, but it is possible we can find it in the wild.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/1651