### PR TITLE
Fix completion condition for `get_json_object` with wildcard paths but empty input array

### DIFF
--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -609,13 +609,14 @@ __device__ bool evaluate_path(json_parser& p,
             // add outer array tokens
             ctx.g.write_child_raw_value(
               child_g_start, child_g_len, /* write_outer_array_tokens */ true);
-            ctx.task_is_done = true;
           } else if (ctx.dirty == 1) {
             // remove outer array tokens
             ctx.g.write_child_raw_value(
               child_g_start, child_g_len, /* write_outer_array_tokens */ false);
-            ctx.task_is_done = true;
           }  // else do not write anything
+
+          // Done anyway, since we already reached the end array.
+          ctx.task_is_done = true;
         }
       }
       // case (START_ARRAY, Wildcard :: xs)


### PR DESCRIPTION
In cases when we have wildcard paths  (`[*]`) but the input array corresponding to it is an empty array, the current code does not report as complete after parsing past the end of the array. Instead, it continues parsing the input string indefinitely until the end of the string. Although that does not produce an incorrect output, it is a wrong behavior.

This fixes such behavior, allowing the code to terminate correctly.

