### PR TITLE
Remove deprecated `supports_streams()` from `spark_resource_adaptor`.

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -401,8 +401,6 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
 
   rmm::mr::device_memory_resource* get_wrapped_resource() { return resource; }
 
-  bool supports_streams() const noexcept override { return resource->supports_streams(); }
-
   /**
    * Update the internal state so that a specific thread is dedicated to a task.
    * This may be called multiple times for a given thread and if the thread is already


### PR DESCRIPTION
Fixes #1814. (Possibly only partially.)

This change removes the override of `spark_resource_adaptor::supports_stream()`, in light of https://github.com/rapidsai/rmm/issues/1389, which deprecated the method.  This should get rid of the deprecation warnings in the `spark-rapids-jni` builds.

Similar to https://github.com/rapidsai/cudf/pull/14857, this change removes the deprecated override.

