### PR TITLE
Add support for `parse_uri` to limit query with a column

### DIFF
--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -62,10 +62,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQuery(JNI
   CATCH_STD(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWithLiteral(JNIEnv* env,
-                                                                             jclass,
-                                                                             jlong input_column,
-                                                                             jstring query)
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWithLiteral(
+  JNIEnv* env, jclass, jlong input_column, jstring query)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, query, "query is null", 0);
@@ -74,7 +72,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     cudf::jni::native_jstring native_query(env, query);
-    return cudf::jni::ptr_as_jlong(spark_rapids_jni::parse_uri_to_query(*input, native_query.get()).release());
+    return cudf::jni::ptr_as_jlong(
+      spark_rapids_jni::parse_uri_to_query(*input, native_query.get()).release());
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -61,4 +61,21 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQuery(JNI
   }
   CATCH_STD(env, 0);
 }
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWithLiteral(JNIEnv* env,
+                                                                             jclass,
+                                                                             jlong input_column,
+                                                                             jstring query)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+  JNI_NULL_CHECK(env, query, "query is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    cudf::jni::native_jstring native_query(env, query);
+    return cudf::jni::ptr_as_jlong(spark_rapids_jni::parse_uri_to_query(*input, native_query.get()).release());
+  }
+  CATCH_STD(env, 0);
+}
 }

--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -88,8 +88,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     auto const query = reinterpret_cast<cudf::column_view const*>(query_column);
-    return cudf::jni::ptr_as_jlong(
-      spark_rapids_jni::parse_uri_to_query(*input, *query).release());
+    return cudf::jni::ptr_as_jlong(spark_rapids_jni::parse_uri_to_query(*input, *query).release());
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -77,4 +77,20 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
   }
   CATCH_STD(env, 0);
 }
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWithColumn(
+  JNIEnv* env, jclass, jlong input_column, jlong query_column)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+  JNI_NULL_CHECK(env, query_column, "query column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
+    auto const query = reinterpret_cast<cudf::column_view const*>(query_column);
+    return cudf::jni::ptr_as_jlong(
+      spark_rapids_jni::parse_uri_to_query(*input, *query).release());
+  }
+  CATCH_STD(env, 0);
+}
 }

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -993,4 +993,14 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
   return detail::parse_uri(input, detail::URI_chunks::QUERY, strings_column_view(*col), stream, mr);
 }
 
