### PR TITLE
Make the GpuTimeZoneDB class idempotent

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -90,6 +90,8 @@ public class GpuTimeZoneDB {
   public static void shutdown() {
     if (instance.isLoaded()) {
       instance.close();
+      // Recreate a new instance to reload the database if necessary
+      instance = new GpuTimeZoneDB();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/10129.

The GpuTimeZoneDB class needs to be able to recover from `shutdown()` being called and potentially being revived again. This can happen when the executor plugin context is shutdown but the JVM is reused with a new executor plugin context.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
