### PR TITLE
All kernels in the JNI should have hidden visibility

### DIFF
--- a/src/main/cpp/faultinj/faultinj.cu
+++ b/src/main/cpp/faultinj/faultinj.cu
@@ -136,12 +136,12 @@ CUptiResult cuptiInitialize(void)
   return status;
 }
 
-__global__ void faultInjectorKernelAssert(void)
+__global__ static void faultInjectorKernelAssert(void)
 {
   assert(0 && "faultInjectorKernelAssert triggered");
 }
 
-__global__ void faultInjectorKernelTrap(void) { asm("trap;"); }
+__global__ static void faultInjectorKernelTrap(void) { asm("trap;"); }
 
 boost::optional<boost::property_tree::ptree&> lookupConfig(
   boost::optional<boost::property_tree::ptree&> domainConfigs,

--- a/src/main/cpp/src/bloom_filter.cu
+++ b/src/main/cpp/src/bloom_filter.cu
@@ -60,7 +60,7 @@ __device__ inline std::pair<cudf::size_type, cudf::bitmask_type> gpu_get_hash_ma
 }
 
 template <bool nullable>
-__global__ void gpu_bloom_filter_put(cudf::bitmask_type* const bloom_filter,
+CUDF_KERNEL void gpu_bloom_filter_put(cudf::bitmask_type* const bloom_filter,
                                      cudf::size_type bloom_filter_bits,
                                      cudf::column_device_view input,
                                      cudf::size_type num_hashes)

--- a/src/main/cpp/src/bloom_filter.cu
+++ b/src/main/cpp/src/bloom_filter.cu
@@ -61,9 +61,9 @@ __device__ inline std::pair<cudf::size_type, cudf::bitmask_type> gpu_get_hash_ma
 
 template <bool nullable>
 CUDF_KERNEL void gpu_bloom_filter_put(cudf::bitmask_type* const bloom_filter,
-                                     cudf::size_type bloom_filter_bits,
-                                     cudf::column_device_view input,
-                                     cudf::size_type num_hashes)
+                                      cudf::size_type bloom_filter_bits,
+                                      cudf::column_device_view input,
+                                      cudf::size_type num_hashes)
 {
   size_t const tid = threadIdx.x + blockIdx.x * blockDim.x;
   if (tid >= input.size()) { return; }

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -157,13 +157,13 @@ process_value(bool first_value, T current_val, T const new_digit, bool adding)
  */
 template <typename T>
 void CUDF_KERNEL string_to_integer_kernel(T* out,
-                                         bitmask_type* validity,
-                                         const char* const chars,
-                                         size_type const* offsets,
-                                         bitmask_type const* incoming_null_mask,
-                                         size_type num_rows,
-                                         bool ansi_mode,
-                                         bool strip)
+                                          bitmask_type* validity,
+                                          const char* const chars,
+                                          size_type const* offsets,
+                                          bitmask_type const* incoming_null_mask,
+                                          size_type num_rows,
+                                          bool ansi_mode,
+                                          bool strip)
 {
   auto const group = cooperative_groups::this_thread_block();
   auto const warp  = cooperative_groups::tiled_partition<cudf::detail::warp_size>(group);
@@ -389,14 +389,14 @@ __device__ thrust::optional<thrust::tuple<bool, int, int>> validate_and_exponent
  */
 template <typename T>
 CUDF_KERNEL void string_to_decimal_kernel(T* out,
-                                         bitmask_type* validity,
-                                         const char* const chars,
-                                         size_type const* offsets,
-                                         bitmask_type const* incoming_null_mask,
-                                         size_type num_rows,
-                                         int32_t scale,
-                                         int32_t precision,
-                                         bool strip)
+                                          bitmask_type* validity,
+                                          const char* const chars,
+                                          size_type const* offsets,
+                                          bitmask_type const* incoming_null_mask,
+                                          size_type num_rows,
+                                          int32_t scale,
+                                          int32_t precision,
+                                          bool strip)
 {
   auto const group = cooperative_groups::this_thread_block();
   auto const warp  = cooperative_groups::tiled_partition<cudf::detail::warp_size>(group);

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -156,7 +156,7 @@ process_value(bool first_value, T current_val, T const new_digit, bool adding)
  * @param ansi_mode true if ansi mode is required, which is more strict and throws
  */
 template <typename T>
-void __global__ string_to_integer_kernel(T* out,
+void CUDF_KERNEL string_to_integer_kernel(T* out,
                                          bitmask_type* validity,
                                          const char* const chars,
                                          size_type const* offsets,
@@ -386,10 +386,9 @@ __device__ thrust::optional<thrust::tuple<bool, int, int>> validate_and_exponent
  * @param scale scale of desired decimals
  * @param precision precision of desired decimals
  * @param ansi_mode true if ansi mode is required, which is more strict and throws
- * @return __global__
  */
 template <typename T>
-__global__ void string_to_decimal_kernel(T* out,
+CUDF_KERNEL void string_to_decimal_kernel(T* out,
                                          bitmask_type* validity,
                                          const char* const chars,
                                          size_type const* offsets,

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -618,7 +618,7 @@ class string_to_float {
 };
 
 template <typename T, size_type block_size>
-__global__ void string_to_float_kernel(T* out,
+CUDF_KERNEL void string_to_float_kernel(T* out,
                                        bitmask_type* validity,
                                        int32_t* ansi_except,
                                        size_type* valid_count,

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -619,13 +619,13 @@ class string_to_float {
 
 template <typename T, size_type block_size>
 CUDF_KERNEL void string_to_float_kernel(T* out,
-                                       bitmask_type* validity,
-                                       int32_t* ansi_except,
-                                       size_type* valid_count,
-                                       const char* const chars,
-                                       size_type const* offsets,
-                                       bitmask_type const* incoming_null_mask,
-                                       size_type const num_rows)
+                                        bitmask_type* validity,
+                                        int32_t* ansi_except,
+                                        size_type* valid_count,
+                                        const char* const chars,
+                                        size_type const* offsets,
+                                        bitmask_type const* incoming_null_mask,
+                                        size_type const num_rows)
 {
   size_type const tid = threadIdx.x + (blockDim.x * blockIdx.x);
   size_type const row = tid / 32;

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -771,12 +771,12 @@ uri_parts __device__ validate_uri(const char* str,
  * @param out_validity Bitmask of validity data, updated in function
  */
 CUDF_KERNEL void parse_uri_char_counter(column_device_view const in_strings,
-                                       URI_chunks chunk,
-                                       char const* const base_ptr,
-                                       size_type* const out_lengths,
-                                       size_type* const out_offsets,
-                                       bitmask_type* out_validity,
-                                       thrust::optional<column_device_view const> query_match)
+                                        URI_chunks chunk,
+                                        char const* const base_ptr,
+                                        size_type* const out_lengths,
+                                        size_type* const out_offsets,
+                                        bitmask_type* out_validity,
+                                        thrust::optional<column_device_view const> query_match)
 {
   // thread per row
   auto const tid = cudf::detail::grid_1d::global_thread_id();
@@ -851,10 +851,10 @@ CUDF_KERNEL void parse_uri_char_counter(column_device_view const in_strings,
  * @param out_chars Character buffer for the output string column
  */
 CUDF_KERNEL void parse_uri(column_device_view const in_strings,
-                          char const* const base_ptr,
-                          size_type const* const src_offsets,
-                          size_type const* const offsets,
-                          char* const out_chars)
+                           char const* const base_ptr,
+                           size_type const* const src_offsets,
+                           size_type const* const offsets,
+                           char* const out_chars)
 {
   auto const tid = cudf::detail::grid_1d::global_thread_id();
 

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -770,7 +770,7 @@ uri_parts __device__ validate_uri(const char* str,
  * @param out_offsets Offsets to the start of the chunks
  * @param out_validity Bitmask of validity data, updated in function
  */
-__global__ void parse_uri_char_counter(column_device_view const in_strings,
+CUDF_KERNEL void parse_uri_char_counter(column_device_view const in_strings,
                                        URI_chunks chunk,
                                        char const* const base_ptr,
                                        size_type* const out_lengths,
@@ -850,7 +850,7 @@ __global__ void parse_uri_char_counter(column_device_view const in_strings,
  * @param offsets Offset value of each string associated with `out_chars`
  * @param out_chars Character buffer for the output string column
  */
-__global__ void parse_uri(column_device_view const in_strings,
+CUDF_KERNEL void parse_uri(column_device_view const in_strings,
                           char const* const base_ptr,
                           size_type const* const src_offsets,
                           size_type const* const offsets,


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-jni/issues/1734.

This PR addresses a similar issue to https://github.com/rapidsai/cudf/pull/14726. Instead of adding a new macro as suggested in https://github.com/NVIDIA/spark-rapids-jni/issues/1734, it uses the one in libcudf added in https://github.com/rapidsai/cudf/pull/14726 to avoid duplicate macros.