### PR TITLE
Change contains to check array instead of substring

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -33,41 +33,41 @@ jobs:
       args: ${{ env.args }}
 
     # This job only runs for pull request comments
-    if: contains( '\
-      abellina,\
-      anfeng,\
-      firestarman,\
-      GaryShen2008,\
-      jlowe,\
-      mythrocks,\
-      nartal1,\
-      nvdbaranec,\
-      NvTimLiu,\
-      razajafri,\
-      revans2,\
-      rwlee,\
-      sameerz,\
-      tgravescs,\
-      wbo4958,\
-      wjxiz1992,\
-      sperlingxx,\
-      YanxuanLiu,\
-      hyperbolic2346,\
-      gerashegalov,\
-      ttnghia,\
-      nvliyuan,\
-      res-life,\
-      HaoYang670,\
-      NVnavkumar,\
-      yinqingh,\
-      thirtiseven,\
-      parthosa,\
-      liurenjie1024,\
-      binmahone,\
-      pmattione-nvidia,\
-      Feng-Jiang28,\
-      pxLi,\
-      ', format('{0},', github.actor)) && github.event.comment.body == 'build'
+    if: contains( fromJson('[
+      "abellina",
+      "anfeng",
+      "firestarman",
+      "GaryShen2008",
+      "jlowe",
+      "mythrocks",
+      "nartal1",
+      "nvdbaranec",
+      "NvTimLiu",
+      "razajafri",
+      "revans2",
+      "rwlee",
+      "sameerz",
+      "tgravescs",
+      "wbo4958",
+      "wjxiz1992",
+      "sperlingxx",
+      "YanxuanLiu",
+      "hyperbolic2346",
+      "gerashegalov",
+      "ttnghia",
+      "nvliyuan",
+      "res-life",
+      "HaoYang670",
+      "NVnavkumar",
+      "yinqingh",
+      "thirtiseven",
+      "parthosa",
+      "liurenjie1024",
+      "binmahone",
+      "pmattione-nvidia",
+      "Feng-Jiang28",
+      "pxLi"
+      ]'), format('{0},', github.actor)) && github.event.comment.body == 'build'
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci

--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -67,7 +67,7 @@ jobs:
       "pmattione-nvidia",
       "Feng-Jiang28",
       "pxLi"
-      ]'), format('{0},', github.actor)) && github.event.comment.body == 'build'
+      ]'), github.actor) && github.event.comment.body == 'build'
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci


### PR DESCRIPTION
CI authorization is using a substring to search for allowed users. This allows for usernames that are substrings of authorized users to run CI jobs. This changes the code to be a search in an array. From [github docs](https://docs.github.com/en/actions/learn-github-actions/expressions#contains), this checks to see if the string is one of the strings in the array.
