### PR TITLE
Make run-in-docker usable in other repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,28 @@ the Docker container.
 The script passes all of its arguments onto the Maven command run inside the Docker container,
 so it should be invoked as one would invoke Maven, e.g.: `build/build-in-docker clean package`
 
+When iterating through the development lifecycle you might want to make sure that some set
+of commands is executed in the Docker container without remembering to prefix them with
+build-in-docker. As per usual you can create a set of shell aliases. You can also create a directory
+that is prepended to the `PATH` environment variable. And define symlinks for your frequent
+commands to run. For example
+
+```
+ln -s <SPARK_RAPIDS_JNI_BIN>/cmake <SPARK_RAPIDS_JNI_REPO_DIR>/build/run-in-docker
+export PATH=<SPARK_RAPIDS_JNI_BIN>:$PATH
+```
+
+#### Using spark-rapids-jni Docker Container with other Repos
+
+Spark RAPIDS project spans multiple repos. Some issues are discovered in
+spark-rapids-jni but they need to be made easily reproducible in the cudf repo
+
+To this end export WORKDIR with the path pointing to a different repo
+
+```
+WORKDIR=~/gits/rapidsai/cudf ~/gits/NVIDIA/spark-rapids-jni/build/run-in-docker head README.md
+```
+
 ### cudf Submodule and Build
 
 [RAPIDS cuDF](https://github.com/rapidsai/cudf) is being used as a submodule in this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,17 +61,6 @@ the Docker container.
 The script passes all of its arguments onto the Maven command run inside the Docker container,
 so it should be invoked as one would invoke Maven, e.g.: `build/build-in-docker clean package`
 
-When iterating through the development lifecycle you might want to make sure that some set
-of commands is executed in the Docker container without remembering to prefix them with
-build-in-docker. As per usual you can create a set of shell aliases. You can also create a directory
-that is prepended to the `PATH` environment variable. And define symlinks for your frequent
-commands to run. For example
-
-```
-ln -s <SPARK_RAPIDS_JNI_BIN>/cmake <SPARK_RAPIDS_JNI_REPO_DIR>/build/run-in-docker
-export PATH=<SPARK_RAPIDS_JNI_BIN>:$PATH
-```
-
 #### Using spark-rapids-jni Docker Container with other Repos
 
 Spark RAPIDS project spans multiple repos. Some issues are discovered in
@@ -80,7 +69,8 @@ spark-rapids-jni but they need to be made easily reproducible in the cudf repo
 To this end export WORKDIR with the path pointing to a different repo
 
 ```
-WORKDIR=~/gits/rapidsai/cudf ~/gits/NVIDIA/spark-rapids-jni/build/run-in-docker head README.md
+export WORKDIR=~/gits/rapidsai/cudf
+~/gits/NVIDIA/spark-rapids-jni/build/run-in-docker head README.md
 ```
 
 ### cudf Submodule and Build

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -23,6 +23,7 @@ set -e
 # Base paths relative to this script's location
 SCRIPTDIR=$(cd $(dirname $0); pwd)
 REPODIR=$SCRIPTDIR/..
+WORKDIR=${WORKDIR:-$REPODIR}
 
 CUDA_VERSION=${CUDA_VERSION:-11.8.0}
 DOCKER_CMD=${DOCKER_CMD:-docker}

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -18,13 +18,11 @@
 
 # Run a command in a Docker container with devtoolset
 
-set -ex
+set -e
 
-SCRIPTPATH=$(readlink -f "$0")
 # Base paths relative to this script's location
-SCRIPTDIR=$(cd $(dirname $SCRIPTPATH); pwd)
+SCRIPTDIR=$(cd $(dirname $0); pwd)
 REPODIR=$SCRIPTDIR/..
-WORKDIR=${WORKDIR:-$REPODIR}
 
 CUDA_VERSION=${CUDA_VERSION:-11.8.0}
 DOCKER_CMD=${DOCKER_CMD:-docker}
@@ -57,13 +55,7 @@ if (( $# == 0 )); then
   DOCKER_OPTS="${DOCKER_OPTS} -it"
   RUN_CMD="/bin/bash"
 else
-  THIS_FILE=$(basename $SCRIPTPATH)
-  ARG0_CMD=$(basename "$0")
-  if [[ "$THIS_FILE" != "$ARG0_CMD" ]]; then
-    RUN_CMD="${ARG0_CMD} ${@@Q}"
-  else
-    RUN_CMD="${@@Q}"
-  fi
+  RUN_CMD="${@@Q}"
 fi
 
 $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --rm \

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -18,11 +18,13 @@
 
 # Run a command in a Docker container with devtoolset
 
-set -e
+set -ex
 
+SCRIPTPATH=$(readlink -f "$0")
 # Base paths relative to this script's location
-SCRIPTDIR=$(cd $(dirname $0); pwd)
+SCRIPTDIR=$(cd $(dirname $SCRIPTPATH); pwd)
 REPODIR=$SCRIPTDIR/..
+WORKDIR=${WORKDIR:-$REPODIR}
 
 CUDA_VERSION=${CUDA_VERSION:-11.8.0}
 DOCKER_CMD=${DOCKER_CMD:-docker}
@@ -55,7 +57,13 @@ if (( $# == 0 )); then
   DOCKER_OPTS="${DOCKER_OPTS} -it"
   RUN_CMD="/bin/bash"
 else
-  RUN_CMD="${@@Q}"
+  THIS_FILE=$(basename $SCRIPTPATH)
+  ARG0_CMD=$(basename "$0")
+  if [[ "$THIS_FILE" != "$ARG0_CMD" ]]; then
+    RUN_CMD="${ARG0_CMD} ${@@Q}"
+  else
+    RUN_CMD="${@@Q}"
+  fi
 fi
 
 $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --rm \
@@ -63,10 +71,10 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -v "/etc/passwd:/etc/passwd:ro" \
   -v "/etc/shadow:/etc/shadow:ro" \
   -v "/etc/sudoers.d:/etc/sudoers.d:ro" \
-  -v "$REPODIR:$REPODIR:rw" \
+  -v "$WORKDIR:$WORKDIR:rw" \
   -v "$LOCAL_CCACHE_DIR:$LOCAL_CCACHE_DIR:rw" \
   -v "$LOCAL_MAVEN_REPO:$LOCAL_MAVEN_REPO:rw" \
-  --workdir "$REPODIR" \
+  --workdir "$WORKDIR" \
   -e CCACHE_DIR="$LOCAL_CCACHE_DIR" \
   -e CMAKE_C_COMPILER_LAUNCHER="ccache" \
   -e CMAKE_CXX_COMPILER_LAUNCHER="ccache" \


### PR DESCRIPTION
- Introduces WORKDIR to change the default local path available to Docker to point to another repo

This PR makes it possible to write easy repro steps for cudf or any other path to be executed in the spark-rapids-jni Docker container

 Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
