### PR TITLE
Fix string functors to adapt to the new `make_strings_children` from cudf

### DIFF
--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -88,9 +88,9 @@ struct decimal_to_non_ansi_string_fn {
     } else {
       // positive scale or adjusted exponent < -6 means scientific notation
       auto const extra_digits = abs_value_digits > 1 ? 3 : 2;
-      return static_cast<int32_t>(value < 0) +  // sign if negative
-             abs_value_digits +                 // number of digits
-             extra_digits +                     // decimal point if exists, E, +/-
+      return static_cast<int32_t>(value < 0) +            // sign if negative
+             abs_value_digits +                           // number of digits
+             extra_digits +                               // decimal point if exists, E, +/-
              strings::detail::count_digits(
                numeric::detail::abs(adjusted_exponent));  // exponent portion
     }
@@ -128,7 +128,7 @@ struct decimal_to_non_ansi_string_fn {
       d_buffer +=
         strings::detail::integer_to_string(abs_value / exp_ten, d_buffer);  // add the integer part
       if (scale != 0) {
-        *d_buffer++ = '.';  // add decimal point
+        *d_buffer++ = '.';                                                  // add decimal point
 
         thrust::generate_n(thrust::seq, d_buffer, num_zeros, []() { return '0'; });  // add zeros
         d_buffer += num_zeros;

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,9 @@ namespace {
 template <typename FloatType>
 struct float_to_string_fn {
   cudf::column_device_view d_floats;
-  cudf::size_type* d_offsets;
+  cudf::size_type* d_sizes;
   char* d_chars;
+  cudf::detail::input_offsetalator d_offsets;
 
   __device__ cudf::size_type compute_output_size(cudf::size_type idx) const
   {
@@ -56,13 +57,13 @@ struct float_to_string_fn {
   __device__ void operator()(cudf::size_type idx) const
   {
     if (d_floats.is_null(idx)) {
-      if (d_chars == nullptr) { d_offsets[idx] = 0; }
+      if (d_chars == nullptr) { d_sizes[idx] = 0; }
       return;
     }
     if (d_chars != nullptr) {
       float_to_string(idx);
     } else {
-      d_offsets[idx] = compute_output_size(idx);
+      d_sizes[idx] = compute_output_size(idx);
     }
   }
 };

--- a/src/main/cpp/src/format_float.cu
+++ b/src/main/cpp/src/format_float.cu
@@ -35,8 +35,9 @@ template <typename FloatType>
 struct format_float_fn {
   cudf::column_device_view d_floats;
   int digits;
-  cudf::size_type* d_offsets;
+  cudf::size_type* d_sizes;
   char* d_chars;
+  cudf::detail::input_offsetalator d_offsets;
 
   __device__ cudf::size_type compute_output_size(FloatType const value) const
   {
@@ -56,13 +57,13 @@ struct format_float_fn {
   __device__ void operator()(cudf::size_type const idx) const
   {
     if (d_floats.is_null(idx)) {
-      if (d_chars == nullptr) { d_offsets[idx] = 0; }
+      if (d_chars == nullptr) { d_sizes[idx] = 0; }
       return;
     }
     if (d_chars != nullptr) {
       format_float(idx);
     } else {
-      d_offsets[idx] = compute_output_size(d_floats.element<FloatType>(idx));
+      d_sizes[idx] = compute_output_size(d_floats.element<FloatType>(idx));
     }
   }
 };

--- a/src/main/cpp/src/map_utils.cu
+++ b/src/main/cpp/src/map_utils.cu
@@ -71,7 +71,7 @@ rmm::device_uvector<char> unify_json_strings(cudf::column_view const& input,
   auto const input_scv  = cudf::strings_column_view{input};
   auto const chars_size = input_scv.chars_size(stream);
   auto const output_size =
-    2l +  // two extra bracket characters '[' and ']'
+    2l +                                            // two extra bracket characters '[' and ']'
     static_cast<int64_t>(chars_size) +
     static_cast<int64_t>(input.size() - 1) +        // append `,` character between input rows
     static_cast<int64_t>(input.null_count()) * 2l;  // replace null with "{}"


### PR DESCRIPTION
This fixes the string functors to adapt to the breaking changes made by https://github.com/rapidsai/cudf/pull/15702.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2032.