### PR TITLE
Restore static CUDA runtime linking

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CUDF_CPP_BUILD_DIR
   "$ENV{CUDF_CPP_BUILD_DIR}"
   CACHE STRING "path to libcudf build root"
 )
+set(CUDA_STATIC_RUNTIME ON)
 
 include("${CUDF_DIR}/rapids_config.cmake")
 include(rapids-cmake)
@@ -267,6 +268,7 @@ target_link_libraries(
     ${PARQUET_LIB}
     ${THRIFT_LIB}
 )
+rapids_cuda_set_runtime(spark_rapids_jni USE_STATIC ON)
 set_target_properties(spark_rapids_jni PROPERTIES LINK_LANGUAGE "CXX")
 # For backwards-compatibility with the cudf Java bindings and RAPIDS accelerated UDFs,
 # all of the code is built into libcudf.so that is statically linked to the CUDA runtime library.
@@ -303,8 +305,8 @@ if(USE_GDS)
     -Wl,--no-whole-archive
     spark_rapids_jni
     ${cuFile_LIBRARIES}
-    CUDA::cudart_static
   )
+  rapids_cuda_set_runtime(cufilejni USE_STATIC ON)
 endif()
 
 # ##################################################################################################

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CUDF_CPP_BUILD_DIR
   "$ENV{CUDF_CPP_BUILD_DIR}"
   CACHE STRING "path to libcudf build root"
 )
+# libcudf's kvikio dependency requires this to be set when statically linking CUDA runtime
 set(CUDA_STATIC_RUNTIME ON)
 
 include("${CUDF_DIR}/rapids_config.cmake")


### PR DESCRIPTION
Fixes #2162.  This problem was caused by a [kvikio change](https://github.com/rapidsai/kvikio/pull/369/files#diff-1bba462ab050e89360fd88110a689e85ee037749cea091a1848ab574381d3795R98-R102) that requires downstream projects to set CUDA_STATIC_RUNTIME when they need a static runtime.

In the process of investigating this, I discovered there's an existing rapids_cuda_set_runtime that's supposed to be used for specifying the CUDA runtime settings.  I updated the CMakeLists.txt to use it, although it does not by itself fix the issue.  The CUDA_STATIC_RUNTIME variable is required, but we should update to the RAPIDS method for setting CUDA runtime parameters to match how libcudf is doing it in case the implementation details change in the future.
