### PR TITLE
Remove Path key/subscript to save GPU memory usage to improve perf

### DIFF
--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -322,25 +322,12 @@ __device__ inline bool path_match_elements(path_instruction const* path_ptr,
   return path_ptr[0].type == path_type0 && path_ptr[1].type == path_type1;
 }
 
-__device__ inline bool path_match_elements(path_instruction const* path_ptr,
-                                           size_t path_size,
-                                           path_instruction_type path_type0,
-                                           path_instruction_type path_type1,
-                                           path_instruction_type path_type2,
-                                           path_instruction_type path_type3)
+__device__ inline thrust::tuple<bool, int> path_match_index(path_instruction const* path_ptr,
+                                                            size_t path_size)
 {
-  if (path_size < 4) { return false; }
-  return path_ptr[0].type == path_type0 && path_ptr[1].type == path_type1 &&
-         path_ptr[2].type == path_type2 && path_ptr[3].type == path_type3;
-}
-
-__device__ inline thrust::tuple<bool, int> path_match_subscript_index(
-  path_instruction const* path_ptr, size_t path_size)
-{
-  auto match = path_match_elements(
-    path_ptr, path_size, path_instruction_type::SUBSCRIPT, path_instruction_type::INDEX);
+  auto match = path_match_element(path_ptr, path_size, path_instruction_type::INDEX);
   if (match) {
-    return thrust::make_tuple(true, path_ptr[1].index);
+    return thrust::make_tuple(true, path_ptr[0].index);
   } else {
     return thrust::make_tuple(false, 0);
   }
@@ -357,17 +344,13 @@ __device__ inline thrust::tuple<bool, cudf::string_view> path_match_named(
   }
 }
 
