### PR TITLE
Fix build warnings of chars and make_strings_column

### DIFF
--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -520,7 +520,7 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
   return cudf::make_strings_column(
     num_rows,
     std::move(offsets),
-    std::move(chars),
+    std::move(chars->release().data.release()[0]),
     profile.get_null_frequency().has_value() ? std::move(result_bitmask) : rmm::device_buffer{},
     null_count);
 }

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -191,7 +191,7 @@ struct dispatch_decimal_to_non_ansi_string_fn {
 
     return make_strings_column(input.size(),
                                std::move(offsets),
-                               std::move(chars),
+                               std::move(chars->release().data.release()[0]),
                                input.null_count(),
                                cudf::detail::copy_bitmask(input, stream, mr));
   }

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -88,7 +88,7 @@ struct dispatch_float_to_string_fn {
 
     return make_strings_column(strings_count,
                                std::move(offsets),
-                               std::move(chars),
+                               std::move(chars->release().data.release()[0]),
                                floats.null_count(),
                                cudf::detail::copy_bitmask(floats, stream, mr));
   }

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -624,7 +624,7 @@ void validate_ansi_column(column_view const& col,
     dest.resize(string_bounds[1] - string_bounds[0]);
 
     cudaMemcpyAsync(dest.data(),
-                    &source_col.chars().data<char const>()[string_bounds[0]],
+                    &source_col.chars_begin(stream)[string_bounds[0]],
                     string_bounds[1] - string_bounds[0],
                     cudaMemcpyDeviceToHost,
                     stream.value());
@@ -667,7 +667,7 @@ struct string_to_integer_impl {
     detail::string_to_integer_kernel<<<blocks, threads, 0, stream.value()>>>(
       data.data(),
       null_mask.data(),
-      string_col.chars().data<char const>(),
+      string_col.chars_begin(stream),
       string_col.offsets().data<size_type>(),
       string_col.null_mask(),
       string_col.size(),
@@ -736,7 +736,7 @@ struct string_to_decimal_impl {
     detail::string_to_decimal_kernel<<<blocks, threads, 0, stream.value()>>>(
       data.data(),
       null_mask.data(),
-      string_col.chars().data<char const>(),
+      string_col.chars_begin(stream),
       string_col.offsets().data<size_type>(),
       string_col.null_mask(),
       string_col.size(),

--- a/src/main/cpp/src/format_float.cu
+++ b/src/main/cpp/src/format_float.cu
@@ -89,7 +89,7 @@ struct dispatch_format_float_fn {
 
     return cudf::make_strings_column(strings_count,
                                      std::move(offsets),
-                                     std::move(chars),
+                                     std::move(chars->release().data.release()[0]),
                                      floats.null_count(),
                                      cudf::detail::copy_bitmask(floats, stream, mr));
   }

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -575,8 +575,11 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
 
   auto children = cudf::strings::detail::make_strings_children(
     substring_fn{unified_json_buff, extract_ranges}, num_extract, stream, mr);
-  return cudf::make_strings_column(
-    num_extract, std::move(children.first), std::move(children.second), 0, rmm::device_buffer{});
+  return cudf::make_strings_column(num_extract,
+                                   std::move(children.first),
+                                   std::move(children.second->release().data.release()[0]),
+                                   0,
+                                   rmm::device_buffer{});
 }
 
 // Compute the offsets for the final lists of Struct<String,String>.


### PR DESCRIPTION
Fixes #1724 

There are many warnings when building jni now because cudf deprecated `cudf::make_strings_column` with typed offsets and `cudf::strings_column_view::chars`.

This PR replace those api usage with non-deprecated apis.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
