### PR TITLE
Remove tests of deleted cudf::hash HASH_MURMUR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <libcudf.build.configure>false</libcudf.build.configure>
     <libcudf.clean.skip>true</libcudf.clean.skip>
     <libcudf.install.path>${project.build.directory}/libcudf-install</libcudf.install.path>
-    <libcudf.dependency.mode>pinned</libcudf.dependency.mode>
+    <libcudf.dependency.mode>latest</libcudf.dependency.mode>
     <libcudfjni.build.path>${project.build.directory}/libcudfjni</libcudfjni.build.path>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/cpp/tests/hash.cpp
+++ b/src/main/cpp/tests/hash.cpp
@@ -30,41 +30,6 @@ constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_leve
 
 class HashTest : public cudf::test::BaseFixture {};
 
-TEST_F(HashTest, MultiValue)
-{
-  cudf::test::strings_column_wrapper const strings_col(
-    {"",
-     "The quick brown fox",
-     "jumps over the lazy dog.",
-     "All work and no play makes Jack a dull boy",
-     R"(!"#$%&'()*+,-./0123456789:;<=>?@[\]^_`{|}~)"});
-
-  using limits = std::numeric_limits<int32_t>;
-  cudf::test::fixed_width_column_wrapper<int32_t> const ints_col(
-    {0, 100, -100, limits::min(), limits::max()});
-
-  // Different truth values should be equal
-  cudf::test::fixed_width_column_wrapper<bool> const bools_col1({0, 1, 1, 1, 0});
-  cudf::test::fixed_width_column_wrapper<bool> const bools_col2({0, 1, 2, 255, 0});
-
-  using ts = cudf::timestamp_s;
-  cudf::test::fixed_width_column_wrapper<ts, ts::duration> const secs_col(
-    {ts::duration::zero(),
-     static_cast<ts::duration>(100),
-     static_cast<ts::duration>(-100),
-     ts::duration::min(),
-     ts::duration::max()});
-
-  auto const input1 = cudf::table_view({strings_col, ints_col, bools_col1, secs_col});
-  auto const input2 = cudf::table_view({strings_col, ints_col, bools_col2, secs_col});
-
-  auto const output1 = cudf::hash(input1);
-  auto const output2 = cudf::hash(input2);
-
-  EXPECT_EQ(input1.num_rows(), output1->size());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(output1->view(), output2->view());
-}
-
 TEST_F(HashTest, MultiValueNulls)
 {
   // Nulls with different values should be equal
@@ -116,14 +81,6 @@ TEST_F(HashTest, MultiValueNulls)
   auto const input2 = cudf::table_view({strings_col2, ints_col2, bools_col2, secs_col2});
 
   {
-    auto const output1 = cudf::hash(input1);
-    auto const output2 = cudf::hash(input2);
-
-    EXPECT_EQ(input1.num_rows(), output1->size());
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output1->view(), output2->view());
-  }
-
-  {
     auto const output1 = spark_rapids_jni::murmur_hash3_32(input1, 0);
     auto const output2 = spark_rapids_jni::murmur_hash3_32(input2);
 
@@ -141,221 +98,6 @@ TEST_F(HashTest, MultiValueNulls)
   }
 }
 
-TEST_F(HashTest, BasicList)
-{
-  using LCW = cudf::test::lists_column_wrapper<uint64_t>;
-  using ICW = cudf::test::fixed_width_column_wrapper<uint32_t>;
-
-  auto const col = LCW{{}, {}, {1}, {1, 1}, {1}, {1, 2}, {2, 2}, {2}, {2}, {2, 1}, {2, 2}, {2, 2}};
-  auto const input  = cudf::table_view({col});
-  auto const expect = ICW{1607593296,
-                          1607593296,
-                          -636010097,
-                          -132459357,
-                          -636010097,
-                          -2008850957,
-                          -1023787369,
-                          761197503,
-                          761197503,
-                          1340177511,
-                          -1023787369,
-                          -1023787369};
-
-  auto const output = cudf::hash(input);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, output->view(), verbosity);
-
-  auto const expect_seeded = ICW{1607594268u,
-                                 1607594268u,
-                                 1576790066u,
-                                 1203671017u,
-                                 1576790066u,
-                                 2107478077u,
-                                 1756855002u,
-                                 2228938758u,
-                                 2228938758u,
-                                 3491134126u,
-                                 1756855002u,
-                                 1756855002u};
-
-  auto const seeded_output = cudf::hash(input, cudf::hash_id::HASH_MURMUR3, 15);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect_seeded, seeded_output->view(), verbosity);
-}
-
-TEST_F(HashTest, NullableList)
-{
-  using LCW = cudf::test::lists_column_wrapper<uint64_t>;
-  using ICW = cudf::test::fixed_width_column_wrapper<uint32_t>;
-
-  auto const valids = std::vector<bool>{1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0};
-  auto const col =
-    LCW{{{}, {}, {1}, {1}, {2, 2}, {2}, {2}, {}, {2, 2}, {2, 2}, {}}, valids.begin()};
-  auto expect = ICW{-2023148619,
-                    -2023148619,
-                    -31671896,
-                    -31671896,
-                    -1205248335,
-                    1865773848,
-                    1865773848,
-                    -2023148682,
-                    -1205248335,
-                    -1205248335,
-                    -2023148682};
-
-  auto const output = cudf::hash(cudf::table_view({col}));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, output->view(), verbosity);
-
-  auto const expect_seeded = ICW{2271820643u,
-                                 2271820643u,
-                                 1038318696u,
-                                 1038318696u,
-                                 595138041u,
-                                 3027840870u,
-                                 3027840870u,
-                                 2271820578u,
-                                 595138041u,
-                                 595138041u,
-                                 2271820578u};
-
-  auto const seeded_output = cudf::hash(cudf::table_view({col}), cudf::hash_id::HASH_MURMUR3, 31);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect_seeded, seeded_output->view(), verbosity);
-}
-
-TEST_F(HashTest, ListOfStruct)
-{
-  auto col1 = cudf::test::fixed_width_column_wrapper<int32_t>{
-    {-1, -1, 0, 2, 2, 2, 1, 2, 0, 2, 0, 2, 0, 2, 0, 0, 1, 2},
-    {1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0}};
-  auto col2 = cudf::test::strings_column_wrapper{
-    {"x", "x", "a", "a", "b", "b", "a", "b", "a", "b", "a", "c", "a", "c", "a", "c", "b", "b"},
-    {1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1}};
-  auto struct_col = cudf::test::structs_column_wrapper{
-    {col1, col2}, {0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}};
-
-  auto offsets = cudf::test::fixed_width_column_wrapper<cudf::size_type>{
-    0, 0, 0, 0, 0, 2, 3, 4, 5, 6, 8, 10, 12, 14, 15, 16, 17, 18};
-
-  auto list_nullmask = std::vector<bool>{1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
-  auto list_column = cudf::make_lists_column(
-    17, offsets.release(), struct_col.release(), null_count, std::move(null_mask));
-
-  auto expect = cudf::test::fixed_width_column_wrapper<uint32_t>{83451479,
-                                                                 83451479,
-                                                                 83455332,
-                                                                 83455332,
-                                                                 -759684425,
-                                                                 -959632766,
-                                                                 -959632766,
-                                                                 -959632766,
-                                                                 -959636527,
-                                                                 -656998704,
-                                                                 613652814,
-                                                                 1902080426,
-                                                                 1902080426,
-                                                                 2061025592,
-                                                                 2061025592,
-                                                                 -319840811,
-                                                                 -319840811};
-
-  auto const output = cudf::hash(cudf::table_view({*list_column}));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, output->view(), verbosity);
-
-  auto expect_seeded = cudf::test::fixed_width_column_wrapper<uint32_t>{81710442u,
-                                                                        81710442u,
-                                                                        81729816u,
-                                                                        81729816u,
-                                                                        3532787573u,
-                                                                        3642097855u,
-                                                                        3642097855u,
-                                                                        3642097855u,
-                                                                        3642110391u,
-                                                                        3889855760u,
-                                                                        1494406307u,
-                                                                        103934081u,
-                                                                        103934081u,
-                                                                        3462063680u,
-                                                                        3462063680u,
-                                                                        1696730835u,
-                                                                        1696730835u};
-
-  auto const seeded_output =
-    cudf::hash(cudf::table_view({*list_column}), cudf::hash_id::HASH_MURMUR3, 619);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect_seeded, seeded_output->view(), verbosity);
-}
-
-TEST_F(HashTest, ListOfEmptyStruct)
-{
-  // []
-  // []
-  // Null
-  // Null
-  // [Null, Null]
-  // [Null, Null]
-  // [Null, Null]
-  // [Null]
-  // [Null]
-  // [{}]
-  // [{}]
-  // [{}, {}]
-  // [{}, {}]
-
-  auto struct_validity = std::vector<bool>{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1};
-  auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(struct_validity.begin(), struct_validity.end());
-  auto struct_col = cudf::make_structs_column(14, {}, null_count, std::move(null_mask));
-
-  auto offsets = cudf::test::fixed_width_column_wrapper<cudf::size_type>{
-    0, 0, 0, 0, 0, 2, 4, 6, 7, 8, 9, 10, 12, 14};
-  auto list_nullmask = std::vector<bool>{1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  std::tie(null_mask, null_count) =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
-  auto list_column = cudf::make_lists_column(
-    13, offsets.release(), std::move(struct_col), null_count, std::move(null_mask));
-
-  auto expect = cudf::test::fixed_width_column_wrapper<uint32_t>{2271818677u,
-                                                                 2271818677u,
-                                                                 2271818614u,
-                                                                 2271818614u,
-                                                                 3954409013u,
-                                                                 3954409013u,
-                                                                 3954409013u,
-                                                                 2295666275u,
-                                                                 2295666275u,
-                                                                 2295666276u,
-                                                                 2295666276u,
-                                                                 3954409052u,
-                                                                 3954409052u};
-
-  auto output = cudf::hash(cudf::table_view({*list_column}));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, output->view(), verbosity);
-}
-
-TEST_F(HashTest, EmptyDeepList)
-{
-  // List<List<int>>, where all lists are empty
-  // []
-  // []
-  // Null
-  // Null
-
-  // Internal empty list
-  auto list1 = cudf::test::lists_column_wrapper<int>{};
-
-  auto offsets       = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 0, 0, 0, 0};
-  auto list_nullmask = std::vector<bool>{1, 1, 0, 0};
-  auto [null_mask, null_count] =
-    cudf::test::detail::make_null_mask(list_nullmask.begin(), list_nullmask.end());
-  auto list_column = cudf::make_lists_column(
-    4, offsets.release(), list1.release(), null_count, std::move(null_mask));
-
-  auto expect = cudf::test::fixed_width_column_wrapper<uint32_t>{
-    2271818677u, 2271818677u, 2271818614u, 2271818614u};
-
-  auto output = cudf::hash(cudf::table_view({*list_column}));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, output->view(), verbosity);
-}
-
 template <typename T>
 class HashTestTyped : public cudf::test::BaseFixture {};
 
