### PR TITLE
case when improvement: avoid copy_if_else

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -152,6 +152,7 @@ set(CUDFJNI_INCLUDE_DIRS
 add_library(
   spark_rapids_jni SHARED
   src/BloomFilterJni.cpp
+  src/CaseWhenJni.cpp
   src/CastStringJni.cpp
   src/DateTimeRebaseJni.cpp
   src/DecimalUtilsJni.cpp
@@ -167,6 +168,7 @@ add_library(
   src/SparkResourceAdaptorJni.cpp
   src/ZOrderJni.cpp
   src/bloom_filter.cu
+  src/case_when.cu
   src/cast_decimal_to_string.cu
   src/format_float.cu
   src/cast_float_to_string.cu

--- a/src/main/cpp/src/CaseWhenJni.cpp
+++ b/src/main/cpp/src/CaseWhenJni.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "case_when.hpp"
+#include "cudf_jni_apis.hpp"
+
+#include <vector>
+
+extern "C" {
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CaseWhen_selectFirstTrueIndex(
+  JNIEnv* env, jclass, jlongArray bool_cols)
+{
+  JNI_NULL_CHECK(env, bool_cols, "array of column handles is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::jni::native_jpointerArray<cudf::column_view> n_cudf_bool_columns(env, bool_cols);
+    auto bool_column_views = n_cudf_bool_columns.get_dereferenced();
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::select_first_true_index(cudf::table_view(bool_column_views)));
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CaseWhen_selectFromIndex(JNIEnv* env,
+                                                                                  jclass,
+                                                                                  jlong scalar_cols,
+                                                                                  jlong index_col)
+{
+  JNI_NULL_CHECK(env, scalar_cols, "Column handles is null", 0);
+  JNI_NULL_CHECK(env, index_col, "Column handles is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const scalar_column_view      = reinterpret_cast<cudf::column_view const*>(scalar_cols);
+    auto const scalar_strings_col_view = cudf::strings_column_view{*scalar_column_view};
+    auto const index_column_view       = reinterpret_cast<cudf::column_view const*>(index_col);
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::select_from_index(scalar_strings_col_view, *index_column_view));
+  }
+  CATCH_STD(env, 0);
+}
+}

--- a/src/main/cpp/src/case_when.cu
+++ b/src/main/cpp/src/case_when.cu
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "case_when.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/strings/detail/strings_column_factories.cuh>
+#include <cudf/table/table_device_view.cuh>
+#include <cudf/types.hpp>
+
+#include <thrust/transform.h>
+
+// #include <cudf/detail/iterator.cuh>
+// #include <cudf/detail/utilities/vector_factories.hpp>
+
+// #include <rmm/device_uvector.hpp>
+
+namespace spark_rapids_jni {
+namespace detail {
+
+/**
+ * Find the first column index with true value from bool columns for a specified row
+ */
+struct select_first_true_fn {
+  cudf::table_device_view const d_table;
+
+  /**
+   * bool columns number should be the size of case when branches.
+   * For case when that does not have else branch, max returned index is column number which means
+   * use default null path.
+   *
+   * e.g.:
+   * CASE WHEN 'a' THEN 'A' END , max index is 1 which means use null
+   * CASE WHEN 'a' THEN 'A' ELSE '_' END, max index is also 1 which means use else value '_'
+   */
+  __device__ cudf::size_type operator()(std::size_t row_idx)
+  {
+    auto col_num                     = d_table.num_columns();
+    bool found_true                  = false;
+    cudf::size_type first_true_index = col_num;
+    for (auto col_idx = 0; !found_true && col_idx < col_num; col_idx++) {
+      if (d_table.column(col_idx).element<bool>(row_idx)) {
+        found_true       = true;
+        first_true_index = col_idx;
+      }
+    }
+    return first_true_index;
+  }
+};
+
+std::unique_ptr<cudf::column> select_first_true_index(cudf::table_view const& when_bool_columns,
+                                                      rmm::cuda_stream_view stream,
+                                                      rmm::mr::device_memory_resource* mr)
+{
+  // checks
+  auto const num_columns = when_bool_columns.num_columns();
+  CUDF_EXPECTS(num_columns > 0, "At least one column must be specified");
+  auto const row_count = when_bool_columns.num_rows();
+  if (row_count == 0)  // empty begets empty
+    return cudf::make_empty_column(cudf::type_id::INT32);
+
+  auto ret = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, row_count, cudf::mask_state::ALL_VALID, stream, mr);
+
+  auto d_table = cudf::table_device_view::create(when_bool_columns, stream);
+
+  // select first true index
+  thrust::transform(rmm::exec_policy(stream),
+                    thrust::make_counting_iterator<cudf::size_type>(0),
+                    thrust::make_counting_iterator<cudf::size_type>(row_count),
+                    ret->mutable_view().begin<cudf::size_type>(),
+                    select_first_true_fn{*d_table});
+  return ret;
+}
+
+/**
+ * Exedute SQL `case when` semantic.
+ * If there are multiple branches and each branch uses scalar to generator value,
+ * then it's fast to use this function because it does not generate temp string columns.
+ * Regular logic in RAPIDs Acceselorator invokes multiple cudf::copy_if_else to generate
+ * multiple temp string columns which are time-consuming.
+ *
+ * E.g.:
+ *   SQL is:
+ *     select
+ *        case
+ *          when bool_1_expr then "value_1"
+ *          when bool_2_expr then "value_2"
+ *          when bool_3_expr then "value_3"
+ *          else "value_else"
+ *        end
+ *      from tab
+ *
+ *   E.g.: the input data is:
+ *     bool column 1: [true,  false, false, false]  // the result of
+ bool_1_expr.executeColumnar
+ *     bool column 2: [false, true,  false, flase]  // the result of
+ bool_2_expr.executeColumnar
+ *     bool column 3: [false, false, true,  flase]  // the result of
+ bool_3_expr.executeColumnar
+ *     scalars in SQL are "value_1", "value_1", "value_1", "value_else"
+ *
+ *   Output will be:
+ *     ["value_1", "value_2", "value_3", "value_else"]
+ *
+ * Note: the number of bool columns is greater than the number of scalars by 1.
+ * size(when_bool_columns) == (row of then_and_else_scalars) + 1
+ *
+ */
+
+std::unique_ptr<cudf::column> select_from_index(
+  cudf::strings_column_view const& then_and_else_scalar_column,
+  cudf::column_view const& select_index_column,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr)
+{
+  cudf::size_type num_of_rows   = select_index_column.size();
+  cudf::size_type num_of_scalar = then_and_else_scalar_column.size();
+
+  // create device views
+  auto d_scalars =
+    *(cudf::column_device_view::create(then_and_else_scalar_column.parent(), stream));
+  auto d_select_index = *(cudf::column_device_view::create(select_index_column, stream));
+
+  // Select <str_ptr, size> pairs from multiple scalars according to select index
+  using str_view = thrust::pair<char const*, cudf::size_type>;
+  rmm::device_uvector<str_view> indices(num_of_rows, stream);
+  thrust::transform(rmm::exec_policy(stream),
+                    thrust::make_counting_iterator<cudf::size_type>(0),
+                    thrust::make_counting_iterator<cudf::size_type>(num_of_rows),
+                    indices.begin(),
+                    [d_scalars, num_of_scalar, d_select_index] __device__(cudf::size_type row_idx) {
+                      // select scalar according to index
+                      cudf::size_type scalar_idx = d_select_index.element<cudf::size_type>(row_idx);
+
+                      // NOTE a case: scalar_idx == num_of_scalar, e.g.:
+                      // CASE WHEN 'a' THEN 'A' END , max index is 1 which means use null
+                      // CASE WHEN 'a' THEN 'A' ELSE '_' END, max index is also 1 which means use
+                      // else value '_'
+                      if (scalar_idx < num_of_scalar) {
+                        auto const d_str = d_scalars.element<cudf::string_view>(scalar_idx);
+                        return str_view{d_str.data(), d_str.size_bytes()};
+                      } else {
+                        return str_view{nullptr, 0};
+                      }
+                    });
+
+  // create final string column from string index pairs
+  return cudf::strings::detail::make_strings_column(indices.begin(), indices.end(), stream, mr);
+}
+
+}  // namespace detail
+
+std::unique_ptr<cudf::column> select_first_true_index(cudf::table_view const& when_bool_columns,
+                                                      rmm::cuda_stream_view stream,
+                                                      rmm::mr::device_memory_resource* mr)
+{
+  return detail::select_first_true_index(when_bool_columns, stream, mr);
+}
+
+std::unique_ptr<cudf::column> select_from_index(
+  cudf::strings_column_view const& then_and_else_scalars_column,
+  cudf::column_view const& select_index_column,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr)
+{
+  return detail::select_from_index(then_and_else_scalars_column, select_index_column, stream, mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/case_when.hpp
+++ b/src/main/cpp/src/case_when.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace spark_rapids_jni {
+
+/**
+ * select the first column index with true value.
+ * e.g.:
+ * column 0 in table: true,  false, false
+ * column 1 in table: false, true,  false
+ * column 2 in table: false, false, true
+ * 
+ * return column: 0, 1, 2
+*/
+std::unique_ptr<cudf::column> select_first_true_index(
+  cudf::table_view const& when_bool_columns,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/**
+ * Select strings int scalar column according to index column
+ * scalar column: s0, s1, s2
+ * index  column: 0,  1,  2,  2,  1,  0,  3
+ * output column: s0, s1, s2, s2, s1, s0, null
+ * 
+*/
+std::unique_ptr<cudf::column> select_from_index(
+  cudf::strings_column_view const& then_and_else_scalar_column,
+  cudf::column_view const& select_index_column,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+}  // namespace spark_rapids_jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/CaseWhen.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CaseWhen.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.*;
+
+public class CaseWhen {
+
+  public static ColumnVector selectFirstTrueIndex(ColumnVector[] boolColumns) {
+    for (ColumnVector cv : boolColumns) {
+      assert(cv.getType().equals(DType.BOOL8)) : "Columns must be bools";
+    }
+    
+    long[] boolHandles = new long[boolColumns.length];
+    for (int i = 0; i < boolColumns.length; ++i) {
+      boolHandles[i] = boolColumns[i].getNativeView();
+    }
+
+    return new ColumnVector(selectFirstTrueIndex(boolHandles));
+  }
+
+  public static ColumnVector selectFromIndex(ColumnVector scalarCol, ColumnVector indexCol) {
+    assert(scalarCol.getType().equals(DType.STRING)) : "Scalar column must be a String";
+    assert(indexCol.getType().equals(DType.INT32)) : "Index column must be a INT32";
+
+    return new ColumnVector(selectFromIndex(scalarCol.getNativeView(), indexCol.getNativeView()));
+  }
+
+  private static native long selectFirstTrueIndex(long[] boolHandles);
+
+  private static native long selectFromIndex(long scalarHandle, long indexHandle);
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/CaseWhenTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CaseWhenTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.*;
+import org.junit.jupiter.api.Test;
+
+import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+
+public class CaseWhenTest {
+
+  @Test
+  void selectIndexTest() {
+    try (
+        ColumnVector b0 = ColumnVector.fromBooleans(
+            true, false, false, false);
+        ColumnVector b1 = ColumnVector.fromBooleans(
+            true, true, false, false);
+        ColumnVector b2 = ColumnVector.fromBooleans(
+            false, false, true, false);
+        ColumnVector b3 = ColumnVector.fromBooleans(
+            true, true, true, false);
+        ColumnVector expected = ColumnVector.fromInts(0, 1, 2, 4)) {
+      ColumnVector[] boolColumns = new ColumnVector[] { b0, b1, b2, b3 };
+      try (ColumnVector actual = CaseWhen.selectFirstTrueIndex(boolColumns)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+    }
+  }
+
+  @Test
+  void selectTest() {
+    try (ColumnVector values = ColumnVector.fromStrings(
+        "s0", "s1", "s2", "s3");
+        ColumnVector selects = ColumnVector.fromInts(0, 1, 2, 3, 3, 2, 1, 0, 4, 5, 6);
+        ColumnVector expected = ColumnVector.fromStrings("s0", "s1", "s2", "s3", "s3", "s2", "s1", "s0", null, null,
+            null);
+        ColumnVector actual = CaseWhen.selectFromIndex(values, selects)) {
+      assertColumnsAreEqual(expected, actual);
+    }
+  }
+}


### PR DESCRIPTION
Case when improvement: avoid copy_if_else

For the following `case when`:
```
select
  case
    when bool_1_expr then "value_1"
    when bool_2_expr then "value_2"
    when bool_3_expr then "value_3"
    ......
    else "value_else"
  end
from tab
```
### Current logic, [link](https://github.com/NVIDIA/spark-rapids/blob/branch-24.06/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala#L362-L370):
Iteratively invoke `copy_if_else` to merge the tail 2 branches.
This incurr lots of memory operations, here intruduced 3 `copy_if_else`
```
      val elseRet = elseValue
        .map(_.columnarEvalAny(batch))
        .getOrElse(GpuScalar(null, branches.last._2.dataType))
      val any = branches.foldRight[Any](elseRet) {
        case ((predicateExpr, trueExpr), falseRet) =>
          computeIfElse(batch, predicateExpr, trueExpr, falseRet)
      }
```

### Improvement:
First evaluate all the `when` exprs and get bool columns.
Then select the first true in the bool columns and return the column index
Then select salars according to the select column.

implement 2 kernels to handle:

```
/**
 * select the first column index with true value.
 * e.g.:
 * column 0 in table: true,  false, false
 * column 1 in table: false, true,  false
 * column 2 in table: false, false, true
 * 
 * return column: 0, 1, 2
*/
std::unique_ptr<cudf::column> select_first_true_index(
  cudf::table_view const& when_bool_columns,
  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());

/**
 * Select strings int scalar column according to index column
 * scalar column: s0, s1, s2
 * index  column: 0,  1,  2,  2,  1,  0,  3
 * output column: s0, s1, s2, s2, s1, s0, null
 * 
*/
std::unique_ptr<cudf::column> select_from_index(
  cudf::strings_column_view const& then_and_else_scalar_column,
  cudf::column_view const& select_index_column,
  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
```