+std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const& input,
+                                                 cudf::strings_column_view const& query_match,
+                                                 rmm::cuda_stream_view stream,
+                                                 rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+
+  return detail::parse_uri(input, detail::URI_chunks::QUERY, query_match, stream, mr);
+}
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -629,7 +629,11 @@ uri_parts __device__ validate_uri(const char* str,
       // passed as param0, the return would simply be 5.
       if (query_match && query_match->size() > 0) {
         auto const match_idx = row_idx % query_match->size();
-        auto in_match        = query_match->element<string_view>(match_idx);
+        if (query_match->is_null(match_idx)) {
+          ret.valid = 0;
+          return ret;
+        }
+        auto in_match = query_match->element<string_view>(match_idx);
 
         auto const [query, valid] = find_query_part(ret.query, in_match);
         if (!valid) {

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -497,9 +497,10 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   auto const bytes       = needle.size_bytes();
   auto const find_length = haystack.size_bytes() - bytes + 1;
 
-  auto h = haystack.data();
-  auto n = needle.data();
-  for (size_type idx = 0; idx < find_length; ++idx) {
+  auto h           = haystack.data();
+  auto const end_h = haystack.data() + find_length;
+  auto n           = needle.data();
+  while (h < end_h) {
     bool match = true;
     for (size_type jdx = 0; match && (jdx < bytes); ++jdx) {
       match = (h[jdx] == n[jdx]);
@@ -508,8 +509,13 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
       // we don't care about the matched part, we want the string data after that.
       h += bytes;
       break;
+    } else {
+      // skip to the next param, which is after a &.
+      while (h < end_h && *h != '&') {
+        h++;
+      }
     }
-    ++h;
+    h++;
   }
 
   // if h is past the end of the haystack, no match.

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -494,7 +494,7 @@ bool __device__ validate_fragment(string_view fragment)
 
 __device__ std::pair<string_view, bool> find_query_part(string_view haystack, string_view needle)
 {
-  auto const bytes       = needle.size_bytes();
+  auto const n_bytes       = needle.size_bytes();
   auto const find_length = haystack.size_bytes() - bytes + 1;
 
   auto h           = haystack.data();
@@ -507,7 +507,7 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
     }
     if (match) {
       // we don't care about the matched part, we want the string data after that.
-      h += bytes;
+      h += n_bytes;
       break;
     } else {
       // skip to the next param, which is after a &.
@@ -627,7 +627,7 @@ uri_parts __device__ validate_uri(const char* str,
         auto const match_idx = row_idx % query_match->size();
         auto in_match        = query_match->element<string_view>(match_idx);
 
-        auto [query, valid] = find_query_part(ret.query, in_match);
+        auto const [query, valid] = find_query_part(ret.query, in_match);
         if (!valid) {
           ret.valid = 0;
           return ret;
@@ -976,7 +976,7 @@ std::unique_ptr<column> parse_uri_to_query(strings_column_view const& input,
 }
 
 std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const& input,
-                                                 std::string const query_match,
+                                                 std::string const& query_match,
                                                  rmm::cuda_stream_view stream,
                                                  rmm::mr::device_memory_resource* mr)
 {

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -629,15 +629,11 @@ uri_parts __device__ validate_uri(const char* str,
       // passed as param0, the return would simply be 5.
       if (query_match && query_match->size() > 0) {
         auto const match_idx = row_idx % query_match->size();
-<<<<<<< HEAD
         if (query_match->is_null(match_idx)) {
           ret.valid = 0;
           return ret;
         }
         auto in_match = query_match->element<string_view>(match_idx);
-=======
-        auto in_match = query_match->element<string_view>(match_idx);
->>>>>>> upstream/branch-24.02
 
         auto const [query, valid] = find_query_part(ret.query, in_match);
         if (!valid) {
@@ -1009,20 +1005,6 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
   CUDF_FUNC_RANGE();
 
   return detail::parse_uri(input, detail::URI_chunks::QUERY, query_match, stream, mr);
-}
-
-std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const& input,
-                                                 std::string const& query_match,
-                                                 rmm::cuda_stream_view stream,
-                                                 rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-
-  // build string_column_view from incoming query_match string
-  auto d_scalar = make_string_scalar(query_match, stream);
-  auto col      = make_column_from_scalar(*d_scalar, 1);
-
-  return detail::parse_uri(input, detail::URI_chunks::QUERY, strings_column_view(*col), stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -1003,6 +1003,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
                                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
+  CUDF_EXPECTS(input.size() == query_match.size(), "Query column must be the same size as input!");
 
   return detail::parse_uri(input, detail::URI_chunks::QUERY, query_match, stream, mr);
 }

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -65,4 +65,19 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+/**
+ * @brief Parse query and copy from the input string column to the output char buffer.
+ *
+ * @param input Input string column of URIs to parse.
+ * @param query_match String to match in query.
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column.
+ * @return std::unique_ptr<column> String column of queries parsed.
+ */
+std::unique_ptr<cudf::column> parse_uri_to_query(
+  cudf::strings_column_view const& input,
+  std::string const query_match,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -80,4 +80,19 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
+/**
+ * @brief Parse query and copy from the input string column to the output string column.
+ *
+ * @param input Input string column of URIs to parse.
+ * @param query_match string column to match in query.
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column.
+ * @return std::unique_ptr<column> String column of queries parsed.
+ */
+std::unique_ptr<cudf::column> parse_uri_to_query(
+  cudf::strings_column_view const& input,
+  cudf::strings_column_view const& query_match,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -66,7 +66,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Parse query and copy from the input string column to the output char buffer.
+ * @brief Parse query and copy from the input string column to the output string column.
  *
  * @param input Input string column of URIs to parse.
  * @param query_match String to match in query.
@@ -76,7 +76,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
  */
 std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
-  std::string const query_match,
+  std::string const& query_match,
   rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 

--- a/src/main/cpp/tests/parse_uri.cpp
+++ b/src/main/cpp/tests/parse_uri.cpp
@@ -395,4 +395,12 @@ TEST_F(ParseURIQueryTests, Queries)
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }
+  {
+    cudf::test::strings_column_wrapper const query({"param0", "q", "a", "invalid", "test", "query", "fakeparam0", "C"});
+    cudf::test::strings_column_wrapper const expected({"1", "", "b", "param", "", "1", "5", "C"}, {1, 0, 1, 1, 0, 1, 1, 1});
+
+    auto const result = spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, cudf::strings_column_view{query});
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+  }
 }

--- a/src/main/cpp/tests/parse_uri.cpp
+++ b/src/main/cpp/tests/parse_uri.cpp
@@ -134,6 +134,7 @@ cudf::test::strings_column_wrapper get_test_data(test_types t)
         "https://[::1]/?invalid=param&f„⁈.=7&param0=3",
         "https://[::1]/?invalid=param&param0=f„⁈&~.=!@&^",
         "userinfo@www.nvidia.com/path?query=1&param0=5#Ref",
+        "https://www.nvidia.com/path?brokenparam0=1&fakeparam0=5&param0=true",
       });
     default: CUDF_FAIL("Test type unsupported!"); return cudf::test::strings_column_wrapper();
   }
@@ -372,16 +373,17 @@ TEST_F(ParseURIQueryTests, Queries)
                                                        "a=b&param0=true",
                                                        "invalid=param&f„⁈.=7&param0=3",
                                                        "",
-                                                       "query=1&param0=5"},
-                                                      {1, 0, 1, 1, 0, 1});
+                                                       "query=1&param0=5",
+                                                       "brokenparam0=1&fakeparam0=5&param0=true"},
+                                                      {1, 0, 1, 1, 0, 1, 1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }
   {
     auto const result =
       spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, "param0");
-    cudf::test::strings_column_wrapper const expected({"1", "", "true", "3", "", "5"},
-                                                      {1, 0, 1, 1, 0, 1});
+    cudf::test::strings_column_wrapper const expected({"1", "", "true", "3", "", "5", "true"},
+                                                      {1, 0, 1, 1, 0, 1, 1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }

--- a/src/main/cpp/tests/parse_uri.cpp
+++ b/src/main/cpp/tests/parse_uri.cpp
@@ -396,10 +396,13 @@ TEST_F(ParseURIQueryTests, Queries)
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }
   {
-    cudf::test::strings_column_wrapper const query({"param0", "q", "a", "invalid", "test", "query", "fakeparam0", "C"});
-    cudf::test::strings_column_wrapper const expected({"1", "", "b", "param", "", "1", "5", "C"}, {1, 0, 1, 1, 0, 1, 1, 1});
+    cudf::test::strings_column_wrapper const query(
+      {"param0", "q", "a", "invalid", "test", "query", "fakeparam0", "C"});
+    cudf::test::strings_column_wrapper const expected({"1", "", "b", "param", "", "1", "5", "C"},
+                                                      {1, 0, 1, 1, 0, 1, 1, 1});
 
-    auto const result = spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, cudf::strings_column_view{query});
+    auto const result = spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col},
+                                                             cudf::strings_column_view{query});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }

