### PR TITLE
Trim C0 control chars in string to number type conversion

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -45,6 +45,7 @@ constexpr auto NUM_THREADS{256};
  */
 constexpr bool is_whitespace(char const chr)
 {
+  if (chr >= 0x0000 && chr <= 0x001F) { return true; }
   switch (chr) {
     case ' ':
     case '\r':

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -38,7 +38,7 @@ namespace detail {
 constexpr auto NUM_THREADS{256};
 
 /**
- * @brief Identify if a character is whitespace.
+ * @brief Identify if a character is whitespace or C0 control code.
  *
  * @param chr character to test
  * @return true if character is a whitespace character

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -36,13 +36,14 @@ namespace detail {
 __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
 
 /**
- * @brief Identify if a character is whitespace.
+ * @brief Identify if a character is whitespace or C0 control code.
  *
  * @param chr character to test
  * @return true if character is a whitespace character
  */
 constexpr bool is_whitespace(char const chr)
 {
+  if (chr >= 0x0000 && chr <= 0x001F) { return true; }
   switch (chr) {
     case ' ':
     case '\r':

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -33,14 +33,14 @@ public class CastStringsTest {
   @Test
   void castToIntegerTest() {
     Table.TestBuilder tb = new Table.TestBuilder();
-    tb.column(3l, 9l, 4l, 2l, 20l, null, null);
-    tb.column(5, 1, 0, 2, 7, null, null);
-    tb.column(new Byte[]{2, 3, 4, 5, 9, null, null});
+    tb.column(3l, 9l, 4l, 2l, 20l, null, null, 1l);
+    tb.column(5, 1, 0, 2, 7, null, null, 1);
+    tb.column(new Byte[]{2, 3, 4, 5, 9, null, null, 1});
     try (Table expected = tb.build()) {
       Table.TestBuilder tb2 = new Table.TestBuilder();
-      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
-      tb2.column("5", "1  ", "0", "2", "7.1", null, "asdf");
-      tb2.column("2", "3", " 4 ", "5", " 9.2 ", null, "7.8.3");
+      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd", "\u0000 \u001f1\u0014");
+      tb2.column("5", "1  ", "0", "2", "7.1", null, "asdf", "\u0000 \u001f1\u0014");
+      tb2.column("2", "3", " 4 ", "5", " 9.2 ", null, "7.8.3", "\u0000 \u001f1\u0014");
 
       List<ColumnVector> result = new ArrayList<>();
       try (Table origTable = tb2.build()) {
@@ -161,17 +161,17 @@ public class CastStringsTest {
   @Test
   void castToDecimalTest() {
     Table.TestBuilder tb = new Table.TestBuilder();
-    tb.decimal32Column(0,3, 9, 4, 2, 21, null, null);
-    tb.decimal64Column(0, 5l, 1l, 0l, 2l, 7l, null, null);
-    tb.decimal32Column(-1, 20, 30, 40, 51, 92, null, null);
+    tb.decimal32Column(0,3, 9, 4, 2, 21, null, null, 1);
+    tb.decimal64Column(0, 5l, 1l, 0l, 2l, 7l, null, null, 1l);
+    tb.decimal32Column(-1, 20, 30, 40, 51, 92, null, null, 10);
     try (Table expected = tb.build()) {
       int[] desiredPrecision = new int[]{2, 10, 3};
       int[] desiredScale = new int[]{0, 0, -1};
 
       Table.TestBuilder tb2 = new Table.TestBuilder();
-      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd");
-      tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf");
-      tb2.column("2", "3", " 4 ", "5.07", "9.23", null, "7.8.3");
+      tb2.column(" 3", "9", "4", "2", "20.5", null, "7.6asd", "\u0000 \u001f1\u0014");
+      tb2.column("5", "1 ", "0", "2", "7.1", null, "asdf", "\u0000 \u001f1\u0014");
+      tb2.column("2", "3", " 4 ", "5.07", "9.23", null, "7.8.3", "\u0000 \u001f1\u0014");
 
       List<ColumnVector> result = new ArrayList<>();
       try (Table origTable = tb2.build()) {


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10724

In Spark, string to double will trim the string using [String.trim](https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/lang/String.html), so it will trim characters equal to or less than '\u0020' (blank space).

This PR matches this behavior.

WIP for testing.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
