### PR TITLE
Disable large strings support in libcudf build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,7 @@
                   <arg value="-DCUDF_ENABLE_ARROW_PARQUET=ON"/>
                   <arg value="-DCUDF_USE_ARROW_STATIC=ON"/>
                   <arg value="-DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${CUDF_USE_PER_THREAD_DEFAULT_STREAM}" />
+                  <arg value="-DCUDF_LARGE_STRINGS_DISABLED=ON"/>
                   <arg value="-DLIBCUDF_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DUSE_GDS=${USE_GDS}" />


### PR DESCRIPTION
Fixes #2189. rapidsai/cudf#16037 is enabling large strings support by default in libcudf, but the RAPIDS Accelerator still has many places that assume offsets are always 4 bytes.  Until #2190 is fixed, we will need to explicitly disable large strings support in  the libcudf build.