### PR TITLE
Fix cast_string_to_float with trailing whitesapces for inf and nan string

### DIFF
--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -241,11 +241,11 @@ class string_to_float {
                                           (_warp_lane == 1 && (_c == 'A' || _c == 'a')) ||
                                           (_warp_lane == 2 && (_c == 'N' || _c == 'n')));
     if (nan_mask == 0x7) {
-      // if we start with 'nan', then even if we have other garbage character(excluding whitespaces), this is a null row.
-      // but for e.g. : "nan   " cases. spark will treat the as "nan", when the trailing characters
-      // are whitespaces, it is still a valid string.
-      // if we're in ansi mode and this is not -precisely- nan, report that so that we can throw
-      // an exception later.
+      // if we start with 'nan', then even if we have other garbage character(excluding
+      // whitespaces), this is a null row. but for e.g. : "nan   " cases. spark will treat the as
+      // "nan", when the trailing characters are whitespaces, it is still a valid string. if we're
+      // in ansi mode and this is not -precisely- nan, report that so that we can throw an exception
+      // later.
 
       // move forward the curren position by 3
       _bpos += 3;
@@ -257,8 +257,8 @@ class string_to_float {
       // if we're at the end
       if (_bpos == _len) { return true; }
       // if we reach out here, it means that we have other garbage character.
-       _valid  = false;
-       _except = true;
+      _valid  = false;
+      _except = true;
     }
     return false;
   }
@@ -319,7 +319,6 @@ class string_to_float {
       // string but also have additional characters, making this whole thing bogus/null
       _valid = false;
 
-      // TODO: whether or not set _expect to true?
       return true;
     }
     return false;

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -308,18 +308,9 @@ class string_to_float {
         // if we're at the end
         if (_bpos == _len) { return true; }
       }
-// For debug
-//       int len_int = _len;
-//       int bpos_int = _bpos;
-//       printf("I am before _trailing white space _bpos %d : _len %d \n", bpos_int, len_int);
 
       // remove the remaining whitespace if exits
       remove_leading_whitespace();
-// For debug
-//       len_int = _len;
-//       bpos_int = _bpos;
-//
-//       printf("I am after _trailing white space  _bpos %d : _len %d \n", bpos_int, len_int);
 
       // if we're at the end
       if (_bpos == _len) { return true; }

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -59,6 +59,60 @@ public class CastStringsTest {
     }
   }
 
+
+  //This is for testing the CastStrings class with the input of "inf" etc string
+  @Test
+  void castToFloatsInfTest(){
+    // The test data: Table.TestBuilder object with a column containing the string "inf"
+    Table.TestBuilder tb2 = new Table.TestBuilder();
+    tb2.column("INFINITY ", "inf", "+inf ", " -INF  ");
+
+    Table.TestBuilder tb = new Table.TestBuilder();
+    tb.column(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY);
+
+    try (Table expected = tb.build()) {
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toFloat(string_col, false, expected.getColumn(i).getType()));
+        }
+        try (Table result_tbl = new Table(result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
+      }
+    }
+  }
+
+  //This is for testing the CastStrings class with the input of "nan " etc string
+  @Test
+  void castToFloatNanTest(){
+    // The test data: Table.TestBuilder object with a column containing the string "inf"
+    Table.TestBuilder tb2 = new Table.TestBuilder();
+    tb2.column("nan", "nan ", " nan ", "NAN", "nAn ", " NAn ");
+
+    Table.TestBuilder tb = new Table.TestBuilder();
+    tb.column(Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN, Float.NaN);
+
+    try (Table expected = tb.build()) {
+      List<ColumnVector> result = new ArrayList<>();
+      try (Table origTable = tb2.build()) {
+        for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+          ColumnVector string_col = origTable.getColumn(i);
+          result.add(CastStrings.toFloat(string_col, false, expected.getColumn(i).getType()));
+        }
+        try (Table result_tbl = new Table(result.toArray(new ColumnVector[result.size()]))) {
+          AssertUtils.assertTablesAreEqual(expected, result_tbl);
+        }
+      } finally {
+        result.forEach(ColumnVector::close);
+      }
+    }
+  }
+
+
   @Test
   void castToIntegerNoStripTest() {
     Table.TestBuilder tb = new Table.TestBuilder();


### PR DESCRIPTION
 Fix the issue listed in [#10794](https://github.com/NVIDIA/spark-rapids/issues/10794). 
 
In RapidsCastSuit of Spark UT, "Process Infinity, -Infinity, NaN in case insensitive manner" case would fail, the reaseon is that in jni's `cast_to_float.cu`, the functions for checking inf and nan were considering "inf"("infinity")  and "nan" strings with additional characters as illegnal. I added the logic for checking if the additional characters are whitespaces. 