@@ -367,15 +109,6 @@ TYPED_TEST(HashTestTyped, Equality)
   auto const input = cudf::table_view({col});
 
   // Hash of same input should be equal
-
-  {
-    auto const output1 = cudf::hash(input);
-    auto const output2 = cudf::hash(input);
-
-    EXPECT_EQ(input.num_rows(), output1->size());
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output1->view(), output2->view());
-  }
-
   {
     auto const output1 = spark_rapids_jni::murmur_hash3_32(input, 0);
     auto const output2 = spark_rapids_jni::murmur_hash3_32(input);
@@ -403,14 +136,6 @@ TYPED_TEST(HashTestTyped, EqualityNulls)
 
   auto const input1 = cudf::table_view({col1});
   auto const input2 = cudf::table_view({col2});
-
-  {
-    auto const output1 = cudf::hash(input1);
-    auto const output2 = cudf::hash(input2);
-
-    EXPECT_EQ(input1.num_rows(), output1->size());
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output1->view(), output2->view());
-  }
 
   {
     auto const output1 = spark_rapids_jni::murmur_hash3_32(input1, 0);
@@ -453,13 +178,6 @@ TYPED_TEST(HashTestFloatTyped, TestExtremes)
   auto const table_col          = cudf::table_view({col});
   auto const table_col_neg_zero = cudf::table_view({col_neg_zero});
   auto const table_col_neg_nan  = cudf::table_view({col_neg_nan});
-
-  auto const hash_col          = cudf::hash(table_col);
-  auto const hash_col_neg_zero = cudf::hash(table_col_neg_zero);
-  auto const hash_col_neg_nan  = cudf::hash(table_col_neg_nan);
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*hash_col, *hash_col_neg_zero, verbosity);
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*hash_col, *hash_col_neg_nan, verbosity);
 
   // Spark hash is sensitive to 0 and -0
   {

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -139,7 +139,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "8675b2c9ccaa33130cc2e5a291f3fff31f7c903d",
+      "git_tag" : "cdf20a665cc3a0bc0da96975de336ce70408dcf6",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "version" : "24.06"
     },


### PR DESCRIPTION
- Removes tests for the default `cudf::hash`
- Updates cudf deps pins to workaround the issue being fixed by #1928 

Testing:

```bash
$ cd thirdparty/cudf
$ git checkout branch-24.06
$ cd -
$ ./build/build-in-docker clean install -DGPU_ARCHS='NATIVE' -DBUILD_TESTS=0N -DskipTests -Dlibcudf.clean.skip=false -Dlibcudf.dependency.mode=latest -Dsubmodule.check.skip 
$ ./target/cmake-build/gtests/HASH
```

Fixes #1926 
    
Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
