### PR TITLE
Update to support checkout to the cudf release tag [skip ci]

### DIFF
--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -65,11 +65,7 @@ fi
 
 echo "Try update cudf submodule to ${cudf_sha}..."
 git add .
-if [ -n "$CUDF_TAG" ]; then
-  git diff-index --quiet HEAD || git commit -s -m "Update submodule cudf to ${CUDF_TAG}"
-else
-  git diff-index --quiet HEAD || git commit -s -m "Update submodule cudf to ${cudf_sha}"
-fi
+git diff-index --quiet HEAD || git commit -s -m "Update submodule cudf to ${CUDF_TAG:-$cudf_sha}"
 sha=$(git rev-parse HEAD)
 
 echo "Test against ${cudf_sha}..."

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,8 +49,14 @@ else
   git merge origin/${REF}
 fi
 
-# sync up cudf from remote
-git submodule update --remote --merge
+# sync up cudf from remote, checkout to cudf release tag if CUDF_TAG is set
+if [ -n "$CUDF_TAG" ]; then
+  pushd thirdparty/cudf
+  git checkout tags/$CUDF_TAG
+  popd
+else
+  git submodule update --remote --merge
+fi
 cudf_sha=$(git -C thirdparty/cudf rev-parse HEAD)
 if [[ "${cudf_sha}" == "${cudf_prev_sha}" ]]; then
   echo "Submodule is up to date."
@@ -59,7 +65,11 @@ fi
 
 echo "Try update cudf submodule to ${cudf_sha}..."
 git add .
-git diff-index --quiet HEAD || git commit -s -m "Update submodule cudf to ${cudf_sha}"
+if [ -n "$CUDF_TAG" ]; then
+  git diff-index --quiet HEAD || git commit -s -m "Update submodule cudf to ${CUDF_TAG}"
+else
+  git diff-index --quiet HEAD || git commit -s -m "Update submodule cudf to ${cudf_sha}"
+fi
 sha=$(git rev-parse HEAD)
 
 echo "Test against ${cudf_sha}..."


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids-jni/issues/1852

Update ci/submodule-sync.sh to support pinning cudf submodule to the release tag,

then CI job can run the auto release leveraging this change.