-__device__ inline thrust::tuple<bool, int> path_match_subscript_index_subscript_wildcard(
+__device__ inline thrust::tuple<bool, int> path_match_index_wildcard(
   path_instruction const* path_ptr, size_t path_size)
 {
-  auto match = path_match_elements(path_ptr,
-                                   path_size,
-                                   path_instruction_type::SUBSCRIPT,
-                                   path_instruction_type::INDEX,
-                                   path_instruction_type::SUBSCRIPT,
-                                   path_instruction_type::WILDCARD);
+  auto match = path_match_elements(
+    path_ptr, path_size, path_instruction_type::INDEX, path_instruction_type::WILDCARD);
   if (match) {
-    return thrust::make_tuple(true, path_ptr[1].index);
+    return thrust::make_tuple(true, path_ptr[0].index);
   } else {
     return thrust::make_tuple(false, 0);
   }
@@ -696,7 +679,7 @@ __device__ bool evaluate_path(json_parser& p,
   // There is a same constant in JSONUtil.java, keep them consistent when changing
   // Note: Spark-Rapids should guarantee the path depth is less or equal to this limit,
   // or GPU reports cudaErrorIllegalAddress
-  constexpr int max_path_depth = 16;
+  constexpr int max_path_depth = 8;
 
   // define stack; plus 1 indicates root context task needs an extra memory
   context stack[max_path_depth + 1];
@@ -770,37 +753,53 @@ __device__ bool evaluate_path(json_parser& p,
         ctx.dirty        = 1;
         ctx.task_is_done = true;
       }
-      // case (START_OBJECT, Key :: xs)
+      // case (START_OBJECT, Named :: xs)
       // case path 4
       else if (json_token::START_OBJECT == ctx.token &&
-               path_match_element(ctx.path_ptr, ctx.path_size, path_instruction_type::KEY)) {
-        if (json_token::END_OBJECT != p.next_token()) {
+               thrust::get<0>(path_match_named(ctx.path_ptr, ctx.path_size))) {
+        // match first mached children with expected name
+        bool found_expected_child = false;
+        while (json_token::END_OBJECT != p.next_token()) {
           // JSON validation check
           if (json_token::ERROR == p.get_current_token()) { return false; }
 
-          if (ctx.dirty > 0) {
-            // once a match has been found we can skip other fields
+          // need to try more children
+          auto match_named = path_match_named(ctx.path_ptr, ctx.path_size);
+          auto named       = thrust::get<1>(match_named);
+          // current token is FIELD_NAME
+          if (p.match_current_field_name(named)) {
+            // skip FIELD_NAME token
+            if (json_token::ERROR == p.next_token()) { return false; }
+            // meets null token, it's not expected, return false
+            if (json_token::VALUE_NULL == p.get_current_token()) { return false; }
+            // push sub task; sub task will update the result of path 4
+            push_context(
+              p.get_current_token(), 4, ctx.g, ctx.style, ctx.path_ptr + 1, ctx.path_size - 1);
+            found_expected_child = true;
+            break;
+          } else {
+            // skip FIELD_NAME token
+            if (json_token::ERROR == p.next_token()) { return false; }
+
+            // current child is not expected, skip current child
             if (!p.try_skip_children()) {
               // JSON validation check
               return false;
             }
-          } else {
-            // need to try more children
-            push_context(
-              p.get_current_token(), 4, ctx.g, ctx.style, ctx.path_ptr + 1, ctx.path_size - 1);
           }
-        } else {
-          ctx.task_is_done = true;
+        }
+
+        if (!found_expected_child) {
+          // did not find any expected sub child
+          return false;
         }
       }
-      // case (START_ARRAY, Subscript :: Wildcard :: Subscript :: Wildcard :: xs)
+      // case (START_ARRAY, Wildcard :: Wildcard :: xs)
       // case path 5
       else if (json_token::START_ARRAY == ctx.token &&
                path_match_elements(ctx.path_ptr,
                                    ctx.path_size,
-                                   path_instruction_type::SUBSCRIPT,
                                    path_instruction_type::WILDCARD,
-                                   path_instruction_type::SUBSCRIPT,
                                    path_instruction_type::WILDCARD)) {
         // special handling for the non-structure preserving double wildcard
         // behavior in Hive
@@ -816,20 +815,17 @@ __device__ bool evaluate_path(json_parser& p,
                        5,
                        ctx.g,
                        write_style::flatten_style,
-                       ctx.path_ptr + 4,
-                       ctx.path_size - 4);
+                       ctx.path_ptr + 2,
+                       ctx.path_size - 2);
         } else {
           ctx.g.write_end_array();
           ctx.task_is_done = true;
         }
       }
-      // case (START_ARRAY, Subscript :: Wildcard :: xs) if style != QuotedStyle
+      // case (START_ARRAY, Wildcard :: xs) if style != QuotedStyle
       // case path 6
       else if (json_token::START_ARRAY == ctx.token &&
-               path_match_elements(ctx.path_ptr,
-                                   ctx.path_size,
-                                   path_instruction_type::SUBSCRIPT,
-                                   path_instruction_type::WILDCARD) &&
+               path_match_element(ctx.path_ptr, ctx.path_size, path_instruction_type::WILDCARD) &&
                ctx.style != write_style::quoted_style) {
         // retain Flatten, otherwise use Quoted... cannot use Raw within an array
         write_style next_style = write_style::raw_style;
@@ -859,7 +855,7 @@ __device__ bool evaluate_path(json_parser& p,
           // track the number of array elements and only emit an outer array if
           // we've written more than one element, this matches Hive's behavior
           push_context(
-            p.get_current_token(), 6, child_g, next_style, ctx.path_ptr + 2, ctx.path_size - 2);
+            p.get_current_token(), 6, child_g, next_style, ctx.path_ptr + 1, ctx.path_size - 1);
         } else {
           char* child_g_start = child_g.get_output_start_position();
           size_t child_g_len  = child_g.get_output_len();
@@ -877,13 +873,10 @@ __device__ bool evaluate_path(json_parser& p,
           }  // else do not write anything
         }
       }
-      // case (START_ARRAY, Subscript :: Wildcard :: xs)
+      // case (START_ARRAY, Wildcard :: xs)
       // case path 7
       else if (json_token::START_ARRAY == ctx.token &&
-               path_match_elements(ctx.path_ptr,
-                                   ctx.path_size,
-                                   path_instruction_type::SUBSCRIPT,
-                                   path_instruction_type::WILDCARD)) {
+               path_match_element(ctx.path_ptr, ctx.path_size, path_instruction_type::WILDCARD)) {
         if (ctx.is_first_enter) {
           ctx.is_first_enter = false;
           ctx.g.write_start_array();
@@ -899,20 +892,18 @@ __device__ bool evaluate_path(json_parser& p,
                        7,
                        ctx.g,
                        write_style::quoted_style,
-                       ctx.path_ptr + 2,
-                       ctx.path_size - 2);
+                       ctx.path_ptr + 1,
+                       ctx.path_size - 1);
         } else {
           ctx.g.write_end_array();
           ctx.task_is_done = true;
         }
       }
-      /* case (START_ARRAY, Subscript :: Index(idx) :: (xs@Subscript :: Wildcard :: _)) */
+      /* case (START_ARRAY, Index(idx) :: (xs@Wildcard :: _)) */
       // case path 8
       else if (json_token::START_ARRAY == ctx.token &&
-               thrust::get<0>(
-                 path_match_subscript_index_subscript_wildcard(ctx.path_ptr, ctx.path_size))) {
-        int idx = thrust::get<1>(
-          path_match_subscript_index_subscript_wildcard(ctx.path_ptr, ctx.path_size));
+               thrust::get<0>(path_match_index_wildcard(ctx.path_ptr, ctx.path_size))) {
+        int idx = thrust::get<1>(path_match_index_wildcard(ctx.path_ptr, ctx.path_size));
 
         p.next_token();
         // JSON validation check
@@ -940,14 +931,14 @@ __device__ bool evaluate_path(json_parser& p,
                      8,
                      ctx.g,
                      write_style::quoted_style,
-                     ctx.path_ptr + 2,
-                     ctx.path_size - 2);
+                     ctx.path_ptr + 1,
+                     ctx.path_size - 1);
       }