--- a/src/main/cpp/tests/parse_uri.cpp
+++ b/src/main/cpp/tests/parse_uri.cpp
@@ -127,15 +127,15 @@ cudf::test::strings_column_wrapper get_test_data(test_types t)
         "https:// /path/to/file",
       });
     case test_types::QUERY:
-      return cudf::test::strings_column_wrapper({
-        "https://www.nvidia.com/path?param0=1&param2=3&param4=5",
-        "https:// /?params=5&cloth=0&metal=1&param0=param3",
-        "https://[2001:db8::2:1]:443/parms/in/the/uri?a=b&param0=true",
-        "https://[::1]/?invalid=param&f„⁈.=7&param0=3",
-        "https://[::1]/?invalid=param&param0=f„⁈&~.=!@&^",
-        "userinfo@www.nvidia.com/path?query=1&param0=5#Ref",
-        "https://www.nvidia.com/path?brokenparam0=1&fakeparam0=5&param0=true",
-      });
+      return cudf::test::strings_column_wrapper(
+        {"https://www.nvidia.com/path?param0=1&param2=3&param4=5",
+         "https:// /?params=5&cloth=0&metal=1&param0=param3",
+         "https://[2001:db8::2:1]:443/parms/in/the/uri?a=b&param0=true",
+         "https://[::1]/?invalid=param&f„⁈.=7&param0=3",
+         "https://[::1]/?invalid=param&param0=f„⁈&~.=!@&^",
+         "userinfo@www.nvidia.com/path?query=1&param0=5#Ref",
+         "https://www.nvidia.com/path?brokenparam0=1&fakeparam0=5&param0=true",
+         "http://nvidia.com?CBA=CBA&C=C"});
     default: CUDF_FAIL("Test type unsupported!"); return cudf::test::strings_column_wrapper();
   }
 }
