### PR TITLE
Implement interface for `getJsonObjectMultiplePaths`

### DIFF
--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -24,6 +24,7 @@
 using path_instruction_type = spark_rapids_jni::path_instruction_type;
 
 extern "C" {
+
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(
   JNIEnv* env, jclass, jlong input_column, jobjectArray path_instructions)
 {
@@ -64,6 +65,68 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject
 
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::get_json_object(n_strings_col_view, instructions));
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(
+  JNIEnv* env, jclass, jlong j_input, jobjectArray j_paths, jintArray j_path_offsets)
+{
+  JNI_NULL_CHECK(env, j_input, "j_input column is null", 0);
+  JNI_NULL_CHECK(env, j_paths, "j_paths is null", 0);
+  JNI_NULL_CHECK(env, j_path_offsets, "j_path_offsets is null", 0);
+
+  using path_type = std::vector<std::tuple<path_instruction_type, std::string, int64_t>>;
+
+  try {
+    cudf::jni::auto_set_device(env);
+
+    auto const path_offsets = cudf::jni::native_jintArray(env, j_path_offsets).to_vector();
+    CUDF_EXPECTS(path_offsets.size() > 1, "WRONG");  // TODO
+    auto const num_paths = path_offsets.size() - 1;
+    std::vector<path_type> paths(num_paths);
+
+    for (std::size_t i = 0; i < num_paths; ++i) {
+      auto const path_size = path_offsets[i + 1] - path_offsets[i];
+      auto path            = path_type{};
+      path.reserve(path_size);
+      for (int j = path_offsets[i]; j < path_offsets[i + 1]; ++j) {
+        jobject instruction = env->GetObjectArrayElement(j_paths, j);
+        JNI_NULL_CHECK(env, instruction, "path_instruction is null", 0);
+        jclass instruction_class = env->GetObjectClass(instruction);
+        JNI_NULL_CHECK(env, instruction_class, "instruction_class is null", 0);
+
+        jfieldID field_id = env->GetFieldID(instruction_class, "type", "I");
+        JNI_NULL_CHECK(env, field_id, "field_id is null", 0);
+        jint type                              = env->GetIntField(instruction, field_id);
+        path_instruction_type instruction_type = static_cast<path_instruction_type>(type);
+
+        field_id = env->GetFieldID(instruction_class, "name", "Ljava/lang/String;");
+        JNI_NULL_CHECK(env, field_id, "field_id is null", 0);
+        jstring name = (jstring)env->GetObjectField(instruction, field_id);
+        JNI_NULL_CHECK(env, name, "name is null", 0);
+        const char* name_str = env->GetStringUTFChars(name, JNI_FALSE);
+
+        field_id = env->GetFieldID(instruction_class, "index", "J");
+        JNI_NULL_CHECK(env, field_id, "field_id is null", 0);
+        jlong index = env->GetLongField(instruction, field_id);
+
+        path.emplace_back(instruction_type, name_str, index);
+        env->ReleaseStringUTFChars(name, name_str);
+      }
+
+      paths[i] = std::move(path);
+    }
+
+    auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
+    auto output =
+      spark_rapids_jni::get_json_object_multiple_paths(cudf::strings_column_view{*input_cv}, paths);
+
+    auto out_handles = cudf::jni::native_jlongArray(env, output.size());
+    std::transform(output.begin(), output.end(), out_handles.begin(), [](auto& col) {
+      return cudf::jni::release_as_jlong(col);
+    });
+    return out_handles.get_jArray();
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1023,6 +1023,20 @@ std::unique_ptr<cudf::column> get_json_object(
     input.size(), std::move(offsets), chars.release(), null_count, std::move(null_mask));
 }
 
+std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
+  cudf::strings_column_view const& input,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int64_t>>> const&
+    instruction_paths,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  std::vector<std::unique_ptr<cudf::column>> output;
+  for (auto const& instructions : instruction_paths) {
+    output.emplace_back(spark_rapids_jni::get_json_object(input, instructions, stream, mr));
+  }
+  return output;
+}
+
 }  // namespace detail
 
 std::unique_ptr<cudf::column> get_json_object(
@@ -1032,6 +1046,16 @@ std::unique_ptr<cudf::column> get_json_object(
   rmm::device_async_resource_ref mr)
 {
   return detail::get_json_object(input, instructions, stream, mr);
+}
+
+std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
+  cudf::strings_column_view const& input,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int64_t>>> const&
+    instruction_paths,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  return detail::get_json_object_multiple_paths(input, instruction_paths, stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -48,4 +48,14 @@ std::unique_ptr<cudf::column> get_json_object(
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
+/**
+ * TODO
+ */
+std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
+  cudf::strings_column_view const& input,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int64_t>>> const&
+    instruction_paths,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+
 }  // namespace spark_rapids_jni

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -19,6 +19,9 @@ package com.nvidia.spark.rapids.jni;
 import ai.rapids.cudf.ColumnVector;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
 
 public class GetJsonObjectTest {
@@ -615,6 +618,26 @@ public class GetJsonObjectTest {
             "[\"\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\"]", null, null, null, null, null, null, null, null);
         ColumnVector actual = JSONUtils.getJsonObject(input, query)) {
       assertColumnsAreEqual(expected, actual);
+    }
+  }
+
+  @Test
+  void getJsonObjectMultiplePathsTest() {
+    List<JSONUtils.PathInstructionJni> path0 = Arrays.asList(namedPath("k0"));
+    List<JSONUtils.PathInstructionJni> path1 = Arrays.asList(namedPath("k1"));
+    List<List<JSONUtils.PathInstructionJni>> paths = Arrays.asList(path0, path1);
+    try (ColumnVector jsonCv = ColumnVector.fromStrings("{\"k0\": \"v0\", \"k1\": \"v1\"}");
+         ColumnVector expected0 = ColumnVector.fromStrings("v0");
+         ColumnVector expected1 = ColumnVector.fromStrings("v1")) {
+      ColumnVector[] output = JSONUtils.getJsonObjectMultiplePaths(jsonCv, paths);
+      try {
+        assertColumnsAreEqual(expected0, output[0]);
+        assertColumnsAreEqual(expected1, output[1]);
+      } finally {
+        for (ColumnVector cv : output) {
+          cv.close();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This is just an interface to test with Spark plugin. It will be closed when a new PR for `get_json_object_multiple_paths` implementation is completed (which will include changes in this PR).