### PR TITLE
Typo in contributor documentation [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -355,7 +355,7 @@ conda install -c conda-forge pre-commit
 pip install pre-commit
 ```
 
-Then, run pre-commit hooks before committing your code. This wil reformat the stagged files:
+Then, run pre-commit hooks before committing your code. This will reformat the staged files:
 ```
 pre-commit run
 ```


### PR DESCRIPTION
Sorry @jlowe , as you pointed out there was another one I missed.