@@ -374,16 +374,24 @@ TEST_F(ParseURIQueryTests, Queries)
                                                        "invalid=param&f„⁈.=7&param0=3",
                                                        "",
                                                        "query=1&param0=5",
-                                                       "brokenparam0=1&fakeparam0=5&param0=true"},
-                                                      {1, 0, 1, 1, 0, 1, 1});
+                                                       "brokenparam0=1&fakeparam0=5&param0=true",
+                                                       "CBA=CBA&C=C"},
+                                                      {1, 0, 1, 1, 0, 1, 1, 1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }
   {
     auto const result =
       spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, "param0");
-    cudf::test::strings_column_wrapper const expected({"1", "", "true", "3", "", "5", "true"},
-                                                      {1, 0, 1, 1, 0, 1, 1});
+    cudf::test::strings_column_wrapper const expected({"1", "", "true", "3", "", "5", "true", ""},
+                                                      {1, 0, 1, 1, 0, 1, 1, 0});
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
+  }
+  {
+    auto const result = spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, "C");
+    cudf::test::strings_column_wrapper const expected({"", "", "", "", "", "", "", "C"},
+                                                      {0, 0, 0, 0, 0, 0, 0, 1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }

--- a/src/main/cpp/tests/parse_uri.cpp
+++ b/src/main/cpp/tests/parse_uri.cpp
@@ -362,26 +362,26 @@ TEST_F(ParseURIQueryTests, SparkEdges)
 
 TEST_F(ParseURIQueryTests, Queries)
 {
-  auto const col    = get_test_data(test_types::QUERY);
+  auto const col = get_test_data(test_types::QUERY);
 
   {
     auto const result = spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col});
 
-    cudf::test::strings_column_wrapper const expected(
-      {"param0=1&param2=3&param4=5", "", "a=b&param0=true", "invalid=param&f„⁈.=7&param0=3", "", "query=1&param0=5"},
-      {1, 0, 1, 1, 0, 1});
+    cudf::test::strings_column_wrapper const expected({"param0=1&param2=3&param4=5",
+                                                       "",
+                                                       "a=b&param0=true",
+                                                       "invalid=param&f„⁈.=7&param0=3",
+                                                       "",
+                                                       "query=1&param0=5"},
+                                                      {1, 0, 1, 1, 0, 1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }
   {
-    auto const result = spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, "param0");
-    cudf::test::strings_column_wrapper const expected(
-      {"1",
-          "",
-          "true",
-          "3",
-          "",
-          "5"}, {1, 0, 1, 1, 0, 1});
+    auto const result =
+      spark_rapids_jni::parse_uri_to_query(cudf::strings_column_view{col}, "param0");
+    cudf::test::strings_column_wrapper const expected({"1", "", "true", "3", "", "5"},
+                                                      {1, 0, 1, 1, 0, 1});
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
   }

--- a/src/main/java/com/nvidia/spark/rapids/jni/ParseURI.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ParseURI.java
@@ -60,7 +60,20 @@ public class ParseURI {
     return new ColumnVector(parseQuery(uriColumn.getNativeView()));
   }
 
+  /**
+   * Parse query and return a specific parameter for each URI from the incoming column.
+   *
+   * @param URIColumn The input strings column in which each row contains a URI.
+   * @param String The parameter to extract from the query
+   * @return A string column with query data extracted.
+   */
+  public static ColumnVector parseURIQueryWithLiteral(ColumnView uriColumn, String query) {
+    assert uriColumn.getType().equals(DType.STRING) : "Input type must be String";
+    return new ColumnVector(parseQueryWithLiteral(uriColumn.getNativeView(), query));
+  }
+
   private static native long parseProtocol(long jsonColumnHandle);
   private static native long parseHost(long jsonColumnHandle);
   private static native long parseQuery(long jsonColumnHandle);
+  private static native long parseQueryWithLiteral(long jsonColumnHandle, String query);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/ParseURI.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ParseURI.java
@@ -72,8 +72,22 @@ public class ParseURI {
     return new ColumnVector(parseQueryWithLiteral(uriColumn.getNativeView(), query));
   }
 
-  private static native long parseProtocol(long jsonColumnHandle);
-  private static native long parseHost(long jsonColumnHandle);
-  private static native long parseQuery(long jsonColumnHandle);
-  private static native long parseQueryWithLiteral(long jsonColumnHandle, String query);
+    /**
+   * Parse query and return a specific parameter for each URI from the incoming column.
+   *
+   * @param URIColumn The input strings column in which each row contains a URI.
+   * @param String The parameter to extract from the query
+   * @return A string column with query data extracted.
+   */
+  public static ColumnVector parseURIQueryWithColumn(ColumnView uriColumn, ColumnView queryColumn) {
+    assert uriColumn.getType().equals(DType.STRING) : "Input type must be String";
+    assert queryColumn.getType().equals(DType.STRING) : "Query type must be String";
+    return new ColumnVector(parseQueryWithColumn(uriColumn.getNativeView(), queryColumn.getNativeView()));
+  }
+
+  private static native long parseProtocol(long inputColumnHandle);
+  private static native long parseHost(long inputColumnHandle);
+  private static native long parseQuery(long inputColumnHandle);
+  private static native long parseQueryWithLiteral(long inputColumnHandle, String query);
+  private static native long parseQueryWithColumn(long inputColumnHandle, long queryColumnHandle);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -216,10 +216,67 @@ public class ParseURITest {
       "",
       null};
   
+
+      String[] queries = {
+        "a",
+        "h",
+        // commented out until https://github.com/NVIDIA/spark-rapids/issues/10036 is fixed
+        //"object",
+        "object",
+        "a",
+        "h",
+        "a",
+        "f",
+        "g",
+        "a",
+        "a",
+        "f",
+        "g",
+        "a",
+        "a",
+        "b",
+        "a",
+        "",
+        "a",
+        "a",
+        "a",
+        "a",
+        "b",
+        "a",
+        "q",
+        "b",
+        "a",
+        "query",
+        "a",
+        "primekey_in",
+        "a",
+        "q",
+        "ExpertId",
+        "query",
+        "solutionId",
+        "f",
+        "param",
+        "",
+        "q",
+        "a",
+        "f",
+        "mnid=5080",
+        "f",
+        "a",
+        "param4",
+        "cloth",
+        "a",
+        "invalid",
+        "invalid",
+        "query",
+        "a",
+        "f"};
+
     testProtocol(testData);
     testHost(testData);
     testQuery(testData);
     testQuery(testData, "query");
+    testQuery(testData, queries);
   }
 
   @Test

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -90,6 +90,35 @@ public class ParseURITest {
     }
   }
 
