### PR TITLE
Add default value for REF of premerge jenkinsfile to avoid bad overwrittern [skip ci]

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -57,7 +57,8 @@ pipeline {
     parameters {
         string(name: 'PARALLEL_LEVEL', defaultValue: '18',
             description: 'Parallel build cudf cpp with -DCPP_PARALLEL_LEVEL')
-        string(name: 'REF', defaultValue: '',
+        // Put a default value for REF to avoid error when running the pipeline manually
+        string(name: 'REF', defaultValue: 'main',
             description: 'Merged commit of specific PR')
         string(name: 'GITHUB_DATA', defaultValue: '',
             description: 'Json-formatted github data from upstream blossom-ci')


### PR DESCRIPTION
context at https://github.com/NVIDIA/spark-rapids/pull/10966

port the fix to jni repo.

