### PR TITLE
get-json-object:  Add JSON parser and parser utility

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(
   src/cast_string_to_float.cu
   src/datetime_rebase.cu
   src/decimal_utils.cu
+  src/get_json_object.cu
   src/histogram.cu
   src/map_utils.cu
   src/murmur_hash.cu

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "get_json_object.hpp"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/copy.hpp>
+#include <cudf/detail/get_value.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/offsets_iterator_factory.cuh>
+#include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/json/json.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/strings/detail/strings_children.cuh>
+#include <cudf/strings/detail/utilities.hpp>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/optional.h>
+#include <thrust/pair.h>
+#include <thrust/scan.h>
+#include <thrust/tuple.h>
+
+namespace spark_rapids_jni {
+
+namespace detail {
+// namespace {
+
+/**
+ * write JSON style
+ */
+enum class write_style { raw_style, quoted_style, flatten_style };
+
+/**
+ * path instruction type
+ */
+enum class path_instruction_type { subscript, wildcard, key, index, named };
+
+/**
+ * path instruction
+ */
+struct path_instruction {
+  CUDF_HOST_DEVICE inline path_instruction(path_instruction_type _type) : type(_type) {}
+
+  path_instruction_type type;
+
+  // used when type is named type
+  cudf::string_view name;
+
+  // used when type is index
+  int index{-1};
+};
+
+// TODO parse JSON path
+thrust::optional<rmm::device_uvector<path_instruction>> parse_path(
+  cudf::string_scalar const& json_path)
+{
+  return thrust::nullopt;
+}
+
+/**
+ * TODO: JSON generator
+ *
+ */
+template <int max_json_nesting_depth = curr_max_json_nesting_depth>
+class json_generator {
+ public:
+  CUDF_HOST_DEVICE json_generator(char* _output, size_t _output_len)
+    : output(_output), output_len(_output_len)
+  {
+  }
+  CUDF_HOST_DEVICE json_generator() : output(nullptr), output_len(0) {}
+
+  // create a nested child generator based on this parent generator
+  // child generator is a view
+  CUDF_HOST_DEVICE json_generator new_child_generator()
+  {
+    if (nullptr == output) {
+      return json_generator();
+    } else {
+      return json_generator(output + output_len, 0);
+    }
+  }
+
+  CUDF_HOST_DEVICE json_generator finish_child_generator(json_generator const& child_generator)
+  {
+    // logically delete child generator
+    output_len += child_generator.get_output_len();
+  }
+
+  CUDF_HOST_DEVICE void write_start_array()
+  {
+    // TODO
+  }
+
+  CUDF_HOST_DEVICE void write_end_array()
+  {
+    // TODO
+  }
+
+  CUDF_HOST_DEVICE void copy_current_structure(json_parser<max_json_nesting_depth>& parser)
+  {
+    // TODO
+  }
+
+  /**
+   * Get current text from JSON parser and then write the text
+   * Note: Because JSON strings contains '\' to do escape,
+   * JSON parser should do unescape to remove '\' and JSON parser
+   * then can not return a pointer and length pair (char *, len),
+   * For number token, JSON parser can return a pair (char *, len)
+   */
+  CUDF_HOST_DEVICE void write_raw(json_parser<max_json_nesting_depth>& parser)
+  {
+    if (output) {
+      auto copied = parser.try_copy_raw_text(output + output_len);
+      output_len += copied;
+    }
+  }
+
+  CUDF_HOST_DEVICE inline size_t get_output_len() const { return output_len; }
+
+ private:
+  char const* const output;
+  size_t output_len;
+};
+
+/**
+ * @brief Result of calling a parse function.
+ *
+ * The primary use of this is to distinguish between "success" and
+ * "success but no data" return cases.  For example, if you are reading the
+ * values of an array you might call a parse function in a while loop. You
+ * would want to continue doing this until you either encounter an error
+ * (parse_result::ERROR) or you get nothing back (parse_result::EMPTY)
+ */
+enum class parse_result {
+  ERROR,          // failure
+  SUCCESS,        // success
+  MISSING_FIELD,  // success, but the field is missing
+  EMPTY,          // success, but no data
+};
+
+/**
+ * @brief Parse a single json string using the provided command buffer
+ *
+ * @param j_state The incoming json string and associated parser
+ * @param commands The command buffer to be applied to the string. Always ends
+ * with a path_operator_type::END
+ * @param output Buffer user to store the results of the query
+ * @returns A result code indicating success/fail/empty.
+ */
+template <int max_json_nesting_depth = curr_max_json_nesting_depth>
+__device__ parse_result parse_json_path(json_parser<max_json_nesting_depth>& j_parser,
+                                        path_instruction const* path_commands_ptr,
+                                        int path_commands_size,
+                                        json_generator<max_json_nesting_depth>& output)
+{
+  // TODO
+  return parse_result::SUCCESS;
+}
+
+/**
+ * @brief Parse a single json string using the provided command buffer
+ *
+ * This function exists primarily as a shim for debugging purposes.
+ *
+ * @param input The incoming json string
+ * @param input_len Size of the incoming json string
+ * @param commands The command buffer to be applied to the string. Always ends
+ * with a path_operator_type::END
+ * @param out_buf Buffer user to store the results of the query (nullptr in the
+ * size computation step)
+ * @param out_buf_size Size of the output buffer
+ * @param options Options controlling behavior
+ * @returns A pair containing the result code the output buffer.
+ */
+template <int max_json_nesting_depth = curr_max_json_nesting_depth>
+__device__ thrust::pair<parse_result, json_generator<max_json_nesting_depth>>
+get_json_object_single(char const* input,
+                       cudf::size_type input_len,
+                       path_instruction const* path_commands_ptr,
+                       int path_commands_size,
+                       char* out_buf,
+                       size_t out_buf_size,
+                       json_parser_options options)
+{
+  json_parser j_parser(options, input, input_len);
+  json_generator generator(out_buf, out_buf_size);
+  auto const result = parse_json_path(j_parser, path_commands_ptr, path_commands_size, generator);
+  return {result, generator};
+}
+
+/**
+ * @brief Kernel for running the JSONPath query.
+ *
+ * This kernel operates in a 2-pass way.  On the first pass, it computes
+ * output sizes.  On the second pass it fills in the provided output buffers
+ * (chars and validity)
+ *
+ * @param col Device view of the incoming string
+ * @param commands JSONPath command buffer
+ * @param output_offsets Buffer used to store the string offsets for the results
+ * of the query
+ * @param out_buf Buffer used to store the results of the query
+ * @param out_validity Output validity buffer
+ * @param out_valid_count Output count of # of valid bits
+ * @param options Options controlling behavior
+ */
+template <int block_size>
+__launch_bounds__(block_size) CUDF_KERNEL
+  void get_json_object_kernel(cudf::column_device_view col,
+                              path_instruction const* path_commands_ptr,
+                              int path_commands_size,
+                              cudf::size_type* d_sizes,
+                              cudf::detail::input_offsetalator output_offsets,
+                              thrust::optional<char*> out_buf,
+                              thrust::optional<cudf::bitmask_type*> out_validity,
+                              thrust::optional<cudf::size_type*> out_valid_count,
+                              json_parser_options options)
+{
+  auto tid          = cudf::detail::grid_1d::global_thread_id();
+  auto const stride = cudf::thread_index_type{blockDim.x} * cudf::thread_index_type{gridDim.x};
+
+  cudf::size_type warp_valid_count{0};
+
+  auto active_threads = __ballot_sync(0xffff'ffffu, tid < col.size());
+  while (tid < col.size()) {
+    bool is_valid               = false;
+    cudf::string_view const str = col.element<cudf::string_view>(tid);
+    cudf::size_type output_size = 0;
+    if (str.size_bytes() > 0) {
+      char* dst = out_buf.has_value() ? out_buf.value() + output_offsets[tid] : nullptr;
+      size_t const dst_size =
+        out_buf.has_value() ? output_offsets[tid + 1] - output_offsets[tid] : 0;
+
+      // process one single row
+      auto [result, out] = get_json_object_single(str.data(),
+                                                  str.size_bytes(),
+                                                  path_commands_ptr,
+                                                  path_commands_size,
+                                                  dst,
+                                                  dst_size,
+                                                  options);
+      output_size        = out.get_output_len();
+      if (result == parse_result::SUCCESS) { is_valid = true; }
+    }
+
+    // filled in only during the precompute step. during the compute step, the
+    // offsets are fed back in so we do -not- want to write them out
+    if (!out_buf.has_value()) { d_sizes[tid] = output_size; }
+
+    // validity filled in only during the output step
+    if (out_validity.has_value()) {
+      uint32_t mask = __ballot_sync(active_threads, is_valid);
+      // 0th lane of the warp writes the validity
+      if (!(tid % cudf::detail::warp_size)) {
+        out_validity.value()[cudf::word_index(tid)] = mask;
+        warp_valid_count += __popc(mask);
+      }
+    }
+
+    tid += stride;
+    active_threads = __ballot_sync(active_threads, tid < col.size());
+  }
+
+  // sum the valid counts across the whole block
+  if (out_valid_count) {
+    cudf::size_type block_valid_count =
+      cudf::detail::single_lane_block_sum_reduce<block_size, 0>(warp_valid_count);
+    if (threadIdx.x == 0) { atomicAdd(out_valid_count.value(), block_valid_count); }
+  }
+}
+
+std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& col,
+                                              cudf::string_scalar const& json_path,
+                                              spark_rapids_jni::json_parser_options options,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::mr::device_memory_resource* mr)
+{
+  if (col.is_empty()) return cudf::make_empty_column(cudf::type_id::STRING);
+
+  // parse the json_path into a command buffer
+  auto path_commands_optional = parse_path(json_path);
+
+  // if the json path is empty, return a string column containing all nulls
+  if (!path_commands_optional.has_value()) {
+    return std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::STRING},
+      col.size(),
+      rmm::device_buffer{0, stream, mr},  // no data
+      cudf::detail::create_null_mask(col.size(), cudf::mask_state::ALL_NULL, stream, mr),
+      col.size());  // null count
+  }
+
+  // compute output sizes
+  auto sizes = rmm::device_uvector<cudf::size_type>(
+    col.size(), stream, rmm::mr::get_current_device_resource());
+  auto d_offsets = cudf::detail::offsetalator_factory::make_input_iterator(col.offsets());
+
+  constexpr int block_size = 512;
+  cudf::detail::grid_1d const grid{col.size(), block_size};
+  auto cdv = cudf::column_device_view::create(col.parent(), stream);
+  // preprocess sizes (returned in the offsets buffer)
+  get_json_object_kernel<block_size>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      *cdv,
+      path_commands_optional.value().data(),
+      path_commands_optional.value().size(),
+      sizes.data(),
+      d_offsets,
+      thrust::nullopt,
+      thrust::nullopt,
+      thrust::nullopt,
+      options);
+
+  // convert sizes to offsets
+  auto [offsets, output_size] =
+    cudf::strings::detail::make_offsets_child_column(sizes.begin(), sizes.end(), stream, mr);
+  d_offsets = cudf::detail::offsetalator_factory::make_input_iterator(offsets->view());
+
+  // allocate output string column
+  rmm::device_uvector<char> chars(output_size, stream, mr);
+
+  // potential optimization : if we know that all outputs are valid, we could
+  // skip creating the validity mask altogether
+  rmm::device_buffer validity =
+    cudf::detail::create_null_mask(col.size(), cudf::mask_state::UNINITIALIZED, stream, mr);
+
+  // compute results
+  rmm::device_scalar<cudf::size_type> d_valid_count{0, stream};
+
+  get_json_object_kernel<block_size>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      *cdv,
+      path_commands_optional.value().data(),
+      path_commands_optional.value().size(),
+      sizes.data(),
+      d_offsets,
+      chars.data(),
+      static_cast<cudf::bitmask_type*>(validity.data()),
+      d_valid_count.data(),
+      options);
+
+  auto result = make_strings_column(col.size(),
+                                    std::move(offsets),
+                                    chars.release(),
+                                    col.size() - d_valid_count.value(stream),
+                                    std::move(validity));
+  // unmatched array query may result in unsanitized '[' value in the result
+  if (cudf::detail::has_nonempty_nulls(result->view(), stream)) {
+    result = cudf::detail::purge_nonempty_nulls(result->view(), stream, mr);
+  }
+  return result;
+}
+
+// }  // namespace
+
+}  // namespace detail
+
+std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& col,
+                                              cudf::string_scalar const& json_path,
+                                              spark_rapids_jni::json_parser_options options,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::mr::device_memory_resource* mr)
+{
+  // TODO: main logic
+  // return cudf::make_empty_column(cudf::type_to_id<cudf::size_type>());
+  return detail::get_json_object(col, json_path, options, stream, mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -312,7 +312,7 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
       col.size(),
       rmm::device_buffer{0, stream, mr},  // no data
       cudf::detail::create_null_mask(col.size(), cudf::mask_state::ALL_NULL, stream, mr),
-      col.size());  // null count
+      col.size());                        // null count
   }
 
   // compute output sizes

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "json_parser.hpp"
+
+#include <cudf/strings/string_view.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+
+#include <memory>
+
+namespace spark_rapids_jni {
+
+/**
+ * Extracts json object from a json string based on json path specified, and
+ * returns json string of the extracted json object. It will return null if the
+ * input json string is invalid.
+ */
+std::unique_ptr<cudf::column> get_json_object(
+  cudf::strings_column_view const& col,
+  cudf::string_scalar const& json_path,
+  spark_rapids_jni::json_parser_options options,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/json_parser.hpp
+++ b/src/main/cpp/src/json_parser.hpp
@@ -1,0 +1,1292 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/strings/detail/utf8.hpp>
+#include <cudf/types.hpp>
+
+#include <thrust/pair.h>
+
+namespace spark_rapids_jni {
+
+// deep depth will consume more memory, we can tuning this in future.
+// we ever run into a limit of 254, here use a little value 200.
+constexpr int curr_max_json_nesting_depth = 200;
+
+/**
+ * @brief Settings for `json_parser_options()`.
+ */
+class json_parser_options {
+  // allow single quotes to represent strings in JSON
+  bool allow_single_quotes = false;
+
+  // Whether allow unescaped control characters in JSON Strings.
+  bool allow_unescaped_control_chars = false;
+
+  // Define the maximum JSON String length, counts utf8 bytes.
+  int max_string_utf8_bytes = -1;
+
+  // Define the maximum JSON number length.
+  int max_num_len = -1;
+
+  // Whether allow tailing useless sub-string
+  bool allow_tailing_sub_string = false;
+
+ public:
+  /**
+   * @brief Default constructor.
+   */
+  explicit json_parser_options() = default;
+
+  /**
+   * @brief Returns true/false depending on whether single-quotes for
+   * representing strings are allowed.
+   *
+   * @return true if single-quotes are allowed, false otherwise.
+   */
+  [[nodiscard]] CUDF_HOST_DEVICE inline bool get_allow_single_quotes() const
+  {
+    return allow_single_quotes;
+  }
+
+  /**
+   * @brief Returns true/false depending on whether unescaped characters for
+   * representing strings are allowed.
+   *
+   * Unescaped control characters are ASCII characters with value less than 32,
+   * including tab and line feed characters.
+   *
+   * If true, JSON is not conventional format.
+   * e.g., how to represent carriage return and newline characters:
+   *   if true, allow "\n\r" two control characters without escape directly
+   *   if false, "\n\r" are not allowed, should use escape characters: "\\n\\r"
+   *
+   * @return true if unescaped characters are allowed, false otherwise.
+   */
+  [[nodiscard]] CUDF_HOST_DEVICE inline bool get_allow_unescaped_control_chars() const
+  {
+    return allow_unescaped_control_chars;
+  }
+
+  /**
+   * @brief Returns maximum JSON String length, negative or zero means no
+   * limitation.
+   *
+   * By default, maximum JSON String length is negative one, means no
+   * limitation. e.g.: The length of String "\\n" is 1, JSON parser does not
+   * count escape characters.
+   *
+   * @return integer value of allowed maximum JSON String length, counts utf8
+   * bytes
+   */
+  [[nodiscard]] CUDF_HOST_DEVICE int get_max_string_len() const { return max_string_utf8_bytes; }
+
+  /**
+   * @brief Returns maximum JSON number length, negative or zero means no
+   * limitation.
+   *
+   * By default, maximum JSON number length is negative one, means no
+   * limitation.
+   *
+   * e.g.: The length of number -123.45e-67 is 7. if maximum JSON number length
+   * is 6, then this number is a invalid number.
+   *
+   * @return integer value of allowed maximum JSON number length
+   */
+  [[nodiscard]] CUDF_HOST_DEVICE int get_max_num_len() const { return max_num_len; }
+
+  /**
+   * @brief Returns whether allow tailing useless sub-string in JSON.
+   *
+   * If true, e.g., the following invalid JSON is allowed, because prefix {'k' :
+   * 'v'} is valid.
+   *   {'k' : 'v'}_extra_tail_sub_string
+   *
+   * @return true if alow tailing useless sub-string, false otherwise.
+   */
+  [[nodiscard]] CUDF_HOST_DEVICE int get_allow_tailing_sub_string() const
+  {
+    return allow_tailing_sub_string;
+  }
+
+  /**
+   * @brief Set whether single-quotes for strings are allowed.
+   *
+   * @param _allow_single_quotes bool indicating desired behavior.
+   */
+  void set_allow_single_quotes(bool _allow_single_quotes)
+  {
+    allow_single_quotes = _allow_single_quotes;
+  }
+
+  /**
+   * @brief Set whether alow unescaped control characters.
+   *
+   * @param _allow_unescaped_control_chars bool indicating desired behavior.
+   */
+  void set_allow_unescaped_control_chars(bool _allow_unescaped_control_chars)
+  {
+    allow_unescaped_control_chars = _allow_unescaped_control_chars;
+  }
+
+  /**
+   * @brief Set maximum JSON String length, counts utf8 bytes.
+   *
+   * @param _max_string_len integer indicating desired behavior.
+   */
+  void set_max_string_len(int _max_string_len) { max_string_utf8_bytes = _max_string_len; }
+
+  /**
+   * @brief Set maximum JSON number length.
+   *
+   * @param _max_num_len integer indicating desired behavior.
+   */
+  void set_max_num_len(int _max_num_len) { max_num_len = _max_num_len; }
+
+  /**
+   * @brief Set whether allow tailing useless sub-string.
+   *
+   * @param _allow_tailing_sub_string bool indicating desired behavior.
+   */
+  void set_allow_tailing_sub_string(bool _allow_tailing_sub_string)
+  {
+    allow_tailing_sub_string = _allow_tailing_sub_string;
+  }
+};
+
+/**
+ * JSON token enum
+ */
+enum class json_token {
+  // start token
+  INIT = 0,
+
+  // successfully parsed the whole JSON string
+  SUCCESS,
+
+  // get error when parsing JSON string
+  ERROR,
+
+  // '{'
+  START_OBJECT,
+
+  // '}'
+  END_OBJECT,
+
+  // '['
+  START_ARRAY,
+
+  // ']'
+  END_ARRAY,
+
+  // e.g.: key1 in {"key1" : "value1"}
+  FIELD_NAME,
+
+  // e.g.: value1 in {"key1" : "value1"}
+  VALUE_STRING,
+
+  // e.g.: 123 in {"key1" : 123}
+  VALUE_NUMBER_INT,
+
+  // e.g.: 1.25 in {"key1" : 1.25}
+  VALUE_NUMBER_FLOAT,
+
+  // e.g.: true in {"key1" : true}
+  VALUE_TRUE,
+
+  // e.g.: false in {"key1" : false}
+  VALUE_FALSE,
+
+  // e.g.: null in {"key1" : null}
+  VALUE_NULL
+
+};
+
+/**
+ * JSON parser, provides token by token parsing.
+ * Follow Jackson JSON format by default.
+ *
+ *
+ * For JSON format:
+ * Refer to https://www.json.org/json-en.html.
+ *
+ * Note: when setting `allow_single_quotes` or `allow_unescaped_control_chars`,
+ * then JSON format is not conventional.
+ *
+ * White space can only be 4 chars: ' ', '\n', '\r', '\t',
+ * Jackson does not allow other control chars as white spaces.
+ *
+ * Valid number examples:
+ *   0, 102, -0, -102, 0.3, -0.3
+ *   1e-5, 1E+5, 1e0, 1E0, 1.3e5
+ *   1e01 : allow leading zeor after 'e'
+ *
+ * Invalid number examples:
+ *   00, -00   Leading zeroes not allowed
+ *   infinity, +infinity, -infinity
+ *   1e, 1e+, 1e-, -1., 1.
+ *
+ * When `allow_single_quotes` is true:
+ *   Valid string examples:
+ *     "\'" , "\"" ,  '\'' , '\"' , '"' , "'"
+ *
+ *  When `allow_single_quotes` is false:
+ *   Invalid string examples:
+ *     "\'"
+ *
+ *  When `allow_unescaped_control_chars` is true:
+ *    Valid string: "asscii_control_chars"
+ *      here `asscii_control_chars` represents control chars which in Ascii code
+ * range: [0, 32)
+ *
+ *  When `allow_unescaped_control_chars` is false:
+ *    Invalid string: "asscii_control_chars"
+ *      here `asscii_control_chars` represents control chars which in Ascii code
+ * range: [0, 32)
+ *
+ */
+template <int max_json_nesting_depth = curr_max_json_nesting_depth>
+class json_parser {
+ public:
+  CUDF_HOST_DEVICE inline json_parser(json_parser_options const& _options,
+                                      char const* const _json_start_pos,
+                                      cudf::size_type const _json_len)
+    : options(_options),
+      json_start_pos(_json_start_pos),
+      json_end_pos(_json_start_pos + _json_len),
+      curr_pos(_json_start_pos)
+  {
+  }
+
+ private:
+  /**
+   * is current position EOF?
+   */
+  CUDF_HOST_DEVICE inline bool eof() { return curr_pos >= json_end_pos; }
+
+  /**
+   * is hex digits: 0-9, A-F, a-f
+   */
+  CUDF_HOST_DEVICE inline bool is_hex_digit(char c)
+  {
+    return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+  }
+
+  /**
+   * is 0 to 9 digit
+   */
+  CUDF_HOST_DEVICE inline bool is_digit(char c) { return (c >= '0' && c <= '9'); }
+
+  /**
+   * is white spaces: ' ', '\t', '\n' '\r'
+   */
+  CUDF_HOST_DEVICE inline bool is_whitespace(char c)
+  {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+  }
+
+  /**
+   * skips 4 characters: ' ', '\t', '\n' '\r'
+   */
+  CUDF_HOST_DEVICE inline void skip_whitespaces()
+  {
+    while (!eof() && is_whitespace(*curr_pos)) {
+      curr_pos++;
+    }
+  }
+
+  /**
+   * check current char, if it's expected, then plus the position
+   */
+  CUDF_HOST_DEVICE inline bool try_skip(char expected)
+  {
+    if (!eof() && *curr_pos == expected) {
+      curr_pos++;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * try to push current context into stack
+   * if nested depth exceeds limitation, return false
+   */
+  CUDF_HOST_DEVICE inline bool try_push_context(json_token token)
+  {
+    if (stack_size < max_json_nesting_depth) {
+      push_context(token);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * record the nested state into stack: JSON object or JSON array
+   */
+  CUDF_HOST_DEVICE inline void push_context(json_token token)
+  {
+    bool v              = json_token::START_OBJECT == token ? true : false;
+    stack[stack_size++] = v;
+  }
+
+  /**
+   * whether the top of nested context stack is JSON object context
+   * true is object, false is array
+   * only has two contexts: object or array
+   */
+  CUDF_HOST_DEVICE inline bool is_object_context() { return stack[stack_size - 1]; }
+
+  /**
+   * pop top context from stack
+   */
+  CUDF_HOST_DEVICE inline void pop_curr_context() { stack_size--; }
+
+  /**
+   * is context stack is empty
+   */
+  CUDF_HOST_DEVICE inline bool is_context_stack_empty() { return stack_size == 0; }
+
+  /**
+   * parse the first value token from current position
+   * e.g., after finished this function:
+   *   current token is START_OBJECT if current value is object
+   *   current token is START_ARRAY if current value is array
+   *   current token is string/num/true/false/null if current value is terminal
+   *   current token is ERROR if parse failed
+   */
+  CUDF_HOST_DEVICE inline void parse_first_token_in_value()
+  {
+    // already checked eof
+    char c = *curr_pos;
+    switch (c) {
+      case '{':
+        if (!try_push_context(json_token::START_OBJECT)) {
+          curr_token = json_token::ERROR;
+          return;
+        }
+        curr_pos++;
+        curr_token = json_token::START_OBJECT;
+        break;
+
+      case '[':
+        if (!try_push_context(json_token::START_ARRAY)) {
+          curr_token = json_token::ERROR;
+          return;
+        }
+        curr_pos++;
+        curr_token = json_token::START_ARRAY;
+        break;
+
+      case '"': parse_double_quoted_string(); break;
+
+      case '\'':
+        if (options.get_allow_single_quotes()) {
+          parse_single_quoted_string();
+        } else {
+          curr_token = json_token::ERROR;
+        }
+        break;
+
+      case 't':
+        curr_pos++;
+        parse_true();
+        break;
+
+      case 'f':
+        curr_pos++;
+        parse_false();
+        break;
+
+      case 'n':
+        curr_pos++;
+        parse_null();
+        break;
+
+      default: parse_number();
+    }
+  }
+
+  // =========== Parse string begin ===========
+
+  /**
+   * parse ' quoted string
+   */
+  CUDF_HOST_DEVICE inline void parse_single_quoted_string()
+  {
+    if (try_parse_single_quoted_string()) {
+      curr_token = json_token::VALUE_STRING;
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /**
+   * parse " quoted string
+   */
+  CUDF_HOST_DEVICE inline void parse_double_quoted_string()
+  {
+    if (try_parse_double_quoted_string()) {
+      curr_token = json_token::VALUE_STRING;
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /*
+   * try parse ' or " quoted string
+   * when allow single quote, first try single quote
+   */
+  CUDF_HOST_DEVICE inline bool try_parse_string()
+  {
+    if (options.get_allow_single_quotes() && *curr_pos == '\'') {
+      return try_parse_single_quoted_string();
+    } else {
+      return try_parse_double_quoted_string();
+    }
+  }
+
+  /**
+   * try parse ' quoted string
+   */
+  CUDF_HOST_DEVICE inline bool try_parse_single_quoted_string() { return try_parse_string('\''); }
+
+  /**
+   * try parse " quoted string
+   */
+  CUDF_HOST_DEVICE inline bool try_parse_double_quoted_string() { return try_parse_string('\"'); }
+
+  /**
+   * try parse quoted string using passed `quote_char`
+   * `quote_char` can be ' or "
+   * For UTF-8 encoding:
+   *   Single byte char: The most significant bit of the byte is always 0
+   *   Two-byte characters: The leading bits of the first byte are 110,
+   *     and the leading bits of the second byte are 10.
+   *   Three-byte characters: The leading bits of the first byte are 1110,
+   *     and the leading bits of the second and third bytes are 10.
+   *   Four-byte characters: The leading bits of the first byte are 11110,
+   *     and the leading bits of the second, third, and fourth bytes are 10.
+   * Because JSON structural chars([ ] { } , :), string quote char(" ') and
+   * Escape char \ are all Ascii(The leading bit is 0), so it's safe that do
+   * not convert byte array to UTF-8 char.
+   *
+   * When quote is " and allow_unescaped_control_chars is false, grammar is:
+   *
+   *   STRING
+   *     : '"' (ESC | SAFECODEPOINT)* '"'
+   *     ;
+   *
+   *   fragment ESC
+   *     : '\\' (["\\/bfnrt] | UNICODE)
+   *     ;
+   *
+   *   fragment UNICODE
+   *     : 'u' HEX HEX HEX HEX
+   *     ;
+   *
+   *   fragment HEX
+   *     : [0-9a-fA-F]
+   *     ;
+   *
+   *   fragment SAFECODEPOINT
+   *       // 1 not " or ' depending to allow_single_quotes
+   *       // 2 not \
+   *       // 3 non control character: Ascii value not in [0, 32)
+   *     : ~ ["\\\u0000-\u001F]
+   *     ;
+   *
+   * When allow_unescaped_control_chars is true:
+   *   Allow [0-32) control Ascii chars directly without escape
+   * When allow_single_quotes is true:
+   *   These strings are allowed: '\'' , '\"' , '"' , "\"" , "\'" , "'"
+   */
+  CUDF_HOST_DEVICE inline bool try_parse_string(char quote_char,
+                                                bool copy       = false,
+                                                char* copy_dest = nullptr)
+  {
+    // save start position for VALUE_STRING/FIELD_NAME token
+    token_start_pos = curr_pos;
+    if (!try_skip(quote_char)) { return false; }
+
+    string_token_utf8_bytes = 0;
+
+    // scan string content
+    while (!eof()) {
+      char c = *curr_pos;
+      int v  = static_cast<int>(c);
+      if (c == quote_char) {
+        // path 1: close string
+        curr_pos++;
+        return check_string_max_utf8_bytes();
+      } else if (v >= 0 && v < 32 && options.get_allow_unescaped_control_chars()) {
+        // path 2: unescaped control char
+        if (copy) { *copy_dest++ = *curr_pos; }
+        curr_pos++;
+        string_token_utf8_bytes++;
+        continue;
+      } else if ('\\' == c) {
+        // path 3: escape path
+        curr_pos++;
+        if (!try_skip_escape_part(copy, copy_dest)) { return false; }
+      } else {
+        // path 4: safe code point
+        if (!try_skip_safe_code_point(c)) {
+          return false;
+        } else {
+          if (copy) { *copy_dest++ = c; }
+          string_token_utf8_bytes++;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * skip the second char in \", \', \\, \/, \b, \f, \n, \r, \t;
+   * skip the HEX chars in \u HEX HEX HEX HEX.
+   * @return positive escaped ASCII value if success, -1 otherwise
+   */
+  CUDF_HOST_DEVICE inline bool try_skip_escape_part(bool copy = false, char*& copy_dest = nullptr)
+  {
+    // already skipped the first '\'
+    // try skip second part
+    if (!eof()) {
+      char c = *curr_pos;
+      switch (*curr_pos) {
+        // path 1: \", \', \\, \/, \b, \f, \n, \r, \t
+        case '\"':
+          if (copy) { *copy_dest++ = c; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case '\'':
+          // only allow escape ' when `allow_single_quotes`
+          if (options.get_allow_single_quotes()) {
+            if (copy) { *copy_dest++ = c; }
+            curr_pos++;
+            string_token_utf8_bytes++;
+            return true;
+          } else {
+            return false;
+          }
+        case '\\':
+          if (copy) { *copy_dest++ = c; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case '/':
+          if (copy) { *copy_dest++ = c; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case 'b':
+          if (copy) { *copy_dest++ = '\b'; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case 'f':
+          if (copy) { *copy_dest++ = '\f'; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case 'n':
+          if (copy) { *copy_dest++ = '\n'; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case 'r':
+          if (copy) { *copy_dest++ = '\r'; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        case 't':
+          if (copy) { *copy_dest++ = '\t'; }
+          string_token_utf8_bytes++;
+          curr_pos++;
+          return true;
+        // path 1: \", \', \\, \/, \b, \f, \n, \r, \t
+        case 'u':
+          // path 2: \u HEX HEX HEX HEX
+          curr_pos++;
+          return try_skip_unicode(copy, copy_dest);
+        default:
+          // path 3: invalid
+          return false;
+      }
+    } else {
+      // eof, no escaped char after char '\'
+      return false;
+    }
+  }
+
+  /**
+   * parse:
+   *   fragment SAFECODEPOINT
+   *       // 1 not " or ' depending to allow_single_quotes
+   *       // 2 not \
+   *       // 3 non control character: Ascii value not in [0, 32)
+   *     : ~ ["\\\u0000-\u001F]
+   *     ;
+   */
+  CUDF_HOST_DEVICE inline bool try_skip_safe_code_point(char c)
+  {
+    // 1 the char is not quoted(' or ") char, here satisfy, do not need to check
+    // again
+
+    // 2. the char is not \, here satisfy, do not need to check again
+
+    // 3. chars not in [0, 32)
+    int v = static_cast<int>(c);
+    if (!(v >= 0 && v < 32)) {
+      curr_pos++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * convert chars 0-9, a-f, A-F to int value
+   */
+  CUDF_HOST_DEVICE inline uint8_t hex_value(char c)
+  {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return 0;
+  }
+
+  /**
+   * parse four HEX chars to unsigned int
+   */
+  CUDF_HOST_DEVICE inline cudf::char_utf8 parse_code_point(char const* p)
+  {
+    cudf::char_utf8 v = 0;
+    for (size_t i = 0; i < 4; i++) {
+      v = v * 16 + hex_value(p[i]);
+    }
+    return v;
+  }
+
+  /**
+   * try skip 4 HEX chars
+   * in pattern: '\\' 'u' HEX HEX HEX HEX
+   */
+  CUDF_HOST_DEVICE inline bool try_skip_unicode(bool copy = false, char*& copy_dest = nullptr)
+  {
+    // already parsed u
+    bool is_success = try_skip_hex() && try_skip_hex() && try_skip_hex() && try_skip_hex();
+    if (is_success) {
+      // parse 4 HEX chars to uint32_t value
+      auto code_point = parse_code_point(curr_pos - 4);
+      auto utf_char   = cudf::strings::detail::codepoint_to_utf8(code_point);
+      // write utf8 bytes.
+      // In UTF-8, the maximum number of bytes used to encode a single character
+      // is 4
+      char buff[4];
+      cudf::size_type bytes = cudf::strings::detail::from_char_utf8(utf_char, buff);
+      string_token_utf8_bytes += bytes;
+
+      if (copy) {
+        for (cudf::size_type i = 0; i < bytes; i++) {
+          *copy_dest++ = buff[i];
+        }
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * try skip HEX
+   */
+  CUDF_HOST_DEVICE inline bool try_skip_hex()
+  {
+    if (!eof() && is_hex_digit(*curr_pos)) {
+      curr_pos++;
+      return true;
+    }
+    return false;
+  }
+
+  // =========== Parse string end ===========
+
+  // =========== Parse number begin ===========
+
+  /**
+   * parse number, grammar is:
+   * NUMBER
+   *   : '-'? INT ('.' [0-9]+)? EXP?
+   *   ;
+   *
+   * fragment INT
+   *   // integer part forbis leading 0s (e.g. `01`)
+   *   : '0'
+   *   | [1-9] [0-9]*
+   *   ;
+   *
+   * fragment EXP
+   *   : [Ee] [+\-]? [0-9]+
+   *   ;
+   *
+   * valid number:    0, 0.3, 0e005, 0E005
+   * invalid number:  0., 0e, 0E
+   *
+   */
+  CUDF_HOST_DEVICE inline void parse_number()
+  {
+    // copy start position for number token
+    token_start_pos = curr_pos;
+
+    // reset the float parts
+    float_integer_len  = 0;
+    float_fraction_len = 0;
+    float_exp_len      = 0;
+    float_exp_has_sign = false;
+
+    // parse sign
+    if (try_skip('-')) {
+      float_sign = false;
+    } else {
+      float_sign = true;
+    }
+    float_integer_pos = curr_pos;
+
+    // parse unsigned number
+    bool is_float = false;
+    if (try_unsigned_number(is_float)) {
+      if (check_max_num_len()) {
+        curr_token = (is_float ? json_token::VALUE_NUMBER_FLOAT : json_token::VALUE_NUMBER_INT);
+        // success parsed a number, update the token length
+        number_token_len = curr_pos - token_start_pos;
+      } else {
+        curr_token = json_token::ERROR;
+      }
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /**
+   * verify max number length if enabled
+   * e.g.: -1.23e-456, int len is 1, fraction len is 2, exp digits len is 3
+   */
+  CUDF_HOST_DEVICE inline bool check_max_num_len()
+  {
+    // exp part contains + or - sign char, do not count the exp sign
+    int exp_digit_len = float_exp_len;
+    if (float_exp_len > 0 && float_exp_has_sign) { exp_digit_len--; }
+
+    int sum_len = float_integer_len + float_fraction_len + exp_digit_len;
+    return
+      // disabled num len check
+      options.get_max_num_len() <= 0 ||
+      // enabled num len check
+      (options.get_max_num_len() > 0 && sum_len <= options.get_max_num_len());
+  }
+
+  /**
+   * verify max string length if enabled
+   */
+  CUDF_HOST_DEVICE inline bool check_string_max_utf8_bytes()
+  {
+    return
+      // disabled str len check
+      options.get_max_string_len() <= 0 ||
+      // enabled str len check
+      (options.get_max_string_len() > 0 && string_token_utf8_bytes <= options.get_max_string_len());
+  }
+
+  /**
+   * parse:  INT ('.' [0-9]+)? EXP?
+   *
+   * @param[out] is_float, if contains `.` or `e`, set true
+   */
+  CUDF_HOST_DEVICE inline bool try_unsigned_number(bool& is_float)
+  {
+    if (!eof()) {
+      char c = *curr_pos;
+      if (c >= '1' && c <= '9') {
+        curr_pos++;
+        float_integer_len++;
+        // first digit is [1-9]
+        // path: INT = [1-9] [0-9]*
+        float_integer_len += skip_zero_or_more_digits();
+        return parse_number_from_fraction(is_float);
+      } else if (c == '0') {
+        curr_pos++;
+        float_integer_len++;
+        // first digit is [0]
+        // path: INT = '0'
+        return parse_number_from_fraction(is_float);
+      } else {
+        // first digit is non [0-9]
+        return false;
+      }
+    } else {
+      // eof, has no digits
+      return false;
+    }
+  }
+
+  /**
+   * parse: ('.' [0-9]+)? EXP?
+   * @param[is_float] is float
+   */
+  CUDF_HOST_DEVICE inline bool parse_number_from_fraction(bool& is_float)
+  {
+    // parse fraction
+    if (try_skip('.')) {
+      // has fraction
+      float_fraction_pos = curr_pos;
+      is_float           = true;
+      // try pattern: [0-9]+
+      if (!try_skip_one_or_more_digits(float_fraction_len)) { return false; }
+    }
+
+    // parse exp
+    if (!eof() && (*curr_pos == 'e' || *curr_pos == 'E')) {
+      curr_pos++;
+      is_float = true;
+      return try_parse_exp();
+    }
+
+    return true;
+  }
+
+  /**
+   * parse: [0-9]*
+   * skip zero or more [0-9]
+   */
+  CUDF_HOST_DEVICE inline int skip_zero_or_more_digits()
+  {
+    int digits = 0;
+    while (!eof()) {
+      if (is_digit(*curr_pos)) {
+        digits++;
+        curr_pos++;
+      } else {
+        // point to first non-digit char
+        break;
+      }
+    }
+    return digits;
+  }
+
+  /**
+   * parse: [0-9]+
+   * try skip one or more [0-9]
+   * @param[out] len: skipped num of digits
+   */
+  CUDF_HOST_DEVICE inline bool try_skip_one_or_more_digits(int& len)
+  {
+    if (!eof() && is_digit(*curr_pos)) {
+      curr_pos++;
+      len++;
+      len += skip_zero_or_more_digits();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * parse [eE][+-]?[0-9]+
+   * @param[out] exp_len exp len
+   */
+  CUDF_HOST_DEVICE inline bool try_parse_exp()
+  {
+    // already parsed [eE]
+
+    float_exp_pos = curr_pos;
+
+    // parse [+-]?
+    if (!eof() && (*curr_pos == '+' || *curr_pos == '-')) {
+      float_exp_len++;
+      curr_pos++;
+      float_exp_has_sign = true;
+    }
+
+    // parse [0-9]+
+    return try_skip_one_or_more_digits(float_exp_len);
+  }
+
+  // =========== Parse number end ===========
+
+  /**
+   * parse true
+   */
+  CUDF_HOST_DEVICE inline void parse_true()
+  {
+    // already parsed 't'
+    if (try_skip('r') && try_skip('u') && try_skip('e')) {
+      curr_token = json_token::VALUE_TRUE;
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /**
+   * parse false
+   */
+  CUDF_HOST_DEVICE inline void parse_false()
+  {
+    // already parsed 'f'
+    if (try_skip('a') && try_skip('l') && try_skip('s') && try_skip('e')) {
+      curr_token = json_token::VALUE_FALSE;
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /**
+   * parse null
+   */
+  CUDF_HOST_DEVICE inline void parse_null()
+  {
+    // already parsed 'n'
+    if (try_skip('u') && try_skip('l') && try_skip('l')) {
+      curr_token = json_token::VALUE_NULL;
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /**
+   * parse the key string in key:value pair
+   */
+  CUDF_HOST_DEVICE inline void parse_field_name()
+  {
+    if (try_parse_string()) {
+      curr_token = json_token::FIELD_NAME;
+    } else {
+      curr_token = json_token::ERROR;
+    }
+  }
+
+  /**
+   * continute parsing the next token and update current token
+   * Note: only parse one token at a time
+   */
+  CUDF_HOST_DEVICE inline json_token parse_next_token()
+  {
+    // SUCCESS or ERROR means parsing is completed,
+    // should not call this function again.
+    assert(curr_token != json_token::SUCCESS && curr_token != json_token::ERROR);
+
+    skip_whitespaces();
+
+    if (!eof()) {
+      char c = *curr_pos;
+      if (is_context_stack_empty()) {
+        // stack is empty
+
+        if (curr_token == json_token::INIT) {
+          // main root entry point
+          parse_first_token_in_value();
+        } else {
+          if (options.get_allow_tailing_sub_string()) {
+            // previous token is not INIT, means already get a token; stack is
+            // empty; Successfully parsed. Note: ignore the tailing sub-string
+            curr_token = json_token::SUCCESS;
+          } else {
+            // not eof, has extra useless tailing characters.
+            curr_token = json_token::ERROR;
+          }
+        }
+      } else {
+        // stack is non-empty
+
+        if (is_object_context()) {
+          // in JSON object context
+          if (curr_token == json_token::START_OBJECT) {
+            // previous token is '{'
+            if (c == '}') {
+              // empty object
+              // close curr object context
+              curr_pos++;
+              curr_token = json_token::END_OBJECT;
+              pop_curr_context();
+            } else {
+              // parse key in key:value pair
+              parse_field_name();
+            }
+          } else if (curr_token == json_token::FIELD_NAME) {
+            if (c == ':') {
+              // skip ':' and parse value in key:value pair
+              curr_pos++;
+              skip_whitespaces();
+              parse_first_token_in_value();
+            } else {
+              curr_token = json_token::ERROR;
+            }
+          } else {
+            // expect next key:value pair or '}'
+            if (c == '}') {
+              // end of object
+              curr_pos++;
+              curr_token = json_token::END_OBJECT;
+              pop_curr_context();
+            } else if (c == ',') {
+              // parse next key:value pair
+              curr_pos++;
+              skip_whitespaces();
+              parse_field_name();
+            } else {
+              curr_token = json_token::ERROR;
+            }
+          }
+        } else {
+          // in Json array context
+          if (curr_token == json_token::START_ARRAY) {
+            // previous token is '['
+            if (c == ']') {
+              // curr: ']', empty array
+              curr_pos++;
+              curr_token = json_token::END_ARRAY;
+              pop_curr_context();
+            } else {
+              // non-empty array, parse the first value in the array
+              parse_first_token_in_value();
+            }
+          } else {
+            if (c == ',') {
+              // skip ',' and parse the next value
+              curr_pos++;
+              skip_whitespaces();
+              parse_first_token_in_value();
+            } else if (c == ']') {
+              // end of array
+              curr_pos++;
+              curr_token = json_token::END_ARRAY;
+              pop_curr_context();
+            } else {
+              curr_token = json_token::ERROR;
+            }
+          }
+        }
+      }
+    } else {
+      // eof
+      if (is_context_stack_empty() && curr_token != json_token::INIT) {
+        // reach eof; stack is empty; previous token is not INIT
+        curr_token = json_token::SUCCESS;
+      } else {
+        // eof, and meet the following cases:
+        //   - has unclosed JSON array/object;
+        //   - the whole JSON is empty
+        curr_token = json_token::ERROR;
+      }
+    }
+    return curr_token;
+  }
+
+ public:
+  /**
+   * continute parsing, get next token.
+   * The final tokens are ERROR or SUCCESS;
+   */
+  CUDF_HOST_DEVICE json_token next_token() { return parse_next_token(); }
+
+  /**
+   * get current token
+   */
+  CUDF_HOST_DEVICE json_token get_current_token() { return curr_token; }
+
+  /**
+   * is valid JSON by parsing through all tokens
+   */
+  CUDF_HOST_DEVICE bool is_valid()
+  {
+    while (curr_token != json_token::ERROR && curr_token != json_token::SUCCESS) {
+      next_token();
+    }
+    return curr_token == json_token::SUCCESS;
+  }
+
+  /**
+   * skip children if current token is [ or {, or do nothing otherwise.
+   * after this call, the current token is ] or } if token is { or [
+   * @return true if JSON is valid so far, false otherwise.
+   */
+  CUDF_HOST_DEVICE bool try_skip_children()
+  {
+    if (curr_token == json_token::ERROR || curr_token == json_token::INIT ||
+        curr_token == json_token::SUCCESS) {
+      return false;
+    }
+
+    if (curr_token != json_token::START_OBJECT && curr_token != json_token::START_ARRAY) {
+      return true;
+    }
+
+    int open = 1;
+    while (true) {
+      json_token t = next_token();
+      if (t == json_token::START_OBJECT || t == json_token::START_ARRAY) {
+        ++open;
+      } else if (t == json_token::END_OBJECT || t == json_token::END_ARRAY) {
+        if (--open == 0) { return true; }
+      } else if (t == json_token::ERROR) {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * copy current text
+   * For number: copy verbatim
+   * For string/field name: skip '\' when unescape; \u HEX HEX HEX HEX convert
+   * to utf8 bytes
+   * @return copied bytes
+   */
+  CUDF_HOST_DEVICE cudf::size_type copy_raw_text(char* destination)
+  {
+    switch (curr_token) {
+      case json_token::VALUE_STRING:
+        // can not copy from JSON directly due to escaped chars
+        // rewind the pos; parse again with copy
+        curr_pos = token_start_pos;
+        // token_start_pos should be ' or "
+        try_parse_string(*token_start_pos, true, destination);
+        return string_token_utf8_bytes;
+      case json_token::VALUE_NUMBER_INT:
+      case json_token::VALUE_NUMBER_FLOAT:
+        // number can be copied from JSON string directly
+        for (cudf::size_type i = 0; i < number_token_len; ++i) {
+          *destination++ = *(token_start_pos + i);
+        }
+        return number_token_len;
+      case json_token::VALUE_TRUE:
+        *destination++ = 't';
+        *destination++ = 'r';
+        *destination++ = 'u';
+        *destination++ = 'e';
+        return 4;
+      case json_token::VALUE_FALSE:
+        *destination++ = 'f';
+        *destination++ = 'a';
+        *destination++ = 'l';
+        *destination++ = 's';
+        *destination++ = 'e';
+        return 5;
+      case json_token::VALUE_NULL:
+        *destination++ = 'n';
+        *destination++ = 'u';
+        *destination++ = 'l';
+        *destination++ = 'l';
+        return 4;
+      case json_token::FIELD_NAME:
+        // can not copy from JSON directly due to escaped chars
+        // rewind the pos; parse again with copy
+        curr_pos = token_start_pos;
+        // token_start_pos should be ' or "
+        try_parse_string(*token_start_pos, true, destination);
+        return string_token_utf8_bytes;
+      case json_token::START_ARRAY: *destination++ = '['; return 1;
+      case json_token::END_ARRAY: *destination++ = ']'; return 1;
+      case json_token::START_OBJECT: *destination++ = '{'; return 1;
+      case json_token::END_OBJECT: *destination++ = '}'; return 1;
+      // for the following tokens, return false
+      case json_token::SUCCESS:
+      case json_token::ERROR:
+      case json_token::INIT: return 0;
+    }
+    return 0;
+  }
+
+  /**
+   * reset the parser
+   */
+  CUDF_HOST_DEVICE void reset()
+  {
+    curr_pos         = json_start_pos;
+    curr_token       = json_token::INIT;
+    stack_size       = 0;
+    token_start_pos  = json_start_pos;
+    number_token_len = 0;
+  }
+
+  /**
+   * get current text for VALUE_NUMBER_INT token or VALUE_NUMBER_FLOAT token
+   */
+  CUDF_HOST_DEVICE thrust::pair<char const*, cudf::size_type> get_current_number_text()
+  {
+    assert(json_token::VALUE_NUMBER_FLOAT == curr_token ||
+           json_token::VALUE_NUMBER_INT == curr_token);
+    return thrust::make_pair(token_start_pos, number_token_len);
+  }
+
+  /**
+   * get float parts
+   */
+  CUDF_HOST_DEVICE thrust::tuple<bool, char const*, int, char const*, int, char const*, int>
+  get_current_float_parts()
+  {
+    assert(json_token::VALUE_NUMBER_FLOAT == curr_token);
+    return thrust::make_tuple(float_sign,
+                              float_integer_pos,
+                              float_integer_len,
+                              float_fraction_pos,
+                              float_fraction_len,
+                              float_exp_pos,
+                              float_exp_len);
+  }
+
+ private:
+  json_parser_options const& options;
+  char const* const json_start_pos;
+  char const* const json_end_pos;
+  char const* curr_pos;
+  json_token curr_token{json_token::INIT};
+
+  // saves the nested contexts: JSON object context or JSON array context
+  // true is JSON object context; false is JSON array context
+  // When encounter EOF and this stack is non-empty, means non-closed JSON
+  // object/array, then parsing will fail.
+  bool stack[max_json_nesting_depth];
+  int stack_size = 0;
+
+  // used by copy number text
+  char const* token_start_pos;
+  // used when token is int/float, int/float string have not escape char, it's
+  // safe to copy verbatim
+  cudf::size_type number_token_len;
+
+  // The following variables record number token informations.
+  // if current token is VALUE_NUMBER_FLOAT, use the following variables to save
+  // float parts e.g.: -123.000456E-000789, sign is false; integer part is 123;
+  // fraction part is 000456; exp part is -000789 The following parts is used by
+  // normalization, e.g.: 0.001 => 1E-2
+  bool float_sign;
+  char const* float_integer_pos;
+  int float_integer_len;
+  char const* float_fraction_pos;
+  int float_fraction_len;
+  char const* float_exp_pos;
+  int float_exp_len;
+  // true indicates has '-' or '+' in the exp part;
+  // the exp sign char is not counted when checking the max number length
+  bool float_exp_has_sign;
+
+  // The following variables record string/field name token informations
+  int string_token_utf8_bytes;
+};
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -63,6 +63,9 @@ ConfigureTest(DATETIME_REBASE
 ConfigureTest(ROW_CONVERSION
     row_conversion.cpp)
 
+ConfigureTest(GET_JSON_OBJECT
+    json_parser_tests.cpp)
+
 ConfigureTest(HASH
     hash.cpp)
 
@@ -77,3 +80,4 @@ ConfigureTest(UTILITIES
 
 ConfigureTest(PARSE_URI
     parse_uri.cpp)
+

--- a/src/main/cpp/tests/json_parser_tests.cpp
+++ b/src/main/cpp/tests/json_parser_tests.cpp
@@ -1,0 +1,847 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf_test/base_fixture.hpp>
+
+#include <json_parser.hpp>
+
+struct JsonParserTests : public cudf::test::BaseFixture {};
+using spark_rapids_jni::json_parser;
+using spark_rapids_jni::json_parser_options;
+using spark_rapids_jni::json_token;
+
+template <int max_json_depth = 128>
+std::vector<json_token> parse(std::string json_str,
+                              bool single_quote,
+                              bool control_char,
+                              bool allow_tailing = true,
+                              int max_string_len = 20000000,
+                              int max_num_len    = 1000)
+{
+  json_parser_options options;
+  options.set_allow_single_quotes(single_quote);
+  options.set_allow_unescaped_control_chars(control_char);
+  options.set_allow_tailing_sub_string(allow_tailing);
+  options.set_max_string_len(max_string_len);
+  options.set_max_num_len(max_num_len);
+  json_parser<max_json_depth> parser(options, json_str.data(), json_str.size());
+  std::vector<json_token> tokens;
+  json_token token = parser.next_token();
+  tokens.push_back(token);
+  while (token != json_token::ERROR && token != json_token::SUCCESS) {
+    token = parser.next_token();
+    tokens.push_back(token);
+  }
+  return tokens;
+}
+
+void test_basic(bool allow_single_quote, bool allow_control_char)
+{
+  std::vector<std::pair<std::string, std::vector<json_token>>> cases = {
+    std::make_pair(
+      // test terminal number
+      std::string{"  \r\n\t  \r\n\t  1   \r\n\t  \r\n\t "},
+      std::vector{json_token::VALUE_NUMBER_INT, json_token::SUCCESS}),
+    std::make_pair(
+      // test terminal float
+      std::string{"  \r\n\t  \r\n\t  1.5   \r\n\t  \r\n\t "},
+      std::vector{json_token::VALUE_NUMBER_FLOAT, json_token::SUCCESS}),
+    std::make_pair(
+      // test terminal string
+      std::string{"  \r\n\t  \r\n\t  \"abc\"   \r\n\t  \r\n\t "},
+      std::vector{json_token::VALUE_STRING, json_token::SUCCESS}),
+    std::make_pair(
+      // test terminal true
+      std::string{"  \r\n\t  \r\n\t  true   \r\n\t  \r\n\t "},
+      std::vector{json_token::VALUE_TRUE, json_token::SUCCESS}),
+    std::make_pair(
+      // test terminal false
+      std::string{"  \r\n\t  \r\n\t  false   \r\n\t  \r\n\t "},
+      std::vector{json_token::VALUE_FALSE, json_token::SUCCESS}),
+    std::make_pair(
+      // test terminal null
+      std::string{"  \r\n\t  \r\n\t  null   \r\n\t  \r\n\t "},
+      std::vector{json_token::VALUE_NULL, json_token::SUCCESS}),
+
+    std::make_pair(
+      // test numbers
+      std::string{R"(
+            [
+              0, 102, -0, -102, 0.3, -0.3000, 1e-050, -1e-5, 1.0e-5, -1.0010e-050, 1E+5, 1e0, 1E0, 1.3e5, -1e01, 1e00000
+            ]
+          )"},
+      std::vector{json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::END_ARRAY,
+                  json_token::SUCCESS}),
+    std::make_pair(
+      // test string
+      std::string{"\"美国,中国\\u12f3\\u113E---abc---\\\", \\/, \\\\, \\b, "
+                  "\\f, \\n, \\r, \\t\""},
+      std::vector{json_token::VALUE_STRING, json_token::SUCCESS}),
+    std::make_pair(
+      // test empty object
+      std::string{"  {   }   "},
+      std::vector{json_token::START_OBJECT, json_token::END_OBJECT, json_token::SUCCESS}),
+    std::make_pair(
+      // test empty array
+      std::string{"   [   ]   "},
+      std::vector{json_token::START_ARRAY, json_token::END_ARRAY, json_token::SUCCESS}),
+    std::make_pair(
+      // test nesting arrays
+      std::string{R"(
+            [
+              1 ,
+              [
+                2 ,
+                [
+                  3 ,
+                  [
+                    41 , 42 , 43
+                  ]
+                ]
+              ]
+            ]
+          )"},
+      std::vector{json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::END_ARRAY,
+                  json_token::END_ARRAY,
+                  json_token::END_ARRAY,
+                  json_token::END_ARRAY,
+                  json_token::SUCCESS}),
+    std::make_pair(
+      // test nesting objects
+      std::string{R"(
+            {
+              "k1" : "v1" ,
+              "k2" : {
+                "k3" : {
+                  "k4" : {
+                    "k51" : "v51" ,
+                    "k52" : "v52"
+                  }
+                }
+              }
+            }
+          )"},
+      std::vector{json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_STRING,
+                  json_token::FIELD_NAME,
+                  json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_STRING,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_STRING,
+                  json_token::END_OBJECT,
+                  json_token::END_OBJECT,
+                  json_token::END_OBJECT,
+                  json_token::END_OBJECT,
+                  json_token::SUCCESS}),
+    std::make_pair(
+      // test nesting objects and arrays
+      std::string{R"(
+            {
+              "k1" : "v1",
+              "k2" : [
+                1, {
+                  "k21" : "v21",
+                  "k22" : [1 , 2 , -1.5]
+                }
+              ]
+            }
+          )"},
+      std::vector{json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_STRING,
+                  json_token::FIELD_NAME,
+                  json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_STRING,
+                  json_token::FIELD_NAME,
+                  json_token::START_ARRAY,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::VALUE_NUMBER_FLOAT,
+                  json_token::END_ARRAY,
+                  json_token::END_OBJECT,
+                  json_token::END_ARRAY,
+                  json_token::END_OBJECT,
+                  json_token::SUCCESS}),
+
+    std::make_pair(
+      // test invalid string: should have 4 HEX
+      std::string{"\"  \\uFFF  \""},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid string: invalid HEX 'T'
+      std::string{"\"  \\uTFFF  \""},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid string: unclosed string
+      std::string{"  \"abc   "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid string: have no char after escape char '\'
+      std::string{"\"\\"},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid string:  \X is not allowed
+      std::string{"\" \\X   \""},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid num
+      std::string{" +5 "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid num
+      std::string{" 1.  "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid num
+      std::string{" 1e  "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid num
+      std::string{" 1e-  "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid num
+      std::string{" infinity  "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{" {"},
+      std::vector{json_token::START_OBJECT, json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{" ["},
+      std::vector{json_token::START_ARRAY, json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{" {1} "},
+      std::vector{json_token::START_OBJECT, json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{R"(
+        {"k",}
+      )"},
+      std::vector{json_token::START_OBJECT, json_token::FIELD_NAME, json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{R"(
+        {"k": }
+      )"},
+      std::vector{json_token::START_OBJECT, json_token::FIELD_NAME, json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{R"(
+        {"k": 1 :}
+      )"},
+      std::vector{json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::ERROR}),
+
+    std::make_pair(
+      // test invalid structure
+      std::string{R"(
+        {"k": 1 , }
+      )"},
+      std::vector{json_token::START_OBJECT,
+                  json_token::FIELD_NAME,
+                  json_token::VALUE_NUMBER_INT,
+                  json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{R"(
+        [ 1 :
+      )"},
+      std::vector{json_token::START_ARRAY, json_token::VALUE_NUMBER_INT, json_token::ERROR}),
+    std::make_pair(
+      // test invalid structure
+      std::string{R"(
+        [ 1,
+      )"},
+      std::vector{json_token::START_ARRAY, json_token::VALUE_NUMBER_INT, json_token::ERROR}),
+    std::make_pair(
+      // test invalid null
+      std::string{" nul "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid false
+      std::string{" fals "},
+      std::vector{json_token::ERROR}),
+    std::make_pair(
+      // test invalid true
+      std::string{" tru "},
+      std::vector{json_token::ERROR}),
+
+  };
+  for (std::size_t i = 0; i < cases.size(); ++i) {
+    std::string json_str                    = cases[i].first;
+    std::vector<json_token> expected_tokens = cases[i].second;
+    std::vector<json_token> actual_tokens = parse(json_str, allow_single_quote, allow_control_char);
+    ASSERT_EQ(actual_tokens, expected_tokens);
+  }
+}
+
+void test_len_limitation()
+{
+  std::vector<std::string> v;
+  v.push_back("  '123456'        ");
+  v.push_back("  'k\n\\'\\\"56'  ");  // do not count escape char '\', actual
+                                      // has 6 chars: k \n ' " 5 6
+  v.push_back("  123456          ");
+  v.push_back("  -1.23e-456      ");
+
+  auto error_token = std::vector<json_token>{json_token::ERROR};
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,  //  bool single_quote,
+                                                  true,  // control_char
+                                                  true,  // allow_tailing
+                                                  5,     // max_string_len
+                                                  5);    // max_num_len
+    // exceed num/str length limits
+    ASSERT_EQ(actual_tokens, error_token);
+  }
+
+  v.clear();
+  v.push_back("   '12345'           ");
+  v.push_back("   'k\n\\'\\\"5'     ");  // do not count escape char '\',
+                                         // has 5 chars: k \n ' " 5
+  auto expect_str_ret = std::vector<json_token>{json_token::VALUE_STRING, json_token::SUCCESS};
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,  // bool single_quote,
+                                                  true,  // control_char
+                                                  true,  // allow_tailing
+                                                  5,     // max_string_len
+                                                  5);    // max_num_len
+    ASSERT_EQ(actual_tokens, expect_str_ret);
+  }
+
+  v.clear();
+  v.push_back("    12345            ");
+  v.push_back("    -1.23e-45        ");
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,   // bool single_quote,
+                                                  false,  // control_char
+                                                  true,   // allow_tailing
+                                                  5,      // max_string_len
+                                                  5);     // max_num_len
+    ASSERT_EQ(actual_tokens[1], json_token::SUCCESS);
+  }
+}
+
+void test_single_double_quote()
+{
+  std::vector<std::string> v;
+  // allow \'  \" " in single quote
+  v.push_back("'    \\\'     \\\"      \"          '");
+  // allow \'  \"  ' in double quote
+  v.push_back("\"   \\\' \\\"   '    \'      \"");  // C++ allow \' to represent
+                                                    // ' in string
+  auto expect_ret = std::vector<json_token>{json_token::VALUE_STRING, json_token::SUCCESS};
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,  //  bool single_quote,
+                                                  false  // control_char
+    );
+    ASSERT_EQ(actual_tokens, expect_ret);
+  }
+
+  v.clear();
+  v.push_back("\"     \\'      \"");  // not allow \' when single_quote is disabled
+  expect_ret = std::vector<json_token>{json_token::ERROR};
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  false,  //  bool single_quote,
+                                                  true    // control_char
+    );
+
+    ASSERT_EQ(actual_tokens, expect_ret);
+  }
+
+  v.clear();
+  v.push_back("\"     '   \\\"      \"");  // allow ' \" in double quote
+  expect_ret = std::vector<json_token>{json_token::VALUE_STRING, json_token::SUCCESS};
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  false,  //  bool single_quote,
+                                                  true    // control_char
+    );
+    ASSERT_EQ(actual_tokens, expect_ret);
+  }
+
+  v.clear();
+  v.push_back("      'str'      ");  // ' is not allowed to quote string
+  expect_ret = std::vector<json_token>{json_token::ERROR};
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  false,  //  bool single_quote,
+                                                  true    // control_char
+    );
+    ASSERT_EQ(actual_tokens, expect_ret);
+  }
+}
+
+void test_max_nested_len()
+{
+  std::vector<std::string> v;
+  v.push_back("[[[[[]]]]]");
+  v.push_back("{'k1':{'k2':{'k3':{'k4':{'k5': 5}}}}}");
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    // set max nested len template value as 5
+    std::vector<json_token> actual_tokens = parse<5>(v[i],
+                                                     true,  //  bool single_quote,
+                                                     true   // control_char
+    );
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::SUCCESS);
+  }
+
+  v.clear();
+  v.push_back("[[[[[[]]]]]]");
+  v.push_back("{'k1':{'k2':{'k3':{'k4':{'k5': {'k6': 6}}}}}}");
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    // set max nested len template value as 5
+    std::vector<json_token> actual_tokens = parse<5>(v[i],
+                                                     true,  //  bool single_quote,
+                                                     false  // control_char
+    );
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::ERROR);
+  }
+}
+
+void test_control_char()
+{
+  std::vector<std::string> v;
+  v.push_back("'   \t   \n   \b '");  // \t \n \b are control chars
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    // set max nested len template value as 5
+    std::vector<json_token> actual_tokens = parse<5>(v[i],
+                                                     true,  //  bool single_quote,
+                                                     true   // control_char
+    );
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::SUCCESS);
+  }
+
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    // set max nested len template value as 5
+    std::vector<json_token> actual_tokens = parse<5>(v[i],
+                                                     true,  //  bool single_quote,
+                                                     false  // control_char
+    );
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::ERROR);
+  }
+}
+
+void test_allow_tailing_useless_chars()
+{
+  std::vector<std::string> v;
+  v.push_back("  0xxxx        ");  // 0 is valid JSON, tailing xxxx is ignored
+                                   // when allow tailing
+  v.push_back("  {}xxxx  ");       // tailing xxxx is ignored
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,  //  bool single_quote,
+                                                  true,  // control_char
+                                                  true   // allow_tailing is true
+    );
+    ASSERT_TRUE(actual_tokens.size() > 0);
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::SUCCESS);
+  }
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,  //  bool single_quote,
+                                                  true,  // control_char
+                                                  false  // allow_tailing is false
+    );
+    ASSERT_TRUE(actual_tokens.size() > 0);
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::ERROR);
+  }
+
+  v.clear();
+  v.push_back("    12345xxxxxx            ");
+  v.push_back("    -1.23e-45xxxxx   ");
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    std::vector<json_token> actual_tokens = parse(v[i],
+                                                  true,   //  bool single_quote,
+                                                  false,  // control_char
+                                                  true,   // allow_tailing
+                                                  5,      // max_string_len
+                                                  5);     // max_num_len
+    ASSERT_TRUE(actual_tokens.size() > 0);
+    ASSERT_EQ(actual_tokens[actual_tokens.size() - 1], json_token::SUCCESS);
+  }
+}
+
+void test_is_valid()
+{
+  std::string json_str = " {    \"k\"   :     [1,2,3]}   ";
+  json_parser_options options;
+  json_parser<10> parser1(options, json_str.data(), json_str.size());
+  ASSERT_TRUE(parser1.is_valid());
+
+  json_str = " {[1,2,    ";
+  json_parser<10> parser2(options, json_str.data(), json_str.size());
+  ASSERT_FALSE(parser2.is_valid());
+}
+
+TEST_F(JsonParserTests, NormalTest)
+{
+  test_basic(/*single_quote*/ true, /*control_char*/ true);
+  test_basic(/*single_quote*/ true, /*control_char*/ false);
+  test_basic(/*single_quote*/ false, /*control_char*/ true);
+  test_basic(/*single_quote*/ false, /*control_char*/ false);
+  test_len_limitation();
+  test_single_double_quote();
+  test_max_nested_len();
+  test_control_char();
+  test_allow_tailing_useless_chars();
+  test_is_valid();
+}
+
+template <int max_json_depth = 128>
+std::unique_ptr<json_parser<max_json_depth>> get_parser(std::string const& json_str,
+                                                        bool single_quote,
+                                                        bool control_char,
+                                                        bool allow_tailing = true,
+                                                        int max_string_len = 20000000,
+                                                        int max_num_len    = 1000)
+{
+  json_parser_options options;
+  options.set_allow_single_quotes(single_quote);
+  options.set_allow_unescaped_control_chars(control_char);
+  options.set_allow_tailing_sub_string(allow_tailing);
+  options.set_max_string_len(max_string_len);
+  options.set_max_num_len(max_num_len);
+  return std::make_unique<json_parser<max_json_depth>>(options, json_str.data(), json_str.size());
+}
+
+TEST_F(JsonParserTests, SkipChildrenForObject)
+{
+  // test skip for the first {
+  std::string json = " { 'k1' : 'v1' , 'k2' : { 'k3' : { 'k4' : 'v5' }  }  } ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+  // can not skip for INIT token
+  ASSERT_FALSE(parser.try_skip_children());
+  ASSERT_EQ(json_token::START_OBJECT, parser.next_token());
+  // test skip for tokens: {
+  ASSERT_TRUE(parser.try_skip_children());
+  ASSERT_EQ(json_token::END_OBJECT, parser.get_current_token());
+  ASSERT_EQ(json_token::SUCCESS, parser.next_token());
+  // can not skip for SUCCESS token
+  ASSERT_FALSE(parser.try_skip_children());
+
+  // test skip for tokens: not [ {
+  parser.reset();
+  ASSERT_EQ(json_token::START_OBJECT, parser.next_token());
+  ASSERT_EQ(json_token::FIELD_NAME, parser.next_token());
+  ASSERT_TRUE(parser.try_skip_children());
+  ASSERT_EQ(json_token::FIELD_NAME, parser.get_current_token());
+}
+
+TEST_F(JsonParserTests, SkipChildrenForArray)
+{
+  // skip for [
+  std::string json = " [ [ [ [ 1, 2, 3 ] ] ] ] ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+  ASSERT_FALSE(parser.try_skip_children());
+  ASSERT_EQ(json_token::START_ARRAY, parser.next_token());
+  ASSERT_EQ(json_token::START_ARRAY, parser.next_token());
+  ASSERT_TRUE(parser.try_skip_children());
+  ASSERT_EQ(json_token::END_ARRAY, parser.get_current_token());
+  ASSERT_EQ(json_token::END_ARRAY, parser.next_token());
+  ASSERT_EQ(json_token::SUCCESS, parser.next_token());
+  // can not skip for SUCCESS token
+  ASSERT_FALSE(parser.try_skip_children());
+
+  parser.reset();
+  // can not skip for INIT token
+  ASSERT_FALSE(parser.try_skip_children());
+}
+
+TEST_F(JsonParserTests, SkipChildrenInvalid)
+{
+  std::string json = " invalid ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+  parser.next_token();
+  ASSERT_EQ(json_token::ERROR, parser.get_current_token());
+  // can not skip for ERROR token
+  ASSERT_FALSE(parser.try_skip_children());
+}
+
+void clear_buff(char buf[], std::size_t size) { memset(buf, 0, size); }
+
+void assert_start_with(char* buf, std::size_t buf_size, const std::string& prefix)
+{
+  std::string str(buf, buf_size);
+  ASSERT_EQ(0, str.find(prefix));
+  for (std::size_t i = prefix.size(); i < str.size(); i++) {
+    ASSERT_EQ('\0', str[i]);
+  }
+}
+
+TEST_F(JsonParserTests, CopyRawStringText)
+{
+  constexpr std::size_t buf_size = 256;
+  char buf[buf_size];
+
+  std::string json = " {  'key123'  :  'value123' } ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::START_OBJECT, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(1, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "{");
+
+  ASSERT_EQ(json_token::FIELD_NAME, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(6, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "key123");
+
+  ASSERT_EQ(json_token::VALUE_STRING, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(8, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "value123");
+
+  ASSERT_EQ(json_token::END_OBJECT, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(1, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "}");
+}
+
+TEST_F(JsonParserTests, CopyRawNumberText)
+{
+  constexpr std::size_t buf_size = 256;
+  char buf[buf_size];
+
+  std::string json = " [  -12345 ,  -1.23e-000123 , true , false , null  ] ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::START_ARRAY, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(1, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "[");
+
+  ASSERT_EQ(json_token::VALUE_NUMBER_INT, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(6, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "-12345");
+
+  ASSERT_EQ(json_token::VALUE_NUMBER_FLOAT, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(13, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "-1.23e-000123");
+
+  ASSERT_EQ(json_token::VALUE_TRUE, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(4, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "true");
+
+  ASSERT_EQ(json_token::VALUE_FALSE, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(5, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "false");
+
+  ASSERT_EQ(json_token::VALUE_NULL, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(4, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "null");
+
+  ASSERT_EQ(json_token::END_ARRAY, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(1, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "]");
+
+  ASSERT_EQ(json_token::SUCCESS, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(0, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "");
+}
+
+TEST_F(JsonParserTests, CopyRawTextInvalid)
+{
+  constexpr std::size_t buf_size = 256;
+  char buf[buf_size];
+
+  std::string json = " invalid ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::INIT, parser.get_current_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(0, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "");
+
+  ASSERT_EQ(json_token::ERROR, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(0, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "");
+}
+
+TEST_F(JsonParserTests, CopyRawTextEscape)
+{
+  constexpr std::size_t buf_size = 256;
+  char buf[buf_size];
+  // test escape: \", \', \\, \/, \b, \f, \n, \r, \t
+  std::string json = "   '\\\"\\'\\\\\\/\\b\\f\\n\\r\\t\\b'   ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+  // avoid unused-but-set-variable compile warnning
+  parser.reset();
+
+  ASSERT_EQ(json_token::VALUE_STRING, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(10, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "\"\'\\/\b\f\n\r\t\b");
+}
+
+TEST_F(JsonParserTests, CopyRawTextUnicode)
+{
+  // "中国".getBytes(StandardCharsets.UTF_8) is:
+  // Array(-28, -72, -83, -27, -101, -67)
+  constexpr std::size_t buf_size = 256;
+  char buf[buf_size];
+  auto json   = "   '\\u4e2d\\u56FD'   ";  // Represents 中国
+  auto parser = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::VALUE_STRING, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(6, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "中国");
+}
+
+TEST_F(JsonParserTests, CopyRawTextOther)
+{
+  constexpr std::size_t buf_size = 256;
+  char buf[buf_size];
+  auto json   = "   '中国'   ";
+  auto parser = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::VALUE_STRING, parser.next_token());
+  clear_buff(buf, buf_size);
+  ASSERT_EQ(6, parser.copy_raw_text(buf));
+  assert_start_with(buf, buf_size, "中国");
+}
+
+void assert_ptr_len(char const* actaul_ptr,
+                    cudf::size_type actual_len,
+                    char* expected_ptr,
+                    cudf::size_type expected_len)
+{
+  ASSERT_EQ(expected_ptr, actaul_ptr);
+  ASSERT_EQ(expected_len, actual_len);
+}
+
+TEST_F(JsonParserTests, GetNumberText)
+{
+  std::string json = "[-12.45e056,123456789]  ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::INIT, parser.get_current_token());
+  ASSERT_EQ(json_token::START_ARRAY, parser.next_token());
+
+  ASSERT_EQ(json_token::VALUE_NUMBER_FLOAT, parser.next_token());
+  auto [ptr1, len1] = parser.get_current_number_text();
+  assert_ptr_len(ptr1, len1, json.data() + 1, 10);
+
+  ASSERT_EQ(json_token::VALUE_NUMBER_INT, parser.next_token());
+  auto [ptr2, len2] = parser.get_current_number_text();
+  assert_ptr_len(ptr2, len2, json.data() + 12, 9);
+}
+
+void assert_float_parts(bool float_sign,
+                        char const* float_integer_pos,
+                        int float_integer_len,
+                        char const* float_fraction_pos,
+                        int float_fraction_len,
+                        char const* float_exp_pos,
+                        int float_exp_len,
+                        bool actual_float_sign,
+                        char const* actual_float_integer_pos,
+                        int actual_float_integer_len,
+                        char const* actual_float_fraction_pos,
+                        int actual_float_fraction_len,
+                        char const* actual_float_exp_pos,
+                        int actual_float_exp_len)
+{
+  ASSERT_EQ(float_sign, actual_float_sign);
+  ASSERT_EQ(float_integer_pos, actual_float_integer_pos);
+  ASSERT_EQ(float_integer_len, actual_float_integer_len);
+  ASSERT_EQ(float_fraction_pos, actual_float_fraction_pos);
+  ASSERT_EQ(float_fraction_len, actual_float_fraction_len);
+  ASSERT_EQ(float_exp_pos, actual_float_exp_pos);
+  ASSERT_EQ(float_exp_len, actual_float_exp_len);
+}
+
+TEST_F(JsonParserTests, GetFloatParts)
+{
+  // int part is 123, fraction part is 0345, exp part is -05678
+  std::string json = "[-123.0345e-05678]  ";
+  auto parser      = *get_parser(json, /*single_quote*/ true, /*control_char*/ true);
+
+  ASSERT_EQ(json_token::INIT, parser.get_current_token());
+  ASSERT_EQ(json_token::START_ARRAY, parser.next_token());
+
+  ASSERT_EQ(json_token::VALUE_NUMBER_FLOAT, parser.next_token());
+  auto parts = parser.get_current_float_parts();
+  assert_float_parts(false,
+                     json.data() + 2,
+                     3,
+                     json.data() + 6,
+                     4,
+                     json.data() + 11,
+                     6,
+                     thrust::get<0>(parts),
+                     thrust::get<1>(parts),
+                     thrust::get<2>(parts),
+                     thrust::get<3>(parts),
+                     thrust::get<4>(parts),
+                     thrust::get<5>(parts),
+                     thrust::get<6>(parts));
+}


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids-jni/issues/1827
closes https://github.com/NVIDIA/spark-rapids-jni/issues/1829

- Add JSON parser
- JSON parser utility: copy_raw_text, skip_children
- Define internal interfaces for JSON generator, JSON parser, JSON path parser
- Copy get-json-obj CUDA code from cuDF

Signed-off-by: Chong Gao <res_life@163.com>