+  void testQuery(String[] testData, String param) {
+    String[] expectedQueryStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String query = null;
+      try {
+        URI uri = new URI(testData[i]);
+        query = uri.getRawQuery();
+      } catch (URISyntaxException ex) {
+        // leave the query null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the query null if URI is null
+      }
+
+      String[] pairs = query.split("&");
+      for (String pair : pairs) {
+        int idx = pair.indexOf("=");
+        if (pair.substring(0, idx) == param) {
+          expectedQueryStrings[i] = pair.substring(idx + 1);
+          break;
+        }
+      }
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector expectedQuery = ColumnVector.fromStrings(expectedQueryStrings);
+      ColumnVector queryResult = ParseURI.parseURIQueryWithLiteral(v0, param)) {
+      AssertUtils.assertColumnsAreEqual(expectedQuery, queryResult);
+    }
+  }
+
   @Test
   void parseURISparkTest() {
     String[] testData = {

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
 
-import java.util.Arrays;
-
 public class ParseURITest {
   void testProtocol(String[] testData) {
     String[] expectedProtocolStrings = new String[testData.length];
@@ -110,26 +108,18 @@ public class ParseURITest {
       if (query != null) {
         String[] pairs = query.split("&");
         for (String pair : pairs) {
-          System.out.println(pair);
           int idx = pair.indexOf("=");
-          if (idx > 0) {
-            System.out.println("comparing '" + pair.substring(0, idx) + "' and '" + param + "'");
-            if (pair.substring(0, idx).equals(param)) {
-              System.out.println("found a match...");
+          if (idx > 0 && pair.substring(0, idx).equals(param)) {
             subquery = pair.substring(idx + 1);
             break;
-            }
           }
         }
       }
       expectedQueryStrings[i] = subquery;
     }
-    System.out.println("Expected Strings:");
-    System.out.println(Arrays.toString(expectedQueryStrings));
     try (ColumnVector v0 = ColumnVector.fromStrings(testData);
       ColumnVector expectedQuery = ColumnVector.fromStrings(expectedQueryStrings);
       ColumnVector queryResult = ParseURI.parseURIQueryWithLiteral(v0, param)) {
-      //throw new IllegalArgumentException(expectedQueryStrings.toString());
       AssertUtils.assertColumnsAreEqual(expectedQuery, queryResult);
     }
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -124,6 +124,41 @@ public class ParseURITest {
     }
   }
 
+  void testQuery(String[] testData, String[] params) {
+    String[] expectedQueryStrings = new String[testData.length];
+    for (int i=0; i<testData.length; i++) {
+      String query = null;
+      try {
+        URI uri = new URI(testData[i]);
+        query = uri.getRawQuery();
+      } catch (URISyntaxException ex) {
+        // leave the query null if URI is invalid
+      } catch (NullPointerException ex) {
+        // leave the query null if URI is null
+      }
+
+      String subquery = null;
+
+      if (query != null) {
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+          int idx = pair.indexOf("=");
+          if (idx > 0 && pair.substring(0, idx).equals(params[i])) {
+            subquery = pair.substring(idx + 1);
+            break;
+          }
+        }
+      }
+      expectedQueryStrings[i] = subquery;
+    }
+    try (ColumnVector v0 = ColumnVector.fromStrings(testData);
+      ColumnVector p0 = ColumnVector.fromStrings(params);
+      ColumnVector expectedQuery = ColumnVector.fromStrings(expectedQueryStrings);
+      ColumnVector queryResult = ParseURI.parseURIQueryWithColumn(v0, p0)) {
+      AssertUtils.assertColumnsAreEqual(expectedQuery, queryResult);
+    }
+  }
+
   @Test
   void parseURISparkTest() {
     String[] testData = {

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
 
+import java.util.Arrays;
+
 public class ParseURITest {
   void testProtocol(String[] testData) {
     String[] expectedProtocolStrings = new String[testData.length];
@@ -103,18 +105,31 @@ public class ParseURITest {
         // leave the query null if URI is null
       }
 
-      String[] pairs = query.split("&");
-      for (String pair : pairs) {
-        int idx = pair.indexOf("=");
-        if (pair.substring(0, idx) == param) {
-          expectedQueryStrings[i] = pair.substring(idx + 1);
-          break;
+      String subquery = null;
+
+      if (query != null) {
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+          System.out.println(pair);
+          int idx = pair.indexOf("=");
+          if (idx > 0) {
+            System.out.println("comparing '" + pair.substring(0, idx) + "' and '" + param + "'");
+            if (pair.substring(0, idx).equals(param)) {
+              System.out.println("found a match...");
+            subquery = pair.substring(idx + 1);
+            break;
+            }
+          }
         }
       }
+      expectedQueryStrings[i] = subquery;
     }
+    System.out.println("Expected Strings:");
+    System.out.println(Arrays.toString(expectedQueryStrings));
     try (ColumnVector v0 = ColumnVector.fromStrings(testData);
       ColumnVector expectedQuery = ColumnVector.fromStrings(expectedQueryStrings);
       ColumnVector queryResult = ParseURI.parseURIQueryWithLiteral(v0, param)) {
+      //throw new IllegalArgumentException(expectedQueryStrings.toString());
       AssertUtils.assertColumnsAreEqual(expectedQuery, queryResult);
     }
   }
@@ -179,6 +194,7 @@ public class ParseURITest {
     testProtocol(testData);
     testHost(testData);
     testQuery(testData);
+    testQuery(testData, "query");
   }
 
   @Test
@@ -192,6 +208,7 @@ public class ParseURITest {
     testProtocol(testData);
     testHost(testData);
     testQuery(testData);
+    testQuery(testData, "query");
   }
 
   @Test
@@ -207,6 +224,7 @@ public class ParseURITest {
     testProtocol(testData);
     testHost(testData);
     testQuery(testData);
+    testQuery(testData, "query");
   }
 
   @Test
@@ -235,5 +253,6 @@ public class ParseURITest {
     testProtocol(testData);
     testHost(testData);
     testQuery(testData);
+    testQuery(testData, "query");
   }
 }


### PR DESCRIPTION
This PR adds support for a column to select the parameter for each row in a URI.

Branched off of #1704 and is draft until that PR is merged.

Closes #1718