### PR TITLE
Replace path-format=absolute with realpath

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -20,8 +20,10 @@
 
 set -e
 
-REPODIR=$(git rev-parse --path-format=absolute --show-toplevel)
-GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+REPODIR_REL=$(git rev-parse --show-toplevel)
+REPODIR=$(readlink -e "$REPODIR_REL")
+GIT_COMMON_DIR_REL=$(git rev-parse --git-common-dir)
+GIT_COMMON_DIR=$(readlink -e "$GIT_COMMON_DIR_REL")
 WORKDIR=${WORKDIR:-$REPODIR}
 
 CUDA_VERSION=${CUDA_VERSION:-11.8.0}

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -21,9 +21,9 @@
 set -e
 
 REPODIR_REL=$(git rev-parse --show-toplevel)
-REPODIR=$(readlink -e "$REPODIR_REL")
+REPODIR=$(realpath "$REPODIR_REL")
 GIT_COMMON_DIR_REL=$(git rev-parse --git-common-dir)
-GIT_COMMON_DIR=$(readlink -e "$GIT_COMMON_DIR_REL")
+GIT_COMMON_DIR=$(realpath "$GIT_COMMON_DIR_REL")
 WORKDIR=${WORKDIR:-$REPODIR}
 
 CUDA_VERSION=${CUDA_VERSION:-11.8.0}


### PR DESCRIPTION
Fixes #2242

Accommodate older git versions without path-format option

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