-      // case (START_ARRAY, Subscript :: Index(idx) :: xs)
+      // case (START_ARRAY, Index(idx) :: xs)
       // case path 9
       else if (json_token::START_ARRAY == ctx.token &&
-               thrust::get<0>(path_match_subscript_index(ctx.path_ptr, ctx.path_size))) {
-        int idx = thrust::get<1>(path_match_subscript_index(ctx.path_ptr, ctx.path_size));
+               thrust::get<0>(path_match_index(ctx.path_ptr, ctx.path_size))) {
+        int idx = thrust::get<1>(path_match_index(ctx.path_ptr, ctx.path_size));
 
         p.next_token();
         // JSON validation check
@@ -971,32 +962,7 @@ __device__ bool evaluate_path(json_parser& p,
 
         // i == 0
         push_context(
-          p.get_current_token(), 9, ctx.g, ctx.style, ctx.path_ptr + 2, ctx.path_size - 2);
-      }
-      // case (FIELD_NAME, Named(name) :: xs) if p.getCurrentName == name
-      // case path 10
-      else if (json_token::FIELD_NAME == ctx.token &&
-               thrust::get<0>(path_match_named(ctx.path_ptr, ctx.path_size)) &&
-               p.match_current_field_name(
-                 thrust::get<1>(path_match_named(ctx.path_ptr, ctx.path_size)))) {
-        if (p.next_token() != json_token::VALUE_NULL) {
-          // JSON validation check
-          if (json_token::ERROR == p.get_current_token()) { return false; }
-          push_context(
-            p.get_current_token(), 10, ctx.g, ctx.style, ctx.path_ptr + 1, ctx.path_size - 1);
-        } else {
-          return false;
-        }
-      }
-      // case (FIELD_NAME, Wildcard :: xs)
-      // case path 11
-      else if (json_token::FIELD_NAME == ctx.token &&
-               path_match_element(ctx.path_ptr, ctx.path_size, path_instruction_type::WILDCARD)) {
-        p.next_token();
-        // JSON validation check
-        if (json_token::ERROR == p.get_current_token()) { return false; }
-        push_context(
-          p.get_current_token(), 11, ctx.g, ctx.style, ctx.path_ptr + 1, ctx.path_size - 1);
+          p.get_current_token(), 9, ctx.g, ctx.style, ctx.path_ptr + 1, ctx.path_size - 1);
       }
       // case _ =>
       // case path 12
