### PR TITLE
Fix a out of bound bug in parse_url query

### DIFF
--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -501,7 +501,7 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
 
   // stop matching early after it can no longer contain the string we are searching for
   while (h + n_bytes < h_end) {
-    bool match_needle = false;  // initialize to false to prevent empty query key
+    bool match_needle = true;
     for (size_type jdx = 0; jdx < n_bytes; ++jdx) {
       match_needle = (h[jdx] == n[jdx]);
       if (!match_needle) { break; }

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -503,8 +503,7 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   bool match       = false;
   while (h < end_h) {
     match = false;  // initialize to false to prevent empty query key
-    for (size_type jdx = 0; (jdx == 0 || match) && (jdx < n_bytes) && (jdx < haystack.size_bytes());
-         ++jdx) {
+    for (size_type jdx = 0; (jdx == 0 || match) && (jdx < n_bytes); ++jdx) {
       match = (h[jdx] == n[jdx]);
     }
     if (match) { match = n_bytes < haystack.size_bytes() && h[n_bytes] == '='; }

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -496,7 +496,7 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
 {
   auto const n_bytes = needle.size_bytes();
   auto h             = haystack.data();
-  auto h_end         = h + haystack.size_bytes();
+  auto const h_end   = h + haystack.size_bytes();
   auto n             = needle.data();
 
   bool match = false;

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -499,10 +499,9 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   auto const h_end   = h + haystack.size_bytes();
   auto n             = needle.data();
 
-  bool match = false;
   // stop matching early after it can no longer contain the string we are searching for
   while (h + n_bytes < h_end) {
-    match = false;  // initialize to false to prevent empty query key
+    bool match_needle = false;  // initialize to false to prevent empty query key
     for (size_type jdx = 0; jdx < n_bytes; ++jdx) {
       match = (h[jdx] == n[jdx]);
       if (!match) { break; }

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -508,10 +508,8 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
     }
 
     if (match_needle && h[n_bytes] == '=') {
-      // we don't care about the matched part, we want the string data after that.
-      h += n_bytes;
-      // skip over the =
-      h++;
+      // we don't care about the matched part, we want the string data after '='
+      h += n_bytes + 1;
 
       // rest of string until end or until '&' is query match
       int match_len = 0;
@@ -528,7 +526,7 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
     while (h + n_bytes < h_end && *h != '&') {
       h++;
     }
-    h++;  // skip over the &
+    h++;  // skip over the & if has, or point to h_end +1
   }
 
   return {{}, false};

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -495,7 +495,7 @@ bool __device__ validate_fragment(string_view fragment)
 __device__ std::pair<string_view, bool> find_query_part(string_view haystack, string_view needle)
 {
   auto const n_bytes     = needle.size_bytes();
-  auto const find_length = haystack.size_bytes() - n_bytes + 1;
+  auto const find_length = haystack.size_bytes() - n_bytes;
 
   auto h           = haystack.data();
   auto const end_h = haystack.data() + find_length;
@@ -503,7 +503,8 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   bool match       = false;
   while (h < end_h) {
     match = false;  // initialize to false to prevent empty query key
-    for (size_type jdx = 0; (jdx == 0 || match) && (jdx < n_bytes); ++jdx) {
+    for (size_type jdx = 0; (jdx == 0 || match) && (jdx < n_bytes) && (jdx < haystack.size_bytes());
+         ++jdx) {
       match = (h[jdx] == n[jdx]);
     }
     if (match) { match = n_bytes < haystack.size_bytes() && h[n_bytes] == '='; }

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -503,11 +503,11 @@ __device__ std::pair<string_view, bool> find_query_part(string_view haystack, st
   while (h + n_bytes < h_end) {
     bool match_needle = false;  // initialize to false to prevent empty query key
     for (size_type jdx = 0; jdx < n_bytes; ++jdx) {
-      match = (h[jdx] == n[jdx]);
-      if (!match) { break; }
+      match_needle = (h[jdx] == n[jdx]);
+      if (!match_needle) { break; }
     }
 
-    if (match && h[n_bytes] == '=') {
+    if (match_needle && h[n_bytes] == '=') {
       // we don't care about the matched part, we want the string data after that.
       h += n_bytes;
       // skip over the =

--- a/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ParseURITest.java
@@ -143,7 +143,7 @@ public class ParseURITest {
         String[] pairs = query.split("&");
         for (String pair : pairs) {
           int idx = pair.indexOf("=");
-          if (idx > 0 && pair.substring(0, idx).equals(params[i])) {
+          if (idx >= 0 && pair.substring(0, idx).equals(params[i])) {
             subquery = pair.substring(idx + 1);
             break;
           }
@@ -218,6 +218,7 @@ public class ParseURITest {
       "https://www.nvidia.com/?cat=12",
       "www.nvidia.com/vote.php?pid=50",
       "https://www.nvidia.com/vote.php?=50",
+      "https://www.nvidia.com/vote.php?query=50"
     };
 
       String[] queries = {
@@ -276,6 +277,7 @@ public class ParseURITest {
         "f",
         "query",
         "query",
+        "",
         ""
       };
 


### PR DESCRIPTION
Fixes #1745 

#1740 adds new test cases `"https://www.nvidia.com/vote.php?=50"` as url and `""` (empty string) as key in a parse_url query with a key kernel, which will lead to an out of bound issue detected by compute sanitizer.

In the following code:

```diff
__device__ std::pair<string_view, bool> find_query_part(string_view haystack, string_view needle)
{
  auto const n_bytes     = needle.size_bytes();
- auto const find_length = haystack.size_bytes() - n_bytes + 1;
+ auto const find_length = haystack.size_bytes() - n_bytes;

  auto h           = haystack.data();
  auto const end_h = haystack.data() + find_length;
  auto n           = needle.data();
  bool match       = false;
  while (h < end_h) {
    match = false;  // initialize to false to prevent empty query key
    for (size_type jdx = 0; (jdx == 0 || match) && (jdx < n_bytes); ++jdx) {
      match = (h[jdx] == n[jdx]);
    }
    if (match) { match = n_bytes < haystack.size_bytes() && h[n_bytes] == '='; }
    if (match) {
      // we don't care about the matched part, we want the string data after that.
      h += n_bytes;
      break;
    } else {
      // skip to the next param, which is after a &.
      while (h < end_h && *h != '&') {
        h++;
      }
    }
    h++;
  }

  // if not match or no value, return nothing
  if (!match || *h != '=') { return {{}, false}; }

  // skip over the =
  h++;

  // rest of string until end or until '&' is query match
  auto const bytes_left = haystack.size_bytes() - (h - haystack.data());
  int match_len         = 0;
  auto start            = h;
  while (*h != '&' && match_len < bytes_left) {
    ++match_len;
    ++h;
  }

  return {{start, match_len}, true};
}
```

when pass haystack = "=50" and needle = "" in, the find_length will be 3 - 0 + 1 = 4, so in line:

```cpp
while (h < end_h && *h != '&') {
```
h will be out of bound.

We use `find_length` to stop matching early after it can no longer contain the string we are searching for, and `find_length = haystack.size_bytes() - n_bytes` is a tighter bound for it.

This PR will unblock CI and submodule-sync, Integration tests and big dataset test passed from plugin side.

(I decide to keep `-DUSE_SANITIZER=ON` in my build command forever...)

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
