### PR TITLE
Add `nvtx` macro for `get_json_object` and `get_json_object_multiple_paths`

### DIFF
--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -19,6 +19,7 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
@@ -1185,6 +1186,7 @@ std::unique_ptr<cudf::column> get_json_object(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  CUDF_FUNC_RANGE();
   return std::move(detail::get_json_object(input, {instructions}, stream, mr).front());
 }
 
@@ -1195,6 +1197,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::get_json_object(input, json_paths, stream, mr);
 }
 


### PR DESCRIPTION
This adds `CUDF_FUNC_RANGE` macro for `get_json_object` and `get_json_object_multiple_paths`, allowing them to be traced easier when profiling.