@@ -1024,22 +990,24 @@ __device__ bool evaluate_path(json_parser& p,
           // never happen
         }
         // path 2: case (START_ARRAY, Nil) if style == FlattenStyle
-        // path 5: case (START_ARRAY, Subscript :: Wildcard :: Subscript :: Wildcard :: xs)
-        // path 7: case (START_ARRAY, Subscript :: Wildcard :: xs)
+        // path 5: case (START_ARRAY, Wildcard :: Wildcard :: xs)
+        // path 7: case (START_ARRAY, Wildcard :: xs)
         else if (2 == ctx.case_path || 5 == ctx.case_path || 7 == ctx.case_path) {
           // collect result from child task
           p_ctx.dirty += ctx.dirty;
           // copy generator states to parent task;
           p_ctx.g = ctx.g;
         }
-        // case (START_OBJECT, Key :: xs)
+        // case (START_OBJECT, Named :: xs)
         // case path 4
         else if (4 == ctx.case_path) {
-          if (p_ctx.dirty < 1 && ctx.dirty > 0) { p_ctx.dirty = ctx.dirty; }
+          p_ctx.dirty = ctx.dirty;
           // copy generator states to parent task;
           p_ctx.g = ctx.g;
+          // set parent task is done, will pop parent task
+          p_ctx.task_is_done = true;
         }
-        // case (START_ARRAY, Subscript :: Wildcard :: xs) if style != QuotedStyle
+        // case (START_ARRAY, Wildcard :: xs) if style != QuotedStyle
         // case path 6
         else if (6 == ctx.case_path) {
           // collect result from child task
@@ -1047,9 +1015,9 @@ __device__ bool evaluate_path(json_parser& p,
           // update child generator for parent task
           p_ctx.child_g = ctx.g;
         }
-        /* case (START_ARRAY, Subscript :: Index(idx) :: (xs@Subscript :: Wildcard :: _)) */
+        /* case (START_ARRAY, Index(idx) :: (xs@Wildcard :: _)) */
         // case path 8
-        // case (START_ARRAY, Subscript :: Index(idx) :: xs)
+        // case (START_ARRAY, Index(idx) :: xs)
         // case path 9
         else if (8 == ctx.case_path || 9 == ctx.case_path) {
           // collect result from child task
@@ -1062,26 +1030,6 @@ __device__ bool evaluate_path(json_parser& p,
             // advance the token stream to the end of the array
             if (!p.try_skip_children()) { return false; }
           }
-          // task is done
-          p_ctx.task_is_done = true;
-          // copy generator states to parent task;
-          p_ctx.g = ctx.g;
-        }
-        // case (FIELD_NAME, Named(name) :: xs) if p.getCurrentName == name
-        // case path 10
-        else if (10 == ctx.case_path) {
-          // collect result from child task
-          p_ctx.dirty += ctx.dirty;
-          // task is done
-          p_ctx.task_is_done = true;
-          // copy generator states to parent task;
-          p_ctx.g = ctx.g;
-        }
-        // case (FIELD_NAME, Wildcard :: xs)
-        // case path 11
-        else if (11 == ctx.case_path) {
-          // collect result from child task
-          p_ctx.dirty += ctx.dirty;
           // task is done
           p_ctx.task_is_done = true;
           // copy generator states to parent task;
@@ -1118,16 +1066,11 @@ rmm::device_uvector<path_instruction> construct_path_commands(
     auto const& [type, name, index] = inst;
     switch (type) {
       case path_instruction_type::SUBSCRIPT:
-        path_commands.emplace_back(path_instruction{path_instruction_type::SUBSCRIPT});
+      case path_instruction_type::KEY:
+        // skip SUBSCRIPT and KEY to save stack size in `evaluate_path`
         break;
       case path_instruction_type::WILDCARD:
         path_commands.emplace_back(path_instruction{path_instruction_type::WILDCARD});
-        break;
-      case path_instruction_type::KEY:
-        path_commands.emplace_back(path_instruction{path_instruction_type::KEY});
-        path_commands.back().name =
-          cudf::string_view(all_names_scalar.data() + name_pos, name.size());
-        name_pos += name.size();
         break;
       case path_instruction_type::INDEX:
         path_commands.emplace_back(path_instruction{path_instruction_type::INDEX});

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -542,7 +542,8 @@ __device__ bool evaluate_path(json_parser& p,
           }
           if (!found_expected_child) {
             // did not find any expected sub child
-            return false;
+            ctx.task_is_done = true;
+            ctx.dirty        = false;
           }
         }
       }

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -28,7 +28,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("k") };
+        namedPath("k") };
     try (ColumnVector jsonCv = ColumnVector.fromStrings(
         "{\"k\": \"v\"}");
         ColumnVector expected = ColumnVector.fromStrings(
@@ -44,7 +44,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest2() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(),
+
         namedPath("k1_111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
     };
 
@@ -69,7 +69,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest3() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("k1"), keyPath(), namedPath("k2")
+        namedPath("k1"), namedPath("k2")
     };
     String JSON = "{\"k1\":{\"k2\":\"v2\"}}";
     String expectedStr = "v2";
@@ -89,14 +89,14 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest4() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("k1"),
-        keyPath(), namedPath("k2"),
-        keyPath(), namedPath("k3"),
-        keyPath(), namedPath("k4"),
-        keyPath(), namedPath("k5"),
-        keyPath(), namedPath("k6"),
-        keyPath(), namedPath("k7"),
-        keyPath(), namedPath("k8")
+        namedPath("k1"),
+        namedPath("k2"),
+        namedPath("k3"),
+        namedPath("k4"),
+        namedPath("k5"),
+        namedPath("k6"),
+        namedPath("k7"),
+        namedPath("k8")
     };
 
     String JSON = "{\"k1\":{\"k2\":{\"k3\":{\"k4\":{\"k5\":{\"k6\":{\"k7\":{\"k8\":\"v8\"}}}}}}}}";
