### PR TITLE
Fix null handling in `percentile` evaluation when the input histogram is empty

### DIFF
--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -16,7 +16,6 @@
 
 #include "histogram.hpp"
 
-//
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
@@ -33,7 +32,6 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 
-//
 #include <thrust/binary_search.h>
 #include <thrust/for_each.h>
 #include <thrust/functional.h>
@@ -42,7 +40,6 @@
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/scan.h>
 
-//
 #include <type_traits>
 
 namespace spark_rapids_jni {
@@ -69,7 +66,7 @@ struct fill_percentile_fn {
     auto const has_all_nulls = start >= end;
 
     auto const percentage_idx = idx % percentages.size();
-    if (out_validity && percentage_idx == 0) {
+    if (percentage_idx == 0) {
       // If the histogram only contains null elements, the output percentile will be null.
       out_validity[histogram_idx] = has_all_nulls ? 0 : 1;
     }
@@ -191,7 +188,13 @@ struct percentile_dispatcher {
                                 stream,
                                 mr);
 
-    auto const fill_percentile = [&](auto const sorted_validity_it, auto const out_validity) {
+    // We may always have nulls in the output due to either:
+    // - Having nulls in the input, and/or,
+    // - Having empty histograms.
+    auto out_validities =
+      rmm::device_uvector<int8_t>(num_histograms, stream, rmm::mr::get_current_device_resource());
+
+    auto const fill_percentile = [&](auto const sorted_validity_it) {
       auto const sorted_input_it =
         thrust::make_permutation_iterator(data.begin<T>(), ordered_indices);
       thrust::for_each_n(rmm::exec_policy(stream),
@@ -203,22 +206,20 @@ struct percentile_dispatcher {
                                             accumulated_counts,
                                             percentages,
                                             percentiles->mutable_view().begin<double>(),
-                                            out_validity});
+                                            out_validities.begin()});
     };
 
     if (!has_null) {
-      fill_percentile(thrust::make_constant_iterator(true), nullptr);
+      fill_percentile(thrust::make_constant_iterator(true));
     } else {
       auto const sorted_validity_it = thrust::make_permutation_iterator(
         cudf::detail::make_validity_iterator<false>(data), ordered_indices);
-      auto out_validities =
-        rmm::device_uvector<int8_t>(num_histograms, stream, rmm::mr::get_current_device_resource());
-      fill_percentile(sorted_validity_it, out_validities.begin());
-
-      auto [null_mask, null_count] = cudf::detail::valid_if(
-        out_validities.begin(), out_validities.end(), thrust::identity{}, stream, mr);
-      if (null_count > 0) { return {std::move(percentiles), std::move(null_mask), null_count}; }
+      fill_percentile(sorted_validity_it);
     }
+
+    auto [null_mask, null_count] = cudf::detail::valid_if(
+      out_validities.begin(), out_validities.end(), thrust::identity{}, stream, mr);
+    if (null_count > 0) { return {std::move(percentiles), std::move(null_mask), null_count}; }
 
     return {std::move(percentiles), rmm::device_buffer{}, 0};
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/HistogramTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HistogramTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.AssertUtils;
+import ai.rapids.cudf.ColumnVector;
+
+import org.junit.jupiter.api.Test;
+
+public class HistogramTest {
+  @Test
+  void testZeroFrequency() {
+    try (ColumnVector values = ColumnVector.fromInts(5, 10, 30);
+         ColumnVector freqs = ColumnVector.fromLongs(1, 0, 1);
+         ColumnVector histogram = Histogram.createHistogramIfValid(values, freqs, true);
+         ColumnVector percentiles = Histogram.percentileFromHistogram(histogram, new double[]{1},
+             false);
+         ColumnVector expected = ColumnVector.fromBoxedDoubles(5.0, null, 30.0)) {
+      AssertUtils.assertColumnsAreEqual(percentiles, expected);
+    }
+  }
+
+  @Test
+  void testAllNulls() {
+    try (ColumnVector values = ColumnVector.fromBoxedInts(null, null, null);
+         ColumnVector freqs = ColumnVector.fromLongs(1, 2, 3);
+         ColumnVector histogram = Histogram.createHistogramIfValid(values, freqs, true);
+         ColumnVector percentiles = Histogram.percentileFromHistogram(histogram, new double[]{0.5},
+             false);
+         ColumnVector expected = ColumnVector.fromBoxedDoubles(null, null, null)) {
+      AssertUtils.assertColumnsAreEqual(percentiles, expected);
+    }
+  }
+}


### PR DESCRIPTION
Previously, `percentile` outputs a `null` when the input histogram contains all nulls. It missed the case when the input is empty (which also need to output a `null`).

This PR fixes that issue.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2029.