### PR TITLE
Improve build-info script

### DIFF
--- a/build/build-info
+++ b/build/build-info
@@ -35,10 +35,15 @@ echo_build_properties() {
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
   echo gpu_architectures=$(
-    cuobjdump libcudf.a | \
-    awk '
-      match($0, /arch = sm_([0-9]+)/, tmp) { arch[tmp[1]]=1 } 
-      END { for (a in arch) s = s ";" a; printf substr(s, 2) }
+    cuobjdump "$libcudf_path" | gawk '
+      match($0, /arch = sm_([0-9]+)/, tmp) { arch[tmp[1]]=tmp[1] }
+      END {
+     	asort(arch) 
+      	for (i in arch) {
+	  s = s ";" arch[i]
+        }
+	printf substr(s, 2) 
+      }
     '
   )
   for arg in "$@"; do

--- a/build/build-info
+++ b/build/build-info
@@ -44,7 +44,7 @@ echo_build_properties() {
       END {
         n = asorti(arch)
         if (n == 0) {
-          print "ERROR: No fatbin ELF / PTX code sections found"
+          print "ERROR: No fatbin ELF / PTX code sections found" > "/dev/stderr"
           exit(1)
         }
         s = arch[1]

--- a/build/build-info
+++ b/build/build-info
@@ -22,8 +22,9 @@
 #   git_path - The path to the repository
 #   libcudf_path - The path to the libcudf library
 set -e
-
+set -o pipefail
 echo_build_properties() {
+
   version=$1
   git_path=$2
   libcudf_path=$3
@@ -34,18 +35,22 @@ echo_build_properties() {
   echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
-  echo gpu_architectures=$(
+  gpu_architectures=$(
     cuobjdump "$libcudf_path" | gawk '
-      match($0, /arch = sm_([0-9]+)/, tmp) { arch[tmp[1]]=tmp[1] }
+      match($0, /arch = sm_([0-9]+)/, tmp) {
+        arch[tmp[1]]=tmp[1]
+      }
+
       END {
-     	asort(arch) 
-      	for (i in arch) {
-	  s = s ";" arch[i]
+        asort(arch)
+        for (i in arch) {
+          s = s ";" arch[i]
         }
-	printf substr(s, 2) 
+        printf substr(s, 2)
       }
     '
   )
+  echo "gpu_architectures=$gpu_architectures"
   for arg in "$@"; do
     echo $arg
   done

--- a/build/build-info
+++ b/build/build-info
@@ -38,17 +38,17 @@ echo_build_properties() {
   gpu_architectures=$(
     cuobjdump "$libcudf_path" | gawk '
       match($0, /arch = sm_([0-9]+)/, tmp) {
-        arch[tmp[1]]=tmp[1]
+        arch[tmp[1]] = 1
       }
 
       END {
-        n=asort(arch)
+        n = asorti(arch)
         if (n == 0) {
           print "ERROR: No fatbin ELF / PTX code sections found"
           exit(1)
         }
         s = arch[1]
-        for (i = 2; i<=n; i++) {
+        for (i = 2; i <= n; i++) {
           s = s ";" arch[i]
         }
         printf s

--- a/build/build-info
+++ b/build/build-info
@@ -34,7 +34,13 @@ echo_build_properties() {
   echo branch=$(cd "$git_path" && git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo url=$(cd "$git_path" && git config --get remote.origin.url)
-  echo gpu_architectures=$(cuobjdump "$libcudf_path" 2>/dev/null | awk -F_ '/arch =/ {print $2}' | sort -n -u | tr '\n' ';')
+  echo gpu_architectures=$(
+    cuobjdump libcudf.a | \
+    awk '
+      match($0, /arch = sm_([0-9]+)/, tmp) { arch[tmp[1]]=1 } 
+      END { for (a in arch) s = s ";" a; printf substr(s, 2) }
+    '
+  )
   for arg in "$@"; do
     echo $arg
   done

--- a/build/build-info
+++ b/build/build-info
@@ -51,7 +51,7 @@ echo_build_properties() {
         for (i = 2; i <= n; i++) {
           s = s ";" arch[i]
         }
-        printf s
+        print s
       }
     '
   )

--- a/build/build-info
+++ b/build/build-info
@@ -23,8 +23,8 @@
 #   libcudf_path - The path to the libcudf library
 set -e
 set -o pipefail
-echo_build_properties() {
 
+echo_build_properties() {
   version=$1
   git_path=$2
   libcudf_path=$3
@@ -42,11 +42,16 @@ echo_build_properties() {
       }
 
       END {
-        asort(arch)
-        for (i in arch) {
+        n=asort(arch)
+        if (n == 0) {
+          print "ERROR: No fatbin ELF / PTX code sections found"
+          exit(1)
+        }
+        s = arch[1]
+        for (i = 2; i<=n; i++) {
           s = s ";" arch[i]
         }
-        printf substr(s, 2)
+        printf s
       }
     '
   )


### PR DESCRIPTION
When running the script outside Docker on the host without CUDA runtime I noticed that it may succeed while generating a corrupt properties file.

```
version=24.04.0-SNAPSHOT
user=user1
revision=d9ec683518b78fb3a52272b324f2184f19381318
branch=branchXY
date=2024-03-11T18:01:51Z
url=git@github.com:NVIDIA/spark-rapids-jni
/home/user1/gits/NVIDIA/spark-rapids-jni/build/build-info: line 53: cuobjdump: command not found
```

This PR improves the script as follows:

- Enable pipefail option to make sure that errors in the pipe are detected by bash
- Separate assignment gpu_architectures to avoid masking the subshell failure by `echo`
- Since awk is symlinked to gawk in the Docker image, we can implement the entire logic for gpu archs in gawk
- Removing the trailing ';' from the list of archs

**Testing**

```
~/gits/NVIDIA/spark-rapids-jni$ $PWD/build/build-info 24.04.0-SNAPSHOT $PWD $PWD/target/libcudf-install/lib64/libcudf.a 
version=24.04.0-SNAPSHOT
user=user1
revision=d9ec683518b78fb3a52272b324f2184f19381318
branch=fixTrailingSemicolon
date=2024-03-11T21:18:48Z
url=git@github.com:NVIDIA/spark-rapids-jni
/home/user1/gits/NVIDIA/spark-rapids-jni/build/build-info: line 53: cuobjdump: command not found
~/gits/NVIDIA/spark-rapids-jni$ echo $?
127
```

```
./build/run-in-docker $PWD/build/build-info 24.04.0-SNAPSHOT $PWD $PWD/target/libcudf-install/lib64/libcudf.a 
version=24.04.0-SNAPSHOT
user=user1
revision=d9ec683518b78fb3a52272b324f2184f19381318
branch=fixTrailingSemicolon
date=2024-03-11T18:27:31Z
url=git@github.com:NVIDIA/spark-rapids-jni
gpu_architectures=75;86
```

