### PR TITLE
Make changes needed to have all host allocations go through a single plugable API

### DIFF
--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -807,7 +807,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_seriali
     transportOut->getBuffer(&buf_ptr, &buf_size);
 
     // 12 extra is for the MAGIC thrift_footer length MAGIC
-    jobject ret = cudf::jni::allocate_host_buffer(env, buf_size + 12, false);
+    jobject ret       = cudf::jni::allocate_host_buffer(env, buf_size + 12, false);
     uint8_t* ret_addr = reinterpret_cast<uint8_t*>(cudf::jni::get_host_buffer_address(env, ret));
     ret_addr[0]       = 'P';
     ret_addr[1]       = 'A';

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -791,7 +791,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumCol
 }
 
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_serializeThriftFile(
-  JNIEnv* env, jclass, jlong handle, jobject host_memory_allocator)
+  JNIEnv* env, jclass, jlong handle)
 {
   CUDF_FUNC_RANGE();
   try {
@@ -807,7 +807,7 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_seriali
     transportOut->getBuffer(&buf_ptr, &buf_size);
 
     // 12 extra is for the MAGIC thrift_footer length MAGIC
-    jobject ret = cudf::jni::allocate_host_buffer(env, buf_size + 12, false, host_memory_allocator);
+    jobject ret = cudf::jni::allocate_host_buffer(env, buf_size + 12, false);
     uint8_t* ret_addr = reinterpret_cast<uint8_t*>(cudf::jni::get_host_buffer_address(env, ret));
     ret_addr[0]       = 'P';
     ret_addr[1]       = 'A';

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1758,9 +1758,9 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
     auto const tid    = static_cast<long>(pthread_self());
     auto const thread = threads.find(tid);
     if (thread != threads.end()) {
-      log_status("DEALLOC", tid, thread->second.task_id, thread->second.state);
+      log_status(is_for_cpu? "CPU_DEALLOC" : "DEALLOC", tid, thread->second.task_id, thread->second.state);
     } else {
-      log_status("DEALLOC", tid, -2, thread_state::UNKNOWN);
+      log_status(is_for_cpu? "CPU_DEALLOC" : "DEALLOC", tid, -2, thread_state::UNKNOWN);
     }
 
     for (auto& [thread_id, t_state] : threads) {

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1758,9 +1758,10 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
     auto const tid    = static_cast<long>(pthread_self());
     auto const thread = threads.find(tid);
     if (thread != threads.end()) {
-      log_status(is_for_cpu? "CPU_DEALLOC" : "DEALLOC", tid, thread->second.task_id, thread->second.state);
+      log_status(
+        is_for_cpu ? "CPU_DEALLOC" : "DEALLOC", tid, thread->second.task_id, thread->second.state);
     } else {
-      log_status(is_for_cpu? "CPU_DEALLOC" : "DEALLOC", tid, -2, thread_state::UNKNOWN);
+      log_status(is_for_cpu ? "CPU_DEALLOC" : "DEALLOC", tid, -2, thread_state::UNKNOWN);
     }
 
     for (auto& [thread_id, t_state] : threads) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/ParquetFooter.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ParquetFooter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/ParquetFooter.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ParquetFooter.java
@@ -103,12 +103,8 @@ public class ParquetFooter implements AutoCloseable {
    * footer file. This will include the MAGIC PAR1 at the beginning and end and also the
    * length of the footer just before the PAR1 at the end.
    */
-  public HostMemoryBuffer serializeThriftFile(HostMemoryAllocator hostMemoryAllocator) {
-    return serializeThriftFile(nativeHandle, hostMemoryAllocator);
-  }
-
   public HostMemoryBuffer serializeThriftFile() {
-    return serializeThriftFile(DefaultHostMemoryAllocator.get());
+    return serializeThriftFile(nativeHandle);
   }
 
   /**
@@ -236,6 +232,5 @@ public class ParquetFooter implements AutoCloseable {
 
   private static native int getNumColumns(long nativeHandle);
 
-  private static native HostMemoryBuffer serializeThriftFile(long nativeHandle,
-    HostMemoryAllocator hostMemoryAllocator);
+  private static native HostMemoryBuffer serializeThriftFile(long nativeHandle);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,19 @@ public class SparkResourceAdaptor
    * Force the thread with the given ID to throw a GpuRetryOOM on their next allocation attempt.
    * @param threadId the ID of the thread to throw the exception (not java thread id).
    * @param numOOMs the number of times the GpuRetryOOM should be thrown
+   * @param oom the type of OOM ot inject
+   * @param skipCount the number of times a matching allocation is skipped before injecting the first OOM
+   */
+  public void forceRetryOOM(long threadId, int numOOMs, OomInjectionType oom, int skipCount) {
+    validateOOMInjectionParams(numOOMs, oom.getId(), skipCount);
+    forceRetryOOM(getHandle(), threadId, numOOMs, oom.getId(), skipCount);
+  }
+
+  // TODO this should be removed one we move the tests over to use the enum.
+  /**
+   * Force the thread with the given ID to throw a GpuRetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numOOMs the number of times the GpuRetryOOM should be thrown
    * @param oomMode ordinal of the corresponding RmmSpark.OomInjectionType
    * @param skipCount the number of times a matching allocation is skipped before injecting the first OOM
    */
@@ -203,6 +216,19 @@ public class SparkResourceAdaptor
       "non-negative oomMode<" + OomInjectionType.values().length + " expected: actual=" + oomMode;
   }
 
+  /**
+   * Force the thread with the given ID to throw a GpuSplitAndRetryOOM on their next allocation attempt.
+   * @param threadId the ID of the thread to throw the exception (not java thread id).
+   * @param numOOMs the number of times the GpuSplitAndRetryOOM should be thrown
+   * @param oom the type of OOM ot inject
+   * @param skipCount the number of times a matching allocation is skipped before injecting the first OOM
+   */
+  public void forceSplitAndRetryOOM(long threadId, int numOOMs, OomInjectionType oom, int skipCount) {
+    validateOOMInjectionParams(numOOMs, oom.getId(), skipCount);
+    forceSplitAndRetryOOM(getHandle(), threadId, numOOMs, oom.getId(), skipCount);
+  }
+
+  // TODO this should be removed one we move the tests over to use the enum.
   /**
    * Force the thread with the given ID to throw a GpuSplitAndRetryOOM on their next allocation attempt.
    * @param threadId the ID of the thread to throw the exception (not java thread id).
@@ -250,7 +276,6 @@ public class SparkResourceAdaptor
   public long getAndResetComputeTimeLostToRetry(long taskId) {
     return getAndResetComputeTimeLostToRetry(getHandle(), taskId);
   }
-
 
   /**
    * Called before doing an allocation on the CPU. This could throw an injected exception to help


### PR DESCRIPTION
https://github.com/rapidsai/cudf/pull/15026 makes it so that we can have all host memory allocations go through a plugable API. This fixes any build incompatibility with that change so that spark-rapids-jni can continue to work. It also cleans up a few small things, like making the logging for RMM deallocations to do the right thing for CPU vs GPU memory, and updates the injection APIs to take an enum instead of the ordinal for the enum.  The other two are minor, but I thought made the code base cleaner and less error prone.