### PR TITLE
Have multi-get_json_object batch and cluster paths

### DIFF
--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -128,9 +128,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
     }
 
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
-    auto output =
-      spark_rapids_jni::get_json_object_multiple_paths(cudf::strings_column_view{*input_cv}, paths,
-          memory_budget_bytes, parallel_override);
+    auto output         = spark_rapids_jni::get_json_object_multiple_paths(
+      cudf::strings_column_view{*input_cv}, paths, memory_budget_bytes, parallel_override);
 
     auto out_handles = cudf::jni::native_jlongArray(env, output.size());
     std::transform(output.begin(), output.end(), out_handles.begin(), [](auto& col) {

--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -83,7 +83,9 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
                                                                       jbyteArray j_type_nums,
                                                                       jobjectArray j_names,
                                                                       jintArray j_indexes,
-                                                                      jintArray j_path_offsets)
+                                                                      jintArray j_path_offsets,
+                                                                      jlong memory_budget_bytes,
+                                                                      jint parallel_override)
 {
   JNI_NULL_CHECK(env, j_input, "j_input column is null", 0);
   JNI_NULL_CHECK(env, j_type_nums, "j_type_nums is null", 0);
@@ -127,7 +129,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
 
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
     auto output =
-      spark_rapids_jni::get_json_object_multiple_paths(cudf::strings_column_view{*input_cv}, paths);
+      spark_rapids_jni::get_json_object_multiple_paths(cudf::strings_column_view{*input_cv}, paths,
+          memory_budget_bytes, parallel_override);
 
     auto out_handles = cudf::jni::native_jlongArray(env, output.size());
     std::transform(output.begin(), output.end(), out_handles.begin(), [](auto& col) {

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -17,8 +17,6 @@
 #include "get_json_object.hpp"
 #include "json_parser.cuh"
 
-#include <numeric>
-
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
@@ -42,6 +40,8 @@
 #include <thrust/pair.h>
 #include <thrust/transform_reduce.h>
 #include <thrust/tuple.h>
+
+#include <numeric>
 
 namespace spark_rapids_jni {
 
@@ -1019,8 +1019,7 @@ bool check_error(cudf::detail::host_vector<int8_t> const& error_check)
 std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   cudf::strings_column_view const& input,
   cudf::detail::input_offsetalator const& in_offsets,
-  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t>>>&
-    json_paths,
+  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
   int64_t scratch_size,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
@@ -1157,8 +1156,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> &
-    json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream,
@@ -1176,7 +1174,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
   }
 
   std::vector<std::size_t> sorted_indices(json_paths.size());
-  std::iota(sorted_indices.begin(), sorted_indices.end(), 0); // Fill with 0, 1, 2, ...
+  std::iota(sorted_indices.begin(), sorted_indices.end(), 0);  // Fill with 0, 1, 2, ...
 
   // Sort indices based on the corresponding paths.
   std::sort(sorted_indices.begin(), sorted_indices.end(), [&json_paths](size_t i, size_t j) {
@@ -1237,14 +1235,14 @@ std::unique_ptr<cudf::column> get_json_object(
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> inst{instructions};
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> inst{
+    instructions};
   return std::move(detail::get_json_object(input, inst, -1, -1, stream, mr).front());
 }
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>&
-    json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -909,7 +909,7 @@ std::tuple<std::vector<rmm::device_uvector<path_instruction>>,
            cudf::string_scalar,
            std::string>
 construct_path_commands(
-  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t>>> const&
+  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> const&
     json_paths,
   rmm::cuda_stream_view stream)
 {
@@ -1019,7 +1019,7 @@ bool check_error(cudf::detail::host_vector<int8_t> const& error_check)
 std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   cudf::strings_column_view const& input,
   cudf::detail::input_offsetalator const& in_offsets,
-  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
+  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> const& json_paths,
   int64_t scratch_size,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
@@ -1156,7 +1156,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const& json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream,
@@ -1189,7 +1189,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
   }
   std::vector<std::unique_ptr<cudf::column>> output(num_outputs);
 
-  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t>>> batch;
+  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> batch;
   std::vector<std::size_t> output_ids;
 
   std::size_t starting_path = 0;
@@ -1230,19 +1230,17 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
 
 std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
-  std::vector<std::tuple<path_instruction_type, std::string, int32_t>>& instructions,
+  std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> inst{
-    instructions};
-  return std::move(detail::get_json_object(input, inst, -1, -1, stream, mr).front());
+  return std::move(detail::get_json_object(input, {instructions}, -1, -1, stream, mr).front());
 }
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const& json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -966,6 +966,34 @@ construct_path_commands(
           std::move(h_inst_names)};
 }
 
+int64_t calc_scratch_size(
+  cudf::strings_column_view const& input,
+  cudf::detail::input_offsetalator const& in_offsets,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) {
+
+  auto const max_row_size = thrust::transform_reduce(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator(0),
+    thrust::make_counting_iterator(input.size()),
+    cuda::proclaim_return_type<int64_t>(
+      [in_offsets] __device__(auto const idx) { return in_offsets[idx + 1] - in_offsets[idx]; }),
+    int64_t{0},
+    thrust::maximum{});
+
+  // We will use scratch buffers to store the output strings without knowing their sizes.
+  // Since we do not know their sizes, we need to allocate the buffer a bit larger than the input
+  // size so that we will not write output strings into an out-of-bound position.
+  // Checking out-of-bound needs to be performed in the main kernel to make sure we will not have
+  // data corruption.
+  auto const scratch_size = [&, max_row_size = max_row_size] {
+    // Pad the scratch buffer by an additional size that is a multiple of max row size.
+    auto constexpr padding_rows = 10;
+    return input.chars_size(stream) + max_row_size * padding_rows;
+  }();
+  return scratch_size;
+}
+
 /**
  * @brief Error handling using error markers gathered after kernel launch.
  *
@@ -988,49 +1016,22 @@ bool check_error(cudf::detail::host_vector<int8_t> const& error_check)
     error_check.cbegin(), error_check.cend(), [](auto const val) { return val != 0; });
 }
 
-std::vector<std::unique_ptr<cudf::column>> get_json_object(
+std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   cudf::strings_column_view const& input,
+  cudf::detail::input_offsetalator const& in_offsets,
   std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
     json_paths,
+  int64_t scratch_size,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  auto const num_outputs = json_paths.size();
-  std::vector<std::unique_ptr<cudf::column>> output;
-
-  // Input is empty or all nulls - just return all null columns.
-  if (input.is_empty() || input.size() == input.null_count()) {
-    for (std::size_t idx = 0; idx < num_outputs; ++idx) {
-      output.emplace_back(std::make_unique<cudf::column>(input.parent(), stream, mr));
-    }
-    return output;
-  }
-
-  auto const d_input_ptr = cudf::column_device_view::create(input.parent(), stream);
-  auto const in_offsets =
-    cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), input.offset());
   auto const [d_json_paths, h_json_paths, d_inst_names, h_inst_names] =
     construct_path_commands(json_paths, stream);
 
-  auto const max_row_size = thrust::transform_reduce(
-    rmm::exec_policy(stream),
-    thrust::make_counting_iterator(0),
-    thrust::make_counting_iterator(input.size()),
-    cuda::proclaim_return_type<int64_t>(
-      [in_offsets] __device__(auto const idx) { return in_offsets[idx + 1] - in_offsets[idx]; }),
-    int64_t{0},
-    thrust::maximum{});
+  auto const num_outputs = json_paths.size();
+  std::vector<std::unique_ptr<cudf::column>> output;
 
-  // We will use scratch buffers to store the output strings without knowing their sizes.
-  // Since we do not know their sizes, we need to allocate the buffer a bit larger than the input
-  // size so that we will not write output strings into an out-of-bound position.
-  // Checking out-of-bound needs to be performed in the main kernel to make sure we will not have
-  // data corruption.
-  auto const scratch_size = [&, max_row_size = max_row_size] {
-    // Pad the scratch buffer by an additional size that is a multiple of max row size.
-    auto constexpr padding_rows = 10;
-    return input.chars_size(stream) + max_row_size * padding_rows;
-  }();
+  auto const d_input_ptr = cudf::column_device_view::create(input.parent(), stream);
 
   // The error check array contains markers denoting if there is any out-of-bound write occurs
   // (first `num_outputs` elements), or if the nesting depth exceeded its limits (the last element).
@@ -1152,6 +1153,73 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
                                 std::move(out_null_masks_and_null_counts[idx].first));
   }
   return output;
+
+}
+
+std::vector<std::unique_ptr<cudf::column>> get_json_object(
+  cudf::strings_column_view const& input,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
+    json_paths,
+  int64_t memory_budget_bytes,
+  int32_t parallel_override,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_outputs = json_paths.size();
+
+  // Input is empty or all nulls - just return all null columns.
+  if (input.is_empty() || input.size() == input.null_count()) {
+    std::vector<std::unique_ptr<cudf::column>> output;
+    for (std::size_t idx = 0; idx < num_outputs; ++idx) {
+      output.emplace_back(std::make_unique<cudf::column>(input.parent(), stream, mr));
+    }
+    return output;
+  }
+
+  std::vector<std::tuple<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>, std::size_t>>
+      sorted_paths;
+  for (std::size_t i = 0; i < json_paths.size(); i++) {
+    sorted_paths.emplace_back(json_paths[i], i);
+  }
+  std::sort(sorted_paths.begin(), sorted_paths.end());
+
+  auto const in_offsets =
+    cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), input.offset());
+  auto const scratch_size = calc_scratch_size(input, in_offsets, stream, mr);
+  if (memory_budget_bytes <= 0 && parallel_override <= 0) {
+    parallel_override = static_cast<int>(sorted_paths.size());
+  }
+  std::vector<std::unique_ptr<cudf::column>> output(num_outputs);
+  std::size_t starting_path = 0;
+  while (starting_path < num_outputs) {
+    std::size_t at = starting_path;
+    std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> batch;
+    std::vector<std::size_t> output_ids;
+    if (parallel_override > 0) {
+      int count = 0;
+      while (at < num_outputs && count < parallel_override) {
+        batch.push_back(std::get<0>(sorted_paths[at]));
+        output_ids.push_back(std::get<1>(sorted_paths[at]));
+        at++;
+        count++;
+      }
+    } else {
+      long budget = 0;
+      while (at < num_outputs && budget < memory_budget_bytes) {
+        batch.push_back(std::get<0>(sorted_paths[at]));
+        output_ids.push_back(std::get<1>(sorted_paths[at]));
+        at++;
+        budget += scratch_size;
+      }
+    }
+    auto tmp = get_json_object_batch(input, in_offsets, batch, scratch_size, stream, mr);
+    for (std::size_t i = 0; i < tmp.size(); i++) {
+      std::size_t out_i = output_ids[i];
+      output[out_i] = std::move(tmp[i]);
+    }
+    starting_path = at;
+  }
+  return output;
 }
 
 }  // namespace detail
@@ -1163,18 +1231,20 @@ std::unique_ptr<cudf::column> get_json_object(
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  return std::move(detail::get_json_object(input, {instructions}, stream, mr).front());
+  return std::move(detail::get_json_object(input, {instructions}, -1, -1, stream, mr).front());
 }
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
   std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
     json_paths,
+  int64_t memory_budget_bytes,
+  int32_t parallel_override,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::get_json_object(input, json_paths, stream, mr);
+  return detail::get_json_object(input, json_paths, memory_budget_bytes, parallel_override, stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1019,7 +1019,8 @@ bool check_error(cudf::detail::host_vector<int8_t> const& error_check)
 std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   cudf::strings_column_view const& input,
   cudf::detail::input_offsetalator const& in_offsets,
-  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> const& json_paths,
+  std::vector<cudf::host_span<std::tuple<path_instruction_type, std::string, int32_t> const>> const&
+    json_paths,
   int64_t scratch_size,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
@@ -1156,7 +1157,8 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const& json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
+    json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream,
@@ -1240,7 +1242,8 @@ std::unique_ptr<cudf::column> get_json_object(
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const& json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
+    json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -966,12 +966,11 @@ construct_path_commands(
           std::move(h_inst_names)};
 }
 
-int64_t calc_scratch_size(
-  cudf::strings_column_view const& input,
-  cudf::detail::input_offsetalator const& in_offsets,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr) {
-
+int64_t calc_scratch_size(cudf::strings_column_view const& input,
+                          cudf::detail::input_offsetalator const& in_offsets,
+                          rmm::cuda_stream_view stream,
+                          rmm::device_async_resource_ref mr)
+{
   auto const max_row_size = thrust::transform_reduce(
     rmm::exec_policy(stream),
     thrust::make_counting_iterator(0),
@@ -1153,7 +1152,6 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
                                 std::move(out_null_masks_and_null_counts[idx].first));
   }
   return output;
-
 }
 
 std::vector<std::unique_ptr<cudf::column>> get_json_object(
@@ -1176,8 +1174,9 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
     return output;
   }
 
-  std::vector<std::tuple<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>, std::size_t>>
-      sorted_paths;
+  std::vector<
+    std::tuple<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>, std::size_t>>
+    sorted_paths;
   for (std::size_t i = 0; i < json_paths.size(); i++) {
     sorted_paths.emplace_back(json_paths[i], i);
   }
@@ -1215,7 +1214,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object(
     auto tmp = get_json_object_batch(input, in_offsets, batch, scratch_size, stream, mr);
     for (std::size_t i = 0; i < tmp.size(); i++) {
       std::size_t out_i = output_ids[i];
-      output[out_i] = std::move(tmp[i]);
+      output[out_i]     = std::move(tmp[i]);
     }
     starting_path = at;
   }
@@ -1244,7 +1243,8 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::get_json_object(input, json_paths, memory_budget_bytes, parallel_override, stream, mr);
+  return detail::get_json_object(
+    input, json_paths, memory_budget_bytes, parallel_override, stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -57,13 +57,12 @@ std::unique_ptr<cudf::column> get_json_object(
  * @param json_paths the path operations to read extract
  * @param memory_budget_bytes a memory budget for temporary memory usage if > 0
  * @param parallel_override if this value is greater than 0 then it specifies the
- *        number of paths to process in parallel (this will cause the 
+ *        number of paths to process in parallel (this will cause the
  *        `memory_budget_bytes` paramemter to be ignored)
  */
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>&
-    json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -43,7 +43,7 @@ enum class path_instruction_type : int8_t { WILDCARD, INDEX, NAMED };
  */
 std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
-  std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
+  std::vector<std::tuple<path_instruction_type, std::string, int32_t>>& instructions,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
@@ -56,12 +56,13 @@ std::unique_ptr<cudf::column> get_json_object(
  * @param input the input string column to parse JSON from
  * @param json_paths the path operations to read extract
  * @param memory_budget_bytes a memory budget for temporary memory usage if > 0
- * @param parallel_override if > 0 then teh number of paths to process in parallel
- *  this will cause the memory_budget_bytes to be ignored.
+ * @param parallel_override if this value is greater than 0 then it specifies the
+ *        number of paths to process in parallel (this will cause the 
+ *        `memory_budget_bytes` paramemter to be ignored)
  */
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>&
     json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -62,7 +62,8 @@ std::unique_ptr<cudf::column> get_json_object(
  */
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const& json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
+    json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -43,7 +43,7 @@ enum class path_instruction_type : int8_t { WILDCARD, INDEX, NAMED };
  */
 std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
-  std::vector<std::tuple<path_instruction_type, std::string, int32_t>>& instructions,
+  std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
@@ -62,7 +62,7 @@ std::unique_ptr<cudf::column> get_json_object(
  */
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
-  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>>& json_paths,
+  std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const& json_paths,
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -53,11 +53,18 @@ std::unique_ptr<cudf::column> get_json_object(
  * This function processes all the JSON paths in parallel, which may be faster than calling
  * to `get_json_object` on the individual JSON paths. However, it may consume much more GPU
  * memory, proportional to the number of JSON paths.
+ * @param input the input string column to parse JSON from
+ * @param json_paths the path operations to read extract
+ * @param memory_budget_bytes a memory budget for temporary memory usage if > 0
+ * @param parallel_override if > 0 then teh number of paths to process in parallel
+ *  this will cause the memory_budget_bytes to be ignored.
  */
 std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   cudf::strings_column_view const& input,
   std::vector<std::vector<std::tuple<path_instruction_type, std::string, int32_t>>> const&
     json_paths,
+  int64_t memory_budget_bytes,
+  int32_t parallel_override,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -55,6 +55,12 @@ public class JSONUtils {
     }
   }
 
+  /**
+   * Extract a JSON path from a JSON column. The path is processed in a Spark compatible way.
+   * @param input the string column containing JSON
+   * @param pathInstructions the instructions for the path processing
+   * @return the result of processing the path.
+   */
   public static ColumnVector getJsonObject(ColumnVector input, PathInstructionJni[] pathInstructions) {
     assert (input.getType().equals(DType.STRING)) : "Input must be of STRING type";
     int numTotalInstructions = pathInstructions.length;
@@ -71,8 +77,36 @@ public class JSONUtils {
     return new ColumnVector(getJsonObject(input.getNativeView(), typeNums, names, indexes));
   }
 
+  /**
+   * Extract multiple JSON paths from a JSON column. The paths are processed n a Spark
+   * compatible way.
+   * @param input the string column containing JSON
+   * @param paths the instructions for multiple paths.
+   * @return the result of processing each path in the order that they were passed in.
+   */
   public static ColumnVector[] getJsonObjectMultiplePaths(ColumnVector input,
                                                           List<List<PathInstructionJni>> paths) {
+    return getJsonObjectMultiplePaths(input, paths, -1, -1);
+  }
+
+  /**
+   * Extract multiple JSON paths from a JSON column. The paths are processed n a Spark
+   * compatible way.
+   * @param input the string column containing JSON
+   * @param paths the instructions for multiple paths.
+   * @param memoryBudgetBytes a budget that is used to limit the amount of memory
+   *                          that is used when processing the paths. This is a soft limit.
+   *                          A value <= 0 disables this and all paths will be processed in parallel.
+   * @param parallelOverride Set a maximum number of paths to be processed in parallel. The memory
+   *                         budget can limit how many paths can be processed in parallel. This overrides
+   *                         that automatically calculated value with a set value for benchmarking purposes.
+   *                         A value <= 0 disables this.
+   * @return the result of processing each path in the order that they were passed in.
+   */
+  public static ColumnVector[] getJsonObjectMultiplePaths(ColumnVector input,
+                                                          List<List<PathInstructionJni>> paths,
+                                                          long memoryBudgetBytes,
+                                                          int parallelOverride) {
     assert (input.getType().equals(DType.STRING)) : "Input must be of STRING type";
     int[] pathOffsets = new int[paths.size() + 1];
     int offset = 0;
@@ -95,7 +129,7 @@ public class JSONUtils {
       }
     }
     long[] ptrs = getJsonObjectMultiplePaths(input.getNativeView(), typeNums,
-        names, indexes, pathOffsets);
+        names, indexes, pathOffsets, memoryBudgetBytes, parallelOverride);
     ColumnVector[] ret = new ColumnVector[ptrs.length];
     for (int i = 0; i < ptrs.length; i++) {
       ret[i] = new ColumnVector(ptrs[i]);
@@ -114,5 +148,7 @@ public class JSONUtils {
                                                           byte[] typeNums,
                                                           String[] names,
                                                           int[] indexes,
-                                                          int[] pathOffsets);
+                                                          int[] pathOffsets,
+                                                          long memoryBudgetBytes,
+                                                          int parallelOverride);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -59,7 +59,7 @@ public class JSONUtils {
    * Extract a JSON path from a JSON column. The path is processed in a Spark compatible way.
    * @param input the string column containing JSON
    * @param pathInstructions the instructions for the path processing
-   * @return the result of processing the path.
+   * @return the result of processing the path
    */
   public static ColumnVector getJsonObject(ColumnVector input, PathInstructionJni[] pathInstructions) {
     assert (input.getType().equals(DType.STRING)) : "Input must be of STRING type";
@@ -78,11 +78,11 @@ public class JSONUtils {
   }
 
   /**
-   * Extract multiple JSON paths from a JSON column. The paths are processed n a Spark
+   * Extract multiple JSON paths from a JSON column. The paths are processed in a Spark
    * compatible way.
    * @param input the string column containing JSON
    * @param paths the instructions for multiple paths.
-   * @return the result of processing each path in the order that they were passed in.
+   * @return the result of processing each path in the order that they were passed in
    */
   public static ColumnVector[] getJsonObjectMultiplePaths(ColumnVector input,
                                                           List<List<PathInstructionJni>> paths) {
@@ -90,7 +90,7 @@ public class JSONUtils {
   }
 
   /**
-   * Extract multiple JSON paths from a JSON column. The paths are processed n a Spark
+   * Extract multiple JSON paths from a JSON column. The paths are processed in a Spark
    * compatible way.
    * @param input the string column containing JSON
    * @param paths the instructions for multiple paths.
@@ -101,7 +101,7 @@ public class JSONUtils {
    *                         budget can limit how many paths can be processed in parallel. This overrides
    *                         that automatically calculated value with a set value for benchmarking purposes.
    *                         A value <= 0 disables this.
-   * @return the result of processing each path in the order that they were passed in.
+   * @return the result of processing each path in the order that they were passed in
    */
   public static ColumnVector[] getJsonObjectMultiplePaths(ColumnVector input,
                                                           List<List<PathInstructionJni>> paths,

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -93,7 +93,7 @@ public class JSONUtils {
    * Extract multiple JSON paths from a JSON column. The paths are processed in a Spark
    * compatible way.
    * @param input the string column containing JSON
-   * @param paths the instructions for multiple paths.
+   * @param paths the instructions for multiple paths
    * @param memoryBudgetBytes a budget that is used to limit the amount of memory
    *                          that is used when processing the paths. This is a soft limit.
    *                          A value <= 0 disables this and all paths will be processed in parallel.

--- a/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/JSONUtils.java
@@ -81,7 +81,7 @@ public class JSONUtils {
    * Extract multiple JSON paths from a JSON column. The paths are processed in a Spark
    * compatible way.
    * @param input the string column containing JSON
-   * @param paths the instructions for multiple paths.
+   * @param paths the instructions for multiple paths
    * @return the result of processing each path in the order that they were passed in
    */
   public static ColumnVector[] getJsonObjectMultiplePaths(ColumnVector input,

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -667,6 +667,46 @@ public class GetJsonObjectTest {
     }
   }
 
+  @Test
+  void getJsonObjectMultiplePathsTestCrazyLowMemoryBudget() {
+    List<JSONUtils.PathInstructionJni> path0 = Arrays.asList(namedPath("k0"));
+    List<JSONUtils.PathInstructionJni> path1 = Arrays.asList(namedPath("k1"));
+    List<List<JSONUtils.PathInstructionJni>> paths = Arrays.asList(path0, path1);
+    try (ColumnVector jsonCv = ColumnVector.fromStrings("{\"k0\": \"v0\", \"k1\": \"v1\"}");
+         ColumnVector expected0 = ColumnVector.fromStrings("v0");
+         ColumnVector expected1 = ColumnVector.fromStrings("v1")) {
+      ColumnVector[] output = JSONUtils.getJsonObjectMultiplePaths(jsonCv, paths, 1L, 0);
+      try {
+        assertColumnsAreEqual(expected0, output[0]);
+        assertColumnsAreEqual(expected1, output[1]);
+      } finally {
+        for (ColumnVector cv : output) {
+          cv.close();
+        }
+      }
+    }
+  }
+
+  @Test
+  void getJsonObjectMultiplePathsTestMemoryBudget() {
+    List<JSONUtils.PathInstructionJni> path0 = Arrays.asList(namedPath("k0"));
+    List<JSONUtils.PathInstructionJni> path1 = Arrays.asList(namedPath("k1"));
+    List<List<JSONUtils.PathInstructionJni>> paths = Arrays.asList(path0, path1);
+    try (ColumnVector jsonCv = ColumnVector.fromStrings("{\"k0\": \"v0\", \"k1\": \"v1\"}");
+         ColumnVector expected0 = ColumnVector.fromStrings("v0");
+         ColumnVector expected1 = ColumnVector.fromStrings("v1")) {
+      ColumnVector[] output = JSONUtils.getJsonObjectMultiplePaths(jsonCv, paths, 1024L, 0);
+      try {
+        assertColumnsAreEqual(expected0, output[0]);
+        assertColumnsAreEqual(expected1, output[1]);
+      } finally {
+        for (ColumnVector cv : output) {
+          cv.close();
+        }
+      }
+    }
+  }
+
   /**
    * This test is when an exception is thrown due to the input JSON path being too long.
    */


### PR DESCRIPTION
This is to improve performance and try to stay within a memory limit.

This contributes to https://github.com/NVIDIA/spark-rapids/issues/11263

In my performance testing I am seeing an improvement of 9% on an a6000 GPU when there are lots of paths to combine, many of which have common beginning paths.  I will test on some less powerful GPUs too. I think we can do a better job with clustering the paths in a smarter way, but this is super simple and is showing a lot of promise so I thought I would check it in.

Note to fully take advantage of this we will need some changes to the plugin as well https://github.com/NVIDIA/spark-rapids/pull/11289.