### PR TITLE
Fix `get_json_object` producing wrong output with wildcard paths

### DIFF
--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -488,10 +488,10 @@ __device__ bool evaluate_path(json_parser& p,
                 return false;
               }
             }
-            ctx.task_is_done = true;
-          } else {
-            return false;
           }
+          // Mark task is done regardless whether the expected child was found.
+          // If it was not found, the root context should eventially still not be dirty.
+          ctx.task_is_done = true;
         } else {
           // below is 1st enter
           ctx.is_first_enter = false;

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -490,7 +490,6 @@ __device__ bool evaluate_path(json_parser& p,
             }
           }
           // Mark task is done regardless whether the expected child was found.
-          // If it was not found, the root context should eventially still not be dirty.
           ctx.task_is_done = true;
         } else {
           // below is 1st enter

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -442,9 +442,9 @@ public class GetJsonObjectTest {
     };
 
     String JSON1 = "[ {'k': [0, 1, 2]}, {'k': [10, 11, 12]}, {'k': [20, 21, 22]}  ]";
-    String JSON2 = "[ {'k': [0, 1, 2]}, {'k': {10, 11, 12}}, {'k': [20, 21, 22]}, {'k': 'abc'}  ]";
+    String JSON2 = "[ {'k': [0, 1, 2]}, {'k': {'a': 'b'}}, {'k': [10, 11, 12]}, {'k': 'abc'}  ]";
     String expectedStr1 = "[[0,1,2],[10,11,12],[20,21,22]]";
-    String expectedStr2 = "[[0,1,2],[20,21,22]]";
+    String expectedStr2 = "[[0,1,2],[10,11,12]]";
 
     try (
         ColumnVector jsonCv = ColumnVector.fromStrings(JSON1, JSON2);

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -442,13 +442,14 @@ public class GetJsonObjectTest {
     };
 
     String JSON1 = "[ {'k': [0, 1, 2]}, {'k': [10, 11, 12]}, {'k': [20, 21, 22]}  ]";
+    String JSON2 = "[ {'k': [0, 1, 2]}, {'k': {10, 11, 12}}, {'k': [20, 21, 22]}, {'k': 'abc'}  ]";
     String expectedStr1 = "[[0,1,2],[10,11,12],[20,21,22]]";
+    String expectedStr2 = "[[0,1,2],[20,21,22]]";
 
     try (
-        ColumnVector jsonCv = ColumnVector.fromStrings(JSON1);
-        ColumnVector expected = ColumnVector.fromStrings(expectedStr1);
+        ColumnVector jsonCv = ColumnVector.fromStrings(JSON1, JSON2);
+        ColumnVector expected = ColumnVector.fromStrings(expectedStr1, expectedStr2);
         ColumnVector actual = JSONUtils.getJsonObject(jsonCv, query)) {
-
       assertColumnsAreEqual(expected, actual);
     }
   }


### PR DESCRIPTION
The output of `get_json_object` is wrong when the json path has a wildcard following by a name instruction. In such situations, the early return statement in the code path processing name instruction may cause the entire output row to be a null, instead of ignoring the child objects that do not contain the desired field.

This fixes the issue by removing the early return statement mentioned above.

Closes https://github.com/NVIDIA/spark-rapids/issues/11172.