### PR TITLE
Fix a bug in format_float kernel

### DIFF
--- a/src/main/cpp/tests/format_float.cpp
+++ b/src/main/cpp/tests/format_float.cpp
@@ -68,6 +68,8 @@ TEST_F(FormatFloatTests, FormatFloats64)
                                                    -4.0d,
                                                    std::numeric_limits<double>::quiet_NaN(),
                                                    839542223232.794248339d,
+                                                   3232.794248339d,
+                                                   11234000000.0d,
                                                    -0.0d};
 
   auto const expected = cudf::test::strings_column_wrapper{"100.00000",
@@ -80,6 +82,8 @@ TEST_F(FormatFloatTests, FormatFloats64)
                                                            "-4.00000",
                                                            "\xEF\xBF\xBD",
                                                            "839,542,223,232.79420",
+                                                           "3,232.79425",
+                                                           "11,234,000,000.00000",
                                                            "-0.00000"};
 
   auto results = spark_rapids_jni::format_float(floats, 5, cudf::get_default_stream());


### PR DESCRIPTION
`format_number(0.485362439659, 13)` will get 1.8536243965900 in the plugin. It's a kernel bug.

Current `round_half_even` will handle trailing zeros, but it's unnecessary because it will be handled later anyway, and it will confuse the following logic which checks the length of the rounded number.

Also add some minor refactoring and testing.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
