### PR TITLE
Pin to 3.1.0 maven-gpg-plugin in deploy script [skip ci]

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,14 +69,15 @@ IFS="$ORI_IFS"
 FIRST_FILE=${CLASS_FILES%%,*}
 cp -f "$FIRST_FILE" "$FPATH.jar"
 
+GPG_PLUGIN="org.apache.maven.plugins:maven-gpg-plugin:3.1.0:sign-and-deploy-file"
 ###### Build the deploy command ######
 if [ "$SIGN_FILE" == true ]; then
     case $SIGN_TOOL in
         nvsec)
-            DEPLOY_CMD="$MVN gpg:sign-and-deploy-file -Dgpg.executable=nvsec_sign"
+            DEPLOY_CMD="$MVN $GPG_PLUGIN -Dgpg.executable=nvsec_sign"
             ;;
         gpg)
-            DEPLOY_CMD="$MVN gpg:sign-and-deploy-file -Dgpg.passphrase=$GPG_PASSPHRASE "
+            DEPLOY_CMD="$MVN $GPG_PLUGIN -Dgpg.passphrase=$GPG_PASSPHRASE "
             ;;
         *)
             echo "Error unsupported sign type : $SIGN_TYPE !"


### PR DESCRIPTION
Refer to: https://github.com/NVIDIA/spark-rapids/issues/10624

As latest maven-gpg-plugin has the issue "error 401 Unauthorized"

when deploy files onto Sonatype repo, we pin it to the

stable version 3.1.0 to unblock our release process.

