### PR TITLE
Update to make_strings_column returning uvector

### DIFF
--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -191,7 +191,7 @@ struct dispatch_decimal_to_non_ansi_string_fn {
 
     return make_strings_column(input.size(),
                                std::move(offsets),
-                               std::move(chars->release().data.release()[0]),
+                               chars.release(),
                                input.null_count(),
                                cudf::detail::copy_bitmask(input, stream, mr));
   }

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -88,7 +88,7 @@ struct dispatch_float_to_string_fn {
 
     return make_strings_column(strings_count,
                                std::move(offsets),
-                               std::move(chars->release().data.release()[0]),
+                               chars.release(),
                                floats.null_count(),
                                cudf::detail::copy_bitmask(floats, stream, mr));
   }

--- a/src/main/cpp/src/format_float.cu
+++ b/src/main/cpp/src/format_float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ struct dispatch_format_float_fn {
 
     return cudf::make_strings_column(strings_count,
                                      std::move(offsets),
-                                     std::move(chars->release().data.release()[0]),
+                                     chars.release(),
                                      floats.null_count(),
                                      cudf::detail::copy_bitmask(floats, stream, mr));
   }

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -574,11 +574,8 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
 
   auto [offsets, chars] = cudf::strings::detail::make_strings_children(
     substring_fn{unified_json_buff, extract_ranges}, num_extract, stream, mr);
-  return cudf::make_strings_column(num_extract,
-                                   std::move(offsets),
-                                   chars.release(),
-                                   0,
-                                   rmm::device_buffer{});
+  return cudf::make_strings_column(
+    num_extract, std::move(offsets), chars.release(), 0, rmm::device_buffer{});
 }
 
 // Compute the offsets for the final lists of Struct<String,String>.

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -572,11 +572,11 @@ std::unique_ptr<cudf::column> extract_keys_or_values(
                                                                   stream);
   auto const num_extract = thrust::distance(extract_ranges.begin(), range_end);
 
-  auto children = cudf::strings::detail::make_strings_children(
+  auto [offsets, chars] = cudf::strings::detail::make_strings_children(
     substring_fn{unified_json_buff, extract_ranges}, num_extract, stream, mr);
   return cudf::make_strings_column(num_extract,
-                                   std::move(children.first),
-                                   std::move(children.second->release().data.release()[0]),
+                                   std::move(offsets),
+                                   chars.release(),
                                    0,
                                    rmm::device_buffer{});
 }


### PR DESCRIPTION
Fixes #1835 and the submodule sync error reported at #1834.  rapidsai/cudf#15171 changed `make_strings_column` to return a uvector, so this updates the spark-rapids-jni code accordingly.