### PR TITLE
Add GPU architectures to the build-info file

### DIFF
--- a/build/build-info
+++ b/build/build-info
@@ -32,6 +32,7 @@ echo_build_properties() {
   echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
+  echo gpu_architectures=$(cd "$git_path" && find . -name libcudfjni.a -o -name libcudf.a | xargs -n 1 bash -c 'cuobjdump $1 || exit 0' _ | grep 'arch = ' | awk -F_ '{print $2}' | sort -n -u)
   for arg in "$@"; do
     echo $arg
   done

--- a/build/build-info
+++ b/build/build-info
@@ -34,7 +34,7 @@ echo_build_properties() {
   echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
-  echo gpu_architectures=$(cuobjdump "$libcudf_path" 2>/dev/null | grep 'arch = ' | awk -F_ '{print $2}' | sort -n -u | tr '\n' ';')
+  echo gpu_architectures=$(cuobjdump "$libcudf_path" 2>/dev/null | awk -F_ '/arch =/ {print $2}' | sort -n -u | tr '\n' ';')
   for arg in "$@"; do
     echo $arg
   done

--- a/build/build-info
+++ b/build/build-info
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,19 +20,21 @@
 # Arguments:
 #   version  - The current version of the project
 #   git_path - The path to the repository
+#   library_path - The path to the libcudf library
 set -e
 
 echo_build_properties() {
   version=$1
   git_path=$2
-  shift 2
+  library_path=$3
+  shift 3
   echo version=$version
   echo user=$USER
   echo revision=$(cd "$git_path" && git rev-parse HEAD)
   echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
-  echo gpu_architectures=$(cd "$git_path" && find . -name libcudfjni.a -o -name libcudf.a | xargs -n 1 bash -c 'cuobjdump $1 || exit 0' _ | grep 'arch = ' | awk -F_ '{print $2}' | sort -n -u)
+  echo gpu_architectures=$(cd "$git_path" && cuobjdump "$library_path" 2>/dev/null | grep 'arch = ' | awk -F_ '{print $2}' | sort -n -u | tr '\n' ';')
   for arg in "$@"; do
     echo $arg
   done

--- a/build/build-info
+++ b/build/build-info
@@ -20,13 +20,13 @@
 # Arguments:
 #   version  - The current version of the project
 #   git_path - The path to the repository
-#   library_path - The path to the libcudf library
+#   libcudf_path - The path to the libcudf library
 set -e
 
 echo_build_properties() {
   version=$1
   git_path=$2
-  library_path=$3
+  libcudf_path=$3
   shift 3
   echo version=$version
   echo user=$USER
@@ -34,7 +34,7 @@ echo_build_properties() {
   echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
-  echo gpu_architectures=$(cd "$git_path" && cuobjdump "$library_path" 2>/dev/null | grep 'arch = ' | awk -F_ '{print $2}' | sort -n -u | tr '\n' ';')
+  echo gpu_architectures=$(cuobjdump "$libcudf_path" 2>/dev/null | grep 'arch = ' | awk -F_ '{print $2}' | sort -n -u | tr '\n' ';')
   for arg in "$@"; do
     echo $arg
   done

--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,7 @@
                   <arg value="${project.basedir}/build/build-info"/>
                   <arg value="${project.version}"/>
                   <arg value="${cudf.path}"/>
+                  <arg value="${libcudf.build.path}/libcudf.a"/>
                 </exec>
                 <exec executable="bash"
                       output="${project.build.directory}/extra-resources/spark-rapids-jni-version-info.properties"
@@ -483,6 +484,7 @@
                   <arg value="${project.basedir}/build/build-info"/>
                   <arg value="${project.version}"/>
                   <arg value="${project.basedir}"/>
+                  <arg value="${native.build.path}/libcudf.so"/>
                 </exec>
               </target>
             </configuration>


### PR DESCRIPTION
Related Issue: NVIDIA/spark-rapids#10430

Based on the discussion thread [here](https://github.com/NVIDIA/spark-rapids/pull/10540#discussion_r1511695519), a new property named `gpu_architectures` has been added in the `version-info.properties` file. This property stores a semicolon-separated list of GPU architectures supported by the cuDF and JNI plugin. 

The plugin will parse this property and verify if the user is running Spark RAPIDS job on a supported architecture.

### Output

File: `spark-rapids-jni-version-info.properties`
```
version=24.04.0-SNAPSHOT
user=
revision=4daf3f8c8bcd5ebaeff12f77ee99ba45e8e0ed46
branch=spark-rapids-jni-10430
date=2024-03-06T22:14:26Z
url=https://github.com/NVIDIA/spark-rapids-jni.git
gpu_architectures=70;75;80;86;90;
```

File:  `cudf-java-version-info.properties`
```
version=24.04.0-SNAPSHOT
user=
revision=8d073e4ca0a6cb9d9a4d9fe5e4e0147f01d7eb36
branch=HEAD
date=2024-03-06T22:14:23Z
url=https://github.com/rapidsai/cudf.git
gpu_architectures=70;75;80;86;90;
```