### PR TITLE
Use NVTX from GitHub.

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -94,6 +94,9 @@ include(cmake/Modules/ConfigureCUDA.cmake) # set other CUDA compilation flags
 # ##################################################################################################
 # * dependencies ----------------------------------------------------------------------------------
 
+# find NVTX
+include(${CUDF_DIR}/cpp/cmake/thirdparty/get_nvtx.cmake)
+
 # find CCCL
 include(${CUDF_DIR}/cpp/cmake/thirdparty/get_cccl.cmake)
 
@@ -224,6 +227,7 @@ target_link_libraries(
   -Wl,--whole-archive
     ${CUDFJNI_LIB}
     cudf::cudf
+    nvtx3-cpp
   -Wl,--no-whole-archive
     ${PARQUET_LIB}
     ${THRIFT_LIB}


### PR DESCRIPTION
This PR adds a CMake dependency on NVTX to accomodate spark-rapids-jni usage of libcudf internal headers.

This follows up on https://github.com/rapidsai/cudf/pull/15178, https://github.com/rapidsai/cudf/issues/15270, and https://github.com/rapidsai/cudf/pull/15271.

This fixes the build errors in https://github.com/NVIDIA/spark-rapids-jni/pull/1855.
