### PR TITLE
Fix NVTX3 dependency

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -233,7 +233,7 @@ target_link_libraries(
   -Wl,--whole-archive
     ${CUDFJNI_LIB}
     cudf::cudf
-    nvtx3-cpp
+    nvtx3::nvtx3-cpp
   -Wl,--no-whole-archive
     ${PARQUET_LIB}
     ${THRIFT_LIB}

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -71,14 +71,6 @@
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "version" : "24.06"
     },
-    "NVTX3" : 
-    {
-      "always_download" : true,
-      "git_shallow" : false,
-      "git_tag" : "e170594ac7cf1dac584da473d4ca9301087090c1",
-      "git_url" : "https://github.com/NVIDIA/NVTX.git",
-      "version" : "3.1.0"
-    },
     "cuco" : 
     {
       "always_download" : true,
@@ -148,11 +140,19 @@
       },
       "version" : "3.0.6"
     },
+    "nvtx3" : 
+    {
+      "always_download" : true,
+      "git_shallow" : false,
+      "git_tag" : "e170594ac7cf1dac584da473d4ca9301087090c1",
+      "git_url" : "https://github.com/NVIDIA/NVTX.git",
+      "version" : "3.1.0"
+    },
     "rmm" : 
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "46e153c18d17b07526d6ff2e04859fcbbd706879",
+      "git_tag" : "dc1e17a03ed2dbc9329ccecc27922e414250f45a",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "version" : "24.06"
     },


### PR DESCRIPTION
Fixes the submodule sync error reported in #2067.  Need to use the qualified nvtx3 name that was changed in rapidsai/cudf#15840.