### PR TITLE
[auto-merge] bot-auto-merge-branch-24.04 to branch-24.06 [skip ci] [bot]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -55,7 +55,7 @@ jobs:
       wbo4958,\
       wjxiz1992,\
       sperlingxx,\
-      pxLi,\
+      YanxuanLiu,\
       hyperbolic2346,\
       gerashegalov,\
       ttnghia,\


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-24.04` to create a PR keeping `branch-24.06` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.