### PR TITLE
Avoid serializing profiler events with invalid timestamps

### DIFF
--- a/src/main/cpp/profiler/profiler_serializer.cpp
+++ b/src/main/cpp/profiler/profiler_serializer.cpp
@@ -324,6 +324,10 @@ void profiler_serializer::flush()
 
 void profiler_serializer::process_api_activity(CUpti_ActivityAPI const* r)
 {
+  if (r->start == 0 || r->end == 0) {
+    // Ignore records with bad timestamps
+    return;
+  }
   auto api_kind = ApiKind_Runtime;
   if (r->kind == CUPTI_ACTIVITY_KIND_DRIVER) {
     api_kind = ApiKind_Driver;
@@ -403,6 +407,10 @@ void profiler_serializer::process_dropped_records(size_t num_dropped)
 
 void profiler_serializer::process_kernel(CUpti_ActivityKernel8 const* r)
 {
+  if (r->start == 0 || r->end == 0) {
+    // Ignore records with invalid timestamps
+    return;
+  }
   auto name = fbb_.CreateSharedString(r->name);
   KernelActivityBuilder kab(fbb_);
   kab.add_requested(r->cacheConfig.config.requested);
@@ -453,6 +461,10 @@ void profiler_serializer::process_kernel(CUpti_ActivityKernel8 const* r)
 
 void profiler_serializer::process_marker_activity(CUpti_ActivityMarker2 const* r)
 {
+  if (r->timestamp == 0) {
+    // Ignore records with invalid timestamps
+    return;
+  }
   auto object_id  = add_object_id(fbb_, r->objectKind, r->objectId);
   auto has_name   = r->name != nullptr;
   auto has_domain = r->name != nullptr;
@@ -472,6 +484,10 @@ void profiler_serializer::process_marker_activity(CUpti_ActivityMarker2 const* r
 
 void profiler_serializer::process_marker_data(CUpti_ActivityMarkerData const* r)
 {
+  if (r->flags == 0 && r->color == 0 && r->category == 0) {
+    // Ignore uninteresting marker data records
+    return;
+  }
   MarkerDataBuilder mdb(fbb_);
   mdb.add_flags(marker_flags_to_fb(r->flags));
   mdb.add_id(r->id);
@@ -482,6 +498,10 @@ void profiler_serializer::process_marker_data(CUpti_ActivityMarkerData const* r)
 
 void profiler_serializer::process_memcpy(CUpti_ActivityMemcpy5 const* r)
 {
+  if (r->start == 0 || r->end == 0) {
+    // Ignore records with invalid timestamps
+    return;
+  }
   MemcpyActivityBuilder mab(fbb_);
   mab.add_copy_kind(to_memcpy_kind(r->copyKind));
   mab.add_src_kind(to_memory_kind(r->srcKind));
@@ -504,6 +524,10 @@ void profiler_serializer::process_memcpy(CUpti_ActivityMemcpy5 const* r)
 
 void profiler_serializer::process_memset(CUpti_ActivityMemset4 const* r)
 {
+  if (r->start == 0 || r->end == 0) {
+    // Ignore records with invalid timestamps
+    return;
+  }
   MemsetActivityBuilder mab(fbb_);
   mab.add_value(r->value);
   mab.add_bytes(r->bytes);
@@ -524,6 +548,10 @@ void profiler_serializer::process_memset(CUpti_ActivityMemset4 const* r)
 
 void profiler_serializer::process_overhead(CUpti_ActivityOverhead const* r)
 {
+  if (r->start == 0 || r->end == 0) {
+    // Ignore records with invalid timestamps
+    return;
+  }
   auto object_id = add_object_id(fbb_, r->objectKind, r->objectId);
   OverheadActivityBuilder oab(fbb_);
   oab.add_overhead_kind(to_overhead_kind(r->overheadKind));


### PR DESCRIPTION
It is possible for CUPTI to generate records that have timestamps set to 0.  When these appear in the nsys-rep file, Nsight Systems shows a profile with a _huge_ timescale, making it very difficult to navigate the profile in the viewer.  This updates the profile serialization processing to ignore records with invalid timestamps and "uninteresting" marker data records that are essentially all zero except for an ID.