### PR TITLE
Fix nvtx3 linking issue in benchmark

### DIFF
--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -23,7 +23,7 @@ target_compile_options(
 )
 
 target_link_libraries(
-  spark_rapids_jni_datagen PUBLIC cudf::cudf nvtx3-cpp
+  spark_rapids_jni_datagen PUBLIC cudf::cudf nvtx3::nvtx3-cpp
 )
 
 target_include_directories(


### PR DESCRIPTION
This fixes compile issue in benchmark code where cmake cannot find nvtx3 due to changes upstream.