### PR TITLE
Fix a parse_uri query bug

### DIFF
--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -500,9 +500,10 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   auto h           = haystack.data();
   auto const end_h = haystack.data() + find_length;
   auto n           = needle.data();
+  bool match       = false;
   while (h < end_h) {
-    bool match = true;
-    for (size_type jdx = 0; match && (jdx < n_bytes); ++jdx) {
+    match = false;
+    for (size_type jdx = 0; (jdx == 0 || match) && (jdx < n_bytes); ++jdx) {
       match = (h[jdx] == n[jdx]);
     }
     if (match) { match = n_bytes < haystack.size_bytes() && h[n_bytes] == '='; }
@@ -520,7 +521,7 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   }
 
   // if h is past the end of the haystack, no match.
-  if (haystack.data() + haystack.size_bytes() <= h || *h != '=') { return {{}, false}; }
+  if (!match || *h != '=') { return {{}, false}; }
 
   // skip over the =
   h++;

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -214,8 +214,11 @@ public class ParseURITest {
       "https://[::1]/?invalid=param&~.=!@&^",
       "userinfo@www.nvidia.com/path?query=1#Ref",
       "",
-      null};
-  
+      null,
+      "https://www.nvidia.com/?cat=12",
+      "www.nvidia.com/vote.php?pid=50",
+      "https://www.nvidia.com/vote.php?=50",
+    };
 
       String[] queries = {
         "a",
@@ -270,7 +273,11 @@ public class ParseURITest {
         "invalid",
         "query",
         "a",
-        "f"};
+        "f",
+        "query",
+        "query",
+        ""
+      };
 
     testProtocol(testData);
     testHost(testData);


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-jni/issues/1735

This pr fixes s small bug in the parse_uri query kernel: If the last value of key in query part has length of **exactly strlen(query)-3** or **0**, and query with a key that can't match, gpu will returns last value.

Tested the kernel with kaggle dataset and got passed, I think now it is correct enough.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
