### PR TITLE
[auto-merge] bot-auto-merge-branch-24.02 to branch-24.04 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-      - branch-23.12
+      - branch-24.02
     types: [closed]
 
 env:
-  HEAD: branch-23.12
-  BASE: branch-24.02
+  HEAD: branch-24.02
+  BASE: branch-24.04
 
 jobs:
   auto-merge:


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-24.02` to create a PR keeping `branch-24.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.