### PR TITLE
Detect and throw exception in `get_json_object` if the input has nesting depth exceed the maximum allowed value

### DIFF
--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -25,6 +25,16 @@ using path_instruction_type = spark_rapids_jni::path_instruction_type;
 
 extern "C" {
 
+JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_getMaxJSONPathDepth(JNIEnv* env,
+                                                                                      jclass)
+{
+  try {
+    cudf::jni::auto_set_device(env);
+    return spark_rapids_jni::MAX_JSON_PATH_DEPTH;
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(
   JNIEnv* env, jclass, jlong input_column, jobjectArray path_instructions)
 {

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1035,9 +1035,9 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
   h_path_data.reserve(json_paths.size());
 
   for (std::size_t idx = 0; idx < num_outputs; ++idx) {
-    auto const& instructions = json_paths[idx];
-    if (instructions.size() > MAX_JSON_PATH_DEPTH) {
-      CUDF_FAIL("JSONPath query exceeds maximum depth");
+    auto const& path = json_paths[idx];
+    if (path.size() > MAX_JSON_PATH_DEPTH) {
+      CUDF_FAIL("JSON Path has depth exceeds the maximum allowed value.");
     }
 
     scratch_buffers.emplace_back(rmm::device_uvector<char>(scratch_size, stream));

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -885,7 +885,7 @@ class kernel_launcher {
       <<<num_blocks, block_size, 0, stream.value()>>>(
         input, path_data, num_threads_per_row, max_path_depth_exceeded.data());
     CUDF_EXPECTS(!max_path_depth_exceeded.value(stream),
-                 "The processed input has depth exceed depth limit.");
+                 "The processed input has nesting depth exceeds depth limit.");
   }
 
  private:

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -379,23 +379,29 @@ struct context {
  * @return A pair containing the result code and the output size
  */
 __device__ thrust::pair<bool, cudf::size_type> evaluate_path(
-  char_range input, cudf::device_span<path_instruction const> path_commands, char* out_buf)
+  char_range input,
+  cudf::device_span<path_instruction const> path_commands,
+  char* out_buf,
+  bool* path_depth_exceeded)
 {
   json_parser p{input};
   p.next_token();
   if (json_token::ERROR == p.get_current_token()) { return {false, 0}; }
 
-  // define stack; plus 1 indicates root context task needs an extra memory
+  // Define stack; plus 1 indicates root context task needs an extra memory.
   context stack[MAX_JSON_PATH_DEPTH + 1];
   int stack_size = 0;
 
-  // push context function
-  auto push_context = [&p, &stack, &stack_size](evaluation_case_path _case_path,
-                                                json_generator _g,
-                                                write_style _style,
-                                                cudf::device_span<path_instruction const> _path) {
-    // no need to check stack is full
-    // because Spark-Rapids already checked maximum length of `path_instruction`
+  auto const push_context = [&](evaluation_case_path _case_path,
+                                json_generator _g,
+                                write_style _style,
+                                cudf::device_span<path_instruction const> _path) {
+    if (stack_size > MAX_JSON_PATH_DEPTH) {
+      *path_depth_exceeded = true;
+      // Because no more context is pushed, the evaluation output should be wrong.
+      // But that is not important, since we will throw exception after the kernel finishes.
+      return;
+    }
     auto& ctx          = stack[stack_size++];
     ctx.g              = std::move(_g);
     ctx.path           = std::move(_path);
@@ -407,7 +413,6 @@ __device__ thrust::pair<bool, cudf::size_type> evaluate_path(
     ctx.task_is_done   = false;
   };
 
-  // put the first context task
   push_context(evaluation_case_path::INVALID, json_generator{}, write_style::RAW, path_commands);
 
   while (stack_size > 0) {
@@ -810,7 +815,8 @@ template <int block_size, int min_block_per_sm>
 __launch_bounds__(block_size, min_block_per_sm) CUDF_KERNEL
   void get_json_object_kernel(cudf::column_device_view input,
                               cudf::device_span<json_path_processing_data> path_data,
-                              std::size_t num_threads_per_row)
+                              std::size_t num_threads_per_row,
+                              bool* path_depth_exceeded)
 {
   auto const tidx    = cudf::detail::grid_1d::global_thread_id();
   auto const row_idx = tidx / num_threads_per_row;
@@ -826,7 +832,8 @@ __launch_bounds__(block_size, min_block_per_sm) CUDF_KERNEL
 
   auto const str = input.element<cudf::string_view>(row_idx);
   if (str.size_bytes() > 0) {
-    thrust::tie(is_valid, out_size) = evaluate_path(char_range{str}, path.path_commands, dst);
+    thrust::tie(is_valid, out_size) =
+      evaluate_path(char_range{str}, path.path_commands, dst, path_depth_exceeded);
 
     auto const max_size = path.offsets[row_idx + 1] - path.offsets[row_idx];
     if (out_size > max_size) { *(path.has_out_of_bound) = 1; }
@@ -864,8 +871,13 @@ class kernel_launcher {
   {
     CUDF_EXPECTS(input.size() == input_size && path_data.size() == path_size,
                  "Unexpected data sizes upon launching kernel.");
+
+    rmm::device_scalar<bool> path_depth_exceeded(false, stream);
     get_json_object_kernel<block_size, min_block_per_sm>
-      <<<num_blocks, block_size, 0, stream.value()>>>(input, path_data, num_threads_per_row);
+      <<<num_blocks, block_size, 0, stream.value()>>>(
+        input, path_data, num_threads_per_row, path_depth_exceeded.data());
+    CUDF_EXPECTS(!path_depth_exceeded.value(stream),
+                 "The processed input has depth exceed depth limit.");
   }
 
  private:

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -26,6 +26,11 @@
 namespace spark_rapids_jni {
 
 /**
+ * @brief The maximum supported depth that a JSON path can reach.
+ */
+constexpr int MAX_JSON_PATH_DEPTH = 16;
+
+/**
  * @brief Type of instruction in a JSON path.
  */
 enum class path_instruction_type : int8_t { WILDCARD, INDEX, NAMED };

--- a/src/main/cpp/src/json_parser.cuh
+++ b/src/main/cpp/src/json_parser.cuh
@@ -43,7 +43,7 @@ enum class escape_style {
  * JSON with a greater depth is invalid
  * If set this to be a greater value, should update `context_stack`
  */
-constexpr int max_json_nesting_depth = 64;
+constexpr int MAX_JSON_NESTING_DEPTH = 64;
 
 //
 /**
@@ -220,7 +220,7 @@ class char_range_reader {
 class json_parser {
  public:
   __device__ inline explicit json_parser(char_range _chars)
-    : chars(_chars), curr_pos(0), current_token(json_token::INIT)
+    : chars(_chars), curr_pos(0), current_token(json_token::INIT), max_depth_exceeded(false)
   {
   }
 
@@ -320,7 +320,7 @@ class json_parser {
    */
   __device__ inline bool try_push_context(json_token token)
   {
-    if (stack_size < max_json_nesting_depth) {
+    if (stack_size < MAX_JSON_NESTING_DEPTH) {
       push_context(token);
       return true;
     } else {
@@ -348,14 +348,8 @@ class json_parser {
     return get_bit_value(context_stack, stack_size - 1);
   }
 
-  /**
-   * pop top context from stack
-   */
   __device__ inline void pop_curr_context() { stack_size--; }
 
-  /**
-   * is context stack is empty
-   */
   __device__ inline bool is_context_stack_empty() const { return stack_size == 0; }
 
   __device__ inline void set_current_error() { current_token = json_token::ERROR; }
@@ -376,6 +370,7 @@ class json_parser {
     switch (c) {
       case '{':
         if (!try_push_context(json_token::START_OBJECT)) {
+          max_depth_exceeded = true;
           set_current_error();
         } else {
           curr_pos++;
@@ -384,6 +379,7 @@ class json_parser {
         break;
       case '[':
         if (!try_push_context(json_token::START_ARRAY)) {
+          max_depth_exceeded = true;
           set_current_error();
         } else {
           curr_pos++;
@@ -1688,6 +1684,8 @@ class json_parser {
     return thrust::make_pair(false, 0);
   }
 
+  __device__ inline bool max_nesting_depth_exceeded() const { return max_depth_exceeded; }
+
  private:
   char_range const chars;
   cudf::size_type curr_pos;
@@ -1707,6 +1705,9 @@ class json_parser {
   cudf::size_type number_token_len;
 
   json_token current_token;
+
+  // Error check if the maximum nesting depth has been reached.
+  bool max_depth_exceeded;
 };
 
 }  // namespace spark_rapids_jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -25,8 +25,7 @@ public class JSONUtils {
     NativeDepsLoader.loadNativeDeps();
   }
 
-  // Keep the same with `max_path_depth` in `get_json_object.cu'
-  public static final int MAX_PATH_DEPTH = 16;
+  public static final int MAX_PATH_DEPTH = getMaxJSONPathDepth();
 
   public enum PathInstructionType {
     WILDCARD,
@@ -77,6 +76,8 @@ public class JSONUtils {
     }
     return ret;
   }
+
+  private static native int getMaxJSONPathDepth();
 
   private static native long getJsonObject(long input, PathInstructionJni[] path_instructions);
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -17,12 +17,14 @@
 package com.nvidia.spark.rapids.jni;
 
 import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.CudfException;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GetJsonObjectTest {
   /**
@@ -641,6 +643,76 @@ public class GetJsonObjectTest {
       }
     }
   }
+
+  /**
+   * This test is when an exception is thrown due to the input JSON path being too long.
+   */
+  @Test
+  void getJsonObjectTest_ExceedMaxNestingDepthInPath() {
+    JSONUtils.PathInstructionJni[] query =
+        new JSONUtils.PathInstructionJni[JSONUtils.MAX_PATH_DEPTH + 1];
+    for (int i = 0; i < JSONUtils.MAX_PATH_DEPTH + 1; ++i) {
+      query[i] = namedPath("k");
+    }
+    try (ColumnVector input = ColumnVector.fromStrings("")) {
+      assertThrows(CudfException.class, () -> JSONUtils.getJsonObject(input, query));
+    }
+  }
+
+  /**
+   * This test is when an exception is thrown due to maximum nesting depth being exceeded
+   * when pushing the context stack during evaluating the JSON path.
+   *
+   * The maximum depth limit here is the same as the limit for the input JSON path.
+   */
+  @Test
+  void getJsonObjectTest_ExceedMaxNestingDepthInContextStack() {
+    JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
+        wildcardPath(), wildcardPath()
+    };
+    String jsonStr = "\"v\"";
+    for (int i = 0; i < JSONUtils.MAX_PATH_DEPTH; ++i) {
+      jsonStr = String.format("[%s]", jsonStr);
+    }
+    // This string has nesting level exceeding the maximum depth.
+    String jsonStrTooDeep = String.format("[%s]", jsonStr);
+
+    try (ColumnVector validInput = ColumnVector.fromStrings(jsonStr);
+         ColumnVector invalidInput = ColumnVector.fromStrings(jsonStrTooDeep);
+         ColumnVector expected = ColumnVector.fromStrings("[\"v\"]");
+         ColumnVector output = JSONUtils.getJsonObject(validInput, query)) {
+      assertColumnsAreEqual(expected, output);
+      assertThrows(CudfException.class, () -> JSONUtils.getJsonObject(invalidInput, query));
+    }
+  }
+
+  /**
+   * This test is when an exception is thrown due to maximum nesting depth being exceeded
+   * in the JSON parser. The JSON path is simply mirroring the input.
+   *
+   * Note that the maximum depth in the internal parser, which is being tested here, is different
+   * from the limit for the input JSON path.
+   */
+  @Test
+  void getJsonObjectTest_ExceedMaxNestingDepthInJSONParser() {
+    // This is equivalent to the path '$'.
+    JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {};
+
+    final int MAX_PARSER_DEPTH = 64;
+    String jsonStr = "\"v\"";
+    for (int i = 0; i < MAX_PARSER_DEPTH; ++i) { // The maximum depth in JSON parser is 64.
+      jsonStr = String.format("{\"k%d\":%s}", i, jsonStr);
+    }
+    // This string has nesting level exceeding the maximum depth of 64.
+    String jsonStrTooDeep = String.format("{\"k%d\":%s}", MAX_PARSER_DEPTH, jsonStr);
+    try (ColumnVector validInput = ColumnVector.fromStrings(jsonStr);
+         ColumnVector invalidInput = ColumnVector.fromStrings(jsonStrTooDeep);
+         ColumnVector output = JSONUtils.getJsonObject(validInput, query)) {
+      assertColumnsAreEqual(validInput, output);
+      assertThrows(CudfException.class, () -> JSONUtils.getJsonObject(invalidInput, query));
+    }
+  }
+
 
   private JSONUtils.PathInstructionJni wildcardPath() {
     return new JSONUtils.PathInstructionJni(JSONUtils.PathInstructionType.WILDCARD, "", -1);


### PR DESCRIPTION
Currently, in `get_json_object`, when the maximum nesting depth has been exceeded, the evaluation process may either  return a null or just crash without any clear message. This PR adds the ability to detect such situation and  throw a better error message.

In addition, this also synchronizes between `MAX_JSON_PATH_DEPTH` in C++ JNI and `MAX_PATH_DEPTH` Java code, avoiding the possibility that they are set at different values.