### PR TITLE
Provide default python in Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -28,7 +28,8 @@ ARG TARGETPLATFORM=linux/amd64
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
 ARG TOOLSET_VERSION=11
 ### Install basic requirements
-RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSION} python39 zlib-devel maven tar wget patch ninja-build git
+RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSION} python39 zlib-devel maven tar wget patch ninja-build git && \
+  alternatives --set python /usr/bin/python3
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -18,7 +18,7 @@
 # NOTE:
 #     this script is for jenkins only, and should not be used for local development
 #     run with ci/Dockerfile in jenkins:
-#         scl enable gcc-toolset-11 rh-python38 "ci/submodule-sync.sh"
+#         scl enable gcc-toolset-11 ci/submodule-sync.sh
 
 set -ex
 


### PR DESCRIPTION
After #1991 the Docker environment no longer contains a default Python executable via /usr/bin/python.  This updates the Dockerfile to setup a default alternative for python to run python3.
