### PR TITLE
[WIP] get-json-object perf improvement: handle 32 rows per thread

### DIFF
--- a/src/main/cpp/compile_commands.json
+++ b/src/main/cpp/compile_commands.json
@@ -1,0 +1,1 @@
+/home/chongg/code/spark-rapids-jni/target/cmake-build/compile_commands.json


### PR DESCRIPTION
get-json-object perf improvement: handle 32 rows per thread

After this PR, IPC improved from 0.04 to 0.35, L2 hit rate from 51 to 92
Execute time dropped from about 400ms to 52ms.

```
Executed Ipc Active [inst/cycle]	0.35
L2 Hit Rate [%]	92.20
```

Note: lack generating bitmask functions, set all returned strings are valid. Will investigate `__shfl_down_sync` to do the following:
- sum the bitmask between threads in a warp
- sum the bitmask between warps in a block
- sum the bitmask between blocks
Seems the generating bitmask is not heavy work, IMO it will not impact perf significantly.

