### PR TITLE
Use RAPIDS cmake to locate GTest

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -110,7 +110,8 @@ endif()
 
 # cudf
 if(BUILD_TESTS)
-  find_package(GTest REQUIRED)
+  include(${rapids-cmake-dir}/cpm/gtest.cmake)
+  rapids_cpm_gtest(BUILD_STATIC)
   rapids_find_package(cudf REQUIRED COMPONENTS testing)
 else()
   rapids_find_package(cudf REQUIRED)


### PR DESCRIPTION
Fixes submodule sync failure reported at #1993.  We need to use RAPIDS cmake to locate GTest, as a normal find_package will not find it after libcudf dropped it as an exposed dependency.