@@ -117,7 +117,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Baidu_unescape_backslash() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("URdeosurl")
+        namedPath("URdeosurl")
     };
 
     String JSON = "{\"brand\":\"ssssss\",\"duratRon\":15,\"eqTosuresurl\":\"\",\"RsZxarthrl\":false,\"xonRtorsurl\":\"\",\"xonRtorsurlstOTe\":0,\"TRctures\":[{\"RxaGe\":\"VttTs:\\/\\/feed-RxaGe.baRdu.cox\\/0\\/TRc\\/-196588744s840172444s-773690137.zTG\"}],\"Toster\":\"VttTs:\\/\\/feed-RxaGe.baRdu.cox\\/0\\/TRc\\/-196588744s840172444s-773690137.zTG\",\"reserUed\":{\"bRtLate\":391.79,\"xooUZRke\":26876,\"nahrlIeneratRonNOTe\":0,\"useJublRc\":6,\"URdeoRd\":821284086},\"tRtle\":\"ssssssssssmMsssssssssssssssssss\",\"url\":\"s{storehrl}\",\"usersTortraRt\":\"VttTs:\\/\\/feed-RxaGe.baRdu.cox\\/0\\/TRc\\/-6971178959s-664926866s-6096674871.zTG\",\"URdeosurl\":\"http:\\/\\/nadURdeo2.baRdu.cox\\/5fa3893aed7fc0f8231dab7be23efc75s820s6240.xT3\",\"URdeoRd\":821284086}";
@@ -138,7 +138,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Baidu_get_unexist_field_name() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("Vgdezsurl")
+        namedPath("Vgdezsurl")
     };
 
     String JSON = "{\"brand\":\"ssssss\",\"duratgzn\":17,\"eSyzsuresurl\":\"\",\"gswUartWrl\":false,\"Uzngtzrsurl\":\"\",\"UzngtzrsurlstJye\":0,\"ygctures\":[{\"gUaqe\":\"Ittys:\\/\\/feed-gUaqe.bagdu.czU\\/0\\/ygc\\/63025364s-376461312s7528698939.Qyq\"}],\"yzster\":\"Ittys:\\/\\/feed-gUaqe.bagdu.czU\\,\"url\":\"s{stHreqrl}\",\"usersPHrtraIt\":\"LttPs:\\/\\/feed-IUaxe.baIdu.cHU\\/0\\/PIc\\/-1043913002s489796992s-1505641721.Pnx\",\"kIdeHsurl\":\"LttP:\\/\\/nadkIdeH9.baIdu.cHU\\/4d7d308bd7c04e63069fd343adfa792as1790s1080.UP3\",\"kIdeHId\":852890923}";
@@ -251,7 +251,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_index() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), indexPath(1)
+        indexPath(1)
     };
 
     String JSON1 = "[ [0, 1, 2] , [10, [11], [121, 122, 123], 13] ,  [20, 21, 22]]";
@@ -271,7 +271,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_index_index() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), indexPath(1), subscriptPath(), indexPath(2)
+        indexPath(1), indexPath(2)
     };
 
     String JSON1 = "[ [0, 1, 2] , [10, [11], [121, 122, 123], 13] ,  [20, 21, 22]]";
@@ -315,7 +315,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path2() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), wildcardPath(), subscriptPath(), wildcardPath()
+        wildcardPath(), wildcardPath()
     };
 
     String JSON1 = "[ [11, 12], [21, [221, [2221, [22221, 22222]]]], [31, 32] ]";
@@ -355,7 +355,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path4() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("k")
+        namedPath("k")
     };
 
     String JSON1 = "{ 'k' : 'v'  }";
@@ -378,8 +378,8 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path5() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), wildcardPath(), subscriptPath(), wildcardPath(), // $[*][*]
-        keyPath(), namedPath("k")
+        wildcardPath(), wildcardPath(), // $[*][*]
+        namedPath("k")
     };
 
     // flatten the arrays, then query named path "k"
@@ -402,7 +402,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path6() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), wildcardPath()
+        wildcardPath()
     };
     String JSON1 = "[1, [21, 22], 3]";
     String expectedStr1 = "[1,[21,22],3]";
@@ -430,13 +430,13 @@ public class GetJsonObjectTest {
    */
   @Test
   void getJsonObjectTest_Test_case_path7() {
-    // subscriptPath(), wildcardPath() subscriptPath(), wildcardPath() will go to
+    // wildcardPath() wildcardPath() will go to
     // path5
-    // so insert keyPath(), namedPath("k")
+    // so insert namedPath("k")
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), wildcardPath(), // path 6
-        keyPath(), namedPath("k"), // path 4, path 10
-        subscriptPath(), wildcardPath() // path 7
+        wildcardPath(), // path 6
+        namedPath("k"), // path 4, path 10
+        wildcardPath() // path 7
     };
 
     String JSON1 = "[ {'k': [0, 1, 2]}, {'k': [10, 11, 12]}, {'k': [20, 21, 22]}  ]";
@@ -459,7 +459,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path8() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), indexPath(1), subscriptPath(), wildcardPath()
+        indexPath(1), wildcardPath()
     };
     String JSON1 = "[ [0], [10, 11, 12], [2] ]";
     String expectedStr1 = "[10,11,12]";
@@ -479,7 +479,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path9() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), indexPath(1), subscriptPath(), indexPath(1), subscriptPath(), wildcardPath()
+        indexPath(1), indexPath(1), wildcardPath()
     };
     String JSON1 = "[[0, 1, 2], [10, [111, 112, 113], 12], [20, 21, 22]]";
     String expectedStr1 = "[111,112,113]";
@@ -501,7 +501,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_case_path10() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), namedPath("k"), subscriptPath(), indexPath(1)
+        namedPath("k"), indexPath(1)
     };
     String JSON1 = "{'k' : [0,1,2]}";
     String expectedStr1 = "1";
@@ -517,26 +517,24 @@ public class GetJsonObjectTest {
 
   /**
    * Test case paths:
-   * case path 11: case (FIELD_NAME, Wildcard :: xs)
+   * case path 11: case (FIELD_NAME, Key :: Wildcard :: xs)
    * Refer to Spark code:
    * https://github.com/apache/spark/blob/v3.5.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala#L218
-   * path sequence key, wildcard can test path 11, but parser can not produce this
-   * sequence.
-   * Note: Here use manually created key, wildcard sequence to test.
+   * Can not produce this Paths: (key, wildcard)
+   * e.g.: Spark will produces (wildcard) path for path string $.*, instead of (key, wildcard) path
+   * Anyway, here is testing $.*
    */
   @Test
   void getJsonObjectTest_Test_case_path11() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        keyPath(), wildcardPath()
+        wildcardPath()
     };
     String JSON1 = "{'k' : [0,1,2]}";
-    String expectedStr1 = "[0,1,2]";
     String JSON2 = "{'k' : null}";
-    String expectedStr2 = "null";
 
     try (
         ColumnVector jsonCv = ColumnVector.fromStrings(JSON1, JSON2);
-        ColumnVector expected = ColumnVector.fromStrings(expectedStr1, expectedStr2);
+        ColumnVector expected = ColumnVector.fromStrings(null, null);
         ColumnVector actual = JSONUtils.getJsonObject(jsonCv, query)) {
       assertColumnsAreEqual(expected, actual);
     }
@@ -568,7 +566,7 @@ public class GetJsonObjectTest {
   @Test
   void getJsonObjectTest_Test_insert_comma_insert_outer_array() {
     JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
-        subscriptPath(), wildcardPath(), subscriptPath(), wildcardPath(), subscriptPath(), wildcardPath()
+        wildcardPath(), wildcardPath(), wildcardPath()
     };
     String JSON1 = "[ [11, 12], [21, 22]]";
     String expectedStr1 = "[[11,12],[21,22]]";
@@ -580,14 +578,6 @@ public class GetJsonObjectTest {
         ColumnVector actual = JSONUtils.getJsonObject(jsonCv, query)) {
       assertColumnsAreEqual(expected, actual);
     }
-  }
-
-  private JSONUtils.PathInstructionJni keyPath() {
-    return new JSONUtils.PathInstructionJni(JSONUtils.PathInstructionType.KEY, "", -1);
-  }
-
-  private JSONUtils.PathInstructionJni subscriptPath() {
-    return new JSONUtils.PathInstructionJni(JSONUtils.PathInstructionType.SUBSCRIPT, "", -1);
   }
 
   private JSONUtils.PathInstructionJni wildcardPath() {

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -580,6 +580,25 @@ public class GetJsonObjectTest {
     }
   }
 
+  /**
+   * Query: $[*][*][*]
+   */
+  @Test
+  void getJsonObjectTest_15() {
+    JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
+        namedPath("a")
+    };
+    String JSON1 = "{'a':'v1'}";
+    String JSON2 = "{'a':\"b\"c\"}";
+    try (
+        ColumnVector jsonCv = ColumnVector.fromStrings(JSON1, JSON2);
+        ColumnVector expected = ColumnVector.fromStrings("v1", null);
+        ColumnVector actual = JSONUtils.getJsonObject(jsonCv, query)) {
+      assertColumnsAreEqual(expected, actual);
+    }
+  }
+
+
   private JSONUtils.PathInstructionJni wildcardPath() {
     return new JSONUtils.PathInstructionJni(JSONUtils.PathInstructionType.WILDCARD, "", -1);
   }


### PR DESCRIPTION
Remove Path key/subscript to save GPU memory usage to improve perf.

I found less GPU stack memory usage will help on perf.
I decreased the max path depth from 16 to 8, and get perf improvement.
```
constexpr int max_path_depth = 8;
```
And I optimized the main flow logic to reduced query paths:  
- key and named to one path => named
- subscript and index/wildcard to one path => index/wildcard
From the definition of JSON query path,  key and named always ocurr in the same time, and also subscript and index/wildcard are always occur in the same time. So it's safe to reduce (key, named) to (named),  and it's safe to reduce (subscript, index/wildcard) to (index/wildcard)

Note: If query path is a single `wildcard` , e.g.:  $.* , Spark returns null, so the path is equivalent to invalid path.

## performance test
| Customer   | Base line(1st, 2nd, 3rd) | After this PR  | speed |
|------------|-----------|---------|------------|
| customer 1 | 231500 ms, 232760 ms, 232647 ms | 275719 ms, 272898 ms, 274407 ms |   about 84%  |
