### PR TITLE
Improve cuda dependencies check during build

### DIFF
--- a/ci/check-cuda-dependencies.sh
+++ b/ci/check-cuda-dependencies.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# common script to help check if libcudf.so has dynamical link to cuda libs
+
+set -exo pipefail
+
+jar_path=$1
+tmp_path=/tmp/"jni-$(date "+%Y%m%d%H%M%S")"
+unzip -j "${jar_path}" "*64/Linux/libcudf.so" -d "${tmp_path}"
+
+if objdump -p "${tmp_path}/libcudf.so" | grep NEEDED | grep -q cuda; then
+    echo "dynamical link to CUDA lib found in libcudf.so..."
+    ldd "${tmp_path}/libcudf.so"
+    exit 1
+else
+    echo "no dynamical link to CUDA lib found in libcudf.so"
+fi

--- a/ci/check-cuda-dependencies.sh
+++ b/ci/check-cuda-dependencies.sh
@@ -26,10 +26,10 @@ unzip -j "${jar_path}" "*64/Linux/*.so" -d "${tmp_path}"
 find "$tmp_path" -type f -name "*.so" | while read -r so_file; do
     # Check if *.so file has a dynamic link to CUDA Runtime
     if objdump -p "$so_file" | grep NEEDED | grep -qi cudart; then
-        echo "Dynamic link to CUDA lib found in $so_file..."
+        echo "Dynamic link to CUDA Runtime found in $so_file..."
         ldd "$so_file"
         exit 1
     else
-        echo "No dynamic link to CUDA lib found in $so_file"
+        echo "No dynamic link to CUDA Runtime found in $so_file"
     fi
 done

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -48,5 +48,5 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DBUILD_TESTS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -Dcuda.version=$CUDA_VER \
   -DUSE_SANITIZER=${USE_SANITIZER}
 
-build_name=$($MVN help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
 . ci/check-cuda-dependencies.sh "target/${build_name}-${artifact_suffix}.jar"

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -29,6 +29,7 @@ USE_GDS=${USE_GDS:-ON}
 USE_SANITIZER=${USE_SANITIZER:-ON}
 BUILD_FAULTINJ=${BUILD_FAULTINJ:-ON}
 ARM64=${ARM64:-false}
+artifact_suffix="${CUDA_VER}"
 
 profiles="source-javadoc"
 if [ "${ARM64}" == "true" ]; then
@@ -36,6 +37,7 @@ if [ "${ARM64}" == "true" ]; then
   USE_GDS="OFF"
   USE_SANITIZER="ON"
   BUILD_FAULTINJ="OFF"
+  artifact_suffix="${artifact_suffix}-arm64"
 fi
 
 ${MVN} clean package ${MVN_MIRROR}  \
@@ -45,3 +47,6 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
   -DBUILD_TESTS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -Dcuda.version=$CUDA_VER \
   -DUSE_SANITIZER=${USE_SANITIZER}
+
+build_name=$($MVN help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+. ci/check-cuda-dependencies.sh "target/${build_name}-${artifact_suffix}.jar"

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -28,3 +28,6 @@ ${MVN} verify ${MVN_MIRROR} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
   -DBUILD_TESTS=ON
+
+build_name=$($MVN help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+. ci/check-cuda-dependencies.sh "target/${build_name}-cuda11.jar"

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -29,5 +29,6 @@ ${MVN} verify ${MVN_MIRROR} \
   -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
   -DBUILD_TESTS=ON
 
-build_name=$($MVN help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
-. ci/check-cuda-dependencies.sh "target/${build_name}-cuda11.jar"
+build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+cuda_version=$(${MVN} help:evaluate -Dexpression=cuda.version -q -DforceStdout)
+. ci/check-cuda-dependencies.sh "target/${build_name}-${cuda_version}.jar"

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -88,8 +88,9 @@ else
   echo "Test failed, will update the result"
 fi
 
-build_name=$($MVN help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
-. ci/check-cuda-dependencies.sh "target/${build_name}-cuda11.jar"
+build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+cuda_version=$(${MVN} help:evaluate -Dexpression=cuda.version -q -DforceStdout)
+. ci/check-cuda-dependencies.sh "target/${build_name}-${cuda_version}.jar"
 
 LIBCUDF_BUILD_PATH=$(${MVN} help:evaluate -Dexpression=libcudf.build.path -q -DforceStdout)
 # Extract the rapids-cmake sha1 that we need to pin too

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -88,6 +88,9 @@ else
   echo "Test failed, will update the result"
 fi
 
+build_name=$($MVN help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+. ci/check-cuda-dependencies.sh "target/${build_name}-cuda11.jar"
+
 LIBCUDF_BUILD_PATH=$(${MVN} help:evaluate -Dexpression=libcudf.build.path -q -DforceStdout)
 # Extract the rapids-cmake sha1 that we need to pin too
 rapids_cmake_sha=$(git -C ${LIBCUDF_BUILD_PATH}/_deps/rapids-cmake-src/ rev-parse HEAD)


### PR DESCRIPTION
fix #2164 

Check shared objects for libcudf.so right after build&test in nightly, pre-merge, and submodule-syncup, fail the run if found cuda-related libs.

fail test run with revert commit https://github.com/NVIDIA/spark-rapids-jni/pull/2165
```
[2024-06-26T05:25:43.508Z] + . ci/check-cuda-dependencies.sh target/spark-rapids-jni-24.08.0-SNAPSHOT-cuda11-arm64.jar
[2024-06-26T05:25:43.508Z] ++ set -exo pipefail
[2024-06-26T05:25:43.508Z] ++ jar_path=target/spark-rapids-jni-24.08.0-SNAPSHOT-cuda11-arm64.jar
[2024-06-26T05:25:43.508Z] +++ date +%Y%m%d%H%M%S
[2024-06-26T05:25:43.508Z] ++ tmp_path=/tmp/jni-20240626052541
[2024-06-26T05:25:43.508Z] ++ unzip -j target/spark-rapids-jni-24.08.0-SNAPSHOT-cuda11-arm64.jar '*64/Linux/libcudf.so' -d /tmp/jni-20240626052541
[2024-06-26T05:25:43.508Z] Archive:  target/spark-rapids-jni-24.08.0-SNAPSHOT-cuda11-arm64.jar
[2024-06-26T05:25:48.767Z]   inflating: /tmp/jni-20240626052541/libcudf.so  
[2024-06-26T05:25:48.767Z] ++ objdump -p /tmp/jni-20240626052541/libcudf.so
[2024-06-26T05:25:48.767Z] ++ grep NEEDED
[2024-06-26T05:25:48.767Z] ++ grep -q cuda
[2024-06-26T05:25:48.767Z] ++ echo 'dynamical link to CUDA lib found in libcudf.so...'
[2024-06-26T05:25:48.767Z] dynamical link to CUDA lib found in libcudf.so...
[2024-06-26T05:25:48.767Z] ++ ldd /tmp/jni-20240626052541/libcudf.so
[2024-06-26T05:25:48.767Z] 	linux-vdso.so.1 (0x0000ffffbde00000)
[2024-06-26T05:25:48.767Z] 	librt.so.1 => /usr/lib64/librt.so.1 (0x0000ffff9618f000)
[2024-06-26T05:25:48.768Z] 	libz.so.1 => /usr/lib64/libz.so.1 (0x0000ffff9615e000)
[2024-06-26T05:25:48.768Z] 	libnvcomp.so => /home/jenkins/agent/workspace/peixinl-spark-rapids-jni_nightly-dev/target/libcudf-install/lib64/libnvcomp.so (0x0000ffff95331000)
[2024-06-26T05:25:48.768Z] 	libnvcomp_gdeflate.so => /home/jenkins/agent/workspace/peixinl-spark-rapids-jni_nightly-dev/target/libcudf-install/lib64/libnvcomp_gdeflate.so (0x0000ffff94373000)
[2024-06-26T05:25:48.768Z] 	libnvcomp_bitcomp.so => /home/jenkins/agent/workspace/peixinl-spark-rapids-jni_nightly-dev/target/libcudf-install/lib64/libnvcomp_bitcomp.so (0x0000ffff93074000)
[2024-06-26T05:25:48.768Z] 	libcudart.so.11.0 => /usr/local/cuda/lib64/libcudart.so.11.0 (0x0000ffff92fbf000)
[2024-06-26T05:25:48.768Z] 	libdl.so.2 => /usr/lib64/libdl.so.2 (0x0000ffff92f9e000)
[2024-06-26T05:25:48.768Z] 	libpthread.so.0 => /usr/lib64/libpthread.so.0 (0x0000ffff92f69000)
[2024-06-26T05:25:48.768Z] 	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x0000ffff92dc5000)
[2024-06-26T05:25:48.768Z] 	libm.so.6 => /usr/lib64/libm.so.6 (0x0000ffff92d04000)
[2024-06-26T05:25:48.768Z] 	libgcc_s.so.1 => /usr/lib64/libgcc_s.so.1 (0x0000ffff92cd3000)
[2024-06-26T05:25:48.768Z] 	libc.so.6 => /usr/lib64/libc.so.6 (0x0000ffff92b5d000)
[2024-06-26T05:25:48.768Z] 	/lib/ld-linux-aarch64.so.1 (0x0000ffffbddc2000)
```

pass with latest change if no dynamical link of cuda libs
```
[2024-06-26T06:34:31.760Z] ++ unzip -j target/spark-rapids-jni-24.08.0-SNAPSHOT-cuda11.jar '*64/Linux/libcudf.so' -d /tmp/jni-20240626063429
[2024-06-26T06:34:31.760Z] Archive:  target/spark-rapids-jni-24.08.0-SNAPSHOT-cuda11.jar
[2024-06-26T06:34:35.927Z]   inflating: /tmp/jni-20240626063429/libcudf.so  
[2024-06-26T06:34:35.927Z] ++ objdump -p /tmp/jni-20240626063429/libcudf.so
[2024-06-26T06:34:35.927Z] ++ grep -q cuda
[2024-06-26T06:34:35.927Z] ++ grep NEEDED
[2024-06-26T06:34:35.927Z] ++ echo 'no dynamical link to CUDA lib found in libcudf.so'
[2024-06-26T06:34:35.927Z] no dynamical link to CUDA lib found in libcudf.so
```

verified internally with cuda{11,12} and CPU arch_{amd64,aarch64}