### PR TITLE
Fix compile issue with `bloom_filter` benchmark

### DIFF
--- a/src/main/cpp/benchmarks/bloom_filter.cu
+++ b/src/main/cpp/benchmarks/bloom_filter.cu
@@ -19,7 +19,7 @@
 #include <cudf_test/column_utilities.hpp>
 
 #include <bloom_filter.hpp>
-#include <hash.cuh>
+#include <hash.hpp>
 #include <nvbench/nvbench.cuh>
 
 static void bloom_filter_put(nvbench::state& state)


### PR DESCRIPTION
This fixes a compile issue in `bloom_filter` benchmark due to moving the function declaration of `xxhash64` from `hash.cuh` to `hash.hpp`.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2194.