### PR TITLE
Build benchmarks during CI/CD

### DIFF
--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -45,7 +45,7 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
-  -DBUILD_TESTS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -Dcuda.version=$CUDA_VER \
+  -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -Dcuda.version=$CUDA_VER \
   -DUSE_SANITIZER=${USE_SANITIZER}
 
 build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -27,7 +27,7 @@ ${MVN} verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
-  -DBUILD_TESTS=ON
+  -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON
 
 build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
 cuda_version=$(${MVN} help:evaluate -Dexpression=cuda.version -q -DforceStdout)


### PR DESCRIPTION
This adds configs to build benchmarks when running CI/CD, allowing to check for any breaking changes in the new PRs that can break the benchmark code.

Depends on:
 * https://github.com/NVIDIA/spark-rapids-jni/pull/2196.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2195.
