### PR TITLE
Explicitly pull in GTest dependency when building C++ tests

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 
 # cudf
 if(BUILD_TESTS)
+  find_package(GTest REQUIRED)
   rapids_find_package(cudf REQUIRED COMPONENTS testing)
 else()
   rapids_find_package(cudf REQUIRED)


### PR DESCRIPTION
@robertmaynard let us know that our explicit use of an implicit GTest dependency via libcudf is going to break in an upcoming libcudf update.  This updates our build with his suggested change to make the dependency explicit.