### PR TITLE
Flipped MACRO ordering to properly match style

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -156,7 +156,7 @@ process_value(bool first_value, T current_val, T const new_digit, bool adding)
  * @param ansi_mode true if ansi mode is required, which is more strict and throws
  */
 template <typename T>
-void CUDF_KERNEL string_to_integer_kernel(T* out,
+CUDF_KERNEL void string_to_integer_kernel(T* out,
                                           bitmask_type* validity,
                                           const char* const chars,
                                           size_type const* offsets,


### PR DESCRIPTION
Tiny fix to help match the style of existing code.

As pointed out by https://github.com/NVIDIA/spark-rapids-jni/pull/2168#discussion_r1655666506.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2177