### PR TITLE
Revert "Switch `rmm::get_current_device_resource` to use references via `rmm::get_current_device_resource_ref`"

### DIFF
--- a/src/main/cpp/src/bloom_filter.hpp
+++ b/src/main/cpp/src/bloom_filter.hpp
@@ -48,7 +48,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(
   int num_hashes,
   int bloom_filter_longs,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Inserts input values into a bloom filter.
@@ -79,7 +79,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
   cudf::column_view const& input,
   cudf::device_span<uint8_t const> bloom_filter,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Probe a bloom filter with an input column of int64_t values.
@@ -96,7 +96,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
   cudf::column_view const& input,
   cudf::list_scalar& bloom_filter,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Merge multiple bloom filters into a single output.
@@ -114,6 +114,6 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
 std::unique_ptr<cudf::list_scalar> bloom_filter_merge(
   cudf::column_view const& bloom_filters,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/case_when.hpp
+++ b/src/main/cpp/src/case_when.hpp
@@ -48,6 +48,6 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> select_first_true_index(
   cudf::table_view const& when_bool_columns,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -75,7 +75,7 @@ std::unique_ptr<cudf::column> string_to_integer(
   bool ansi_mode,
   bool strip,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Convert a string column into an decimal column.
@@ -97,7 +97,7 @@ std::unique_ptr<cudf::column> string_to_decimal(
   bool ansi_mode,
   bool strip,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Convert a string column into an float column.
@@ -115,22 +115,22 @@ std::unique_ptr<cudf::column> string_to_float(
   cudf::strings_column_view const& string_col,
   bool ansi_mode,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> format_float(
   cudf::column_view const& input,
   int const digits,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -991,7 +991,7 @@ std::unique_ptr<cudf::table> multiply_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1026,7 +1026,7 @@ std::unique_ptr<cudf::table> divide_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1060,7 +1060,7 @@ std::unique_ptr<cudf::table> integer_divide_decimal128(cudf::column_view const& 
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1093,7 +1093,7 @@ std::unique_ptr<cudf::table> remainder_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1126,7 +1126,7 @@ std::unique_ptr<cudf::table> add_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1159,7 +1159,7 @@ std::unique_ptr<cudf::table> sub_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1410,7 +1410,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
     output_type, input.size(), cudf::mask_state::UNALLOCATED, stream, mr);
 
   auto const decimal_places = -output_type.scale();
-  auto const default_mr     = rmm::mr::get_current_device_resource_ref();
+  auto const default_mr     = rmm::mr::get_current_device_resource();
 
   rmm::device_uvector<int8_t> validity(input.size(), stream, default_mr);
   rmm::device_scalar<bool> has_failure(false, stream, default_mr);

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -79,6 +79,6 @@ std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
   cudf::data_type output_type,
   int32_t precision,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace cudf::jni

--- a/src/main/cpp/src/from_json.hpp
+++ b/src/main/cpp/src/from_json.hpp
@@ -29,6 +29,6 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> from_json_to_raw_map(
   cudf::strings_column_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -64,7 +64,7 @@ rmm::device_uvector<char> unify_json_strings(cudf::strings_column_view const& in
 {
   if (input.is_empty()) {
     return cudf::detail::make_device_uvector_async<char>(
-      std::vector<char>{'[', ']'}, stream, rmm::mr::get_current_device_resource_ref());
+      std::vector<char>{'[', ']'}, stream, rmm::mr::get_current_device_resource());
   }
 
   auto const d_strings  = cudf::column_device_view::create(input.parent(), stream);
@@ -84,7 +84,7 @@ rmm::device_uvector<char> unify_json_strings(cudf::strings_column_view const& in
     cudf::string_scalar(","),   // append `,` character between the input rows
     cudf::string_scalar("{}"),  // replacement for null rows
     stream,
-    rmm::mr::get_current_device_resource_ref());
+    rmm::mr::get_current_device_resource());
   auto const joined_input_scv        = cudf::strings_column_view{*joined_input};
   auto const joined_input_size_bytes = joined_input_scv.chars_size(stream);
   // TODO: This assertion requires a stream synchronization, may want to remove at some point.
@@ -656,7 +656,7 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
     cudf::device_span<char const>{unified_json_buff.data(), unified_json_buff.size()},
     cudf::io::json_reader_options{},
     stream,
-    rmm::mr::get_current_device_resource_ref());
+    rmm::mr::get_current_device_resource());
 
 #ifdef DEBUG_FROM_JSON
   print_debug(tokens, "Tokens", ", ", stream);

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -959,7 +959,7 @@ construct_path_commands(
   d_path_commands.reserve(h_path_commands->size());
   for (auto const& path_commands : *h_path_commands) {
     d_path_commands.emplace_back(cudf::detail::make_device_uvector_async(
-      path_commands, stream, rmm::mr::get_current_device_resource_ref()));
+      path_commands, stream, rmm::mr::get_current_device_resource()));
   }
 
   return {std::move(d_path_commands),
@@ -1060,7 +1060,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
                                                        d_error_check.data() + idx});
   }
   auto d_path_data = cudf::detail::make_device_uvector_async(
-    h_path_data, stream, rmm::mr::get_current_device_resource_ref());
+    h_path_data, stream, rmm::mr::get_current_device_resource());
   thrust::uninitialized_fill(
     rmm::exec_policy(stream), d_error_check.begin(), d_error_check.end(), 0);
 
@@ -1130,7 +1130,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
 
   // Push data to the GPU and launch the kernel again.
   d_path_data = cudf::detail::make_device_uvector_async(
-    h_path_data, stream, rmm::mr::get_current_device_resource_ref());
+    h_path_data, stream, rmm::mr::get_current_device_resource());
   thrust::uninitialized_fill(
     rmm::exec_policy(stream), d_error_check.begin(), d_error_check.end(), 0);
   kernel_launcher::exec(input, d_path_data, d_max_path_depth_exceeded, stream);

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -45,7 +45,7 @@ std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
   std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Extract multiple JSON objects from a JSON string based on the specified JSON paths.
@@ -67,6 +67,6 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash.hpp
+++ b/src/main/cpp/src/hash.hpp
@@ -40,7 +40,7 @@ std::unique_ptr<cudf::column> murmur_hash3_32(
   cudf::table_view const& input,
   uint32_t seed                     = 0,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Computes the xxhash64 hash value of each row in the input set of columns.
@@ -56,7 +56,7 @@ std::unique_ptr<cudf::column> xxhash64(
   cudf::table_view const& input,
   int64_t seed                      = DEFAULT_XXHASH64_SEED,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Computes the Hive hash value of each row in the input set of columns.
@@ -70,6 +70,6 @@ std::unique_ptr<cudf::column> xxhash64(
 std::unique_ptr<cudf::column> hive_hash(
   cudf::table_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -191,8 +191,8 @@ struct percentile_dispatcher {
     // We may always have nulls in the output due to either:
     // - Having nulls in the input, and/or,
     // - Having empty histograms.
-    auto out_validities = rmm::device_uvector<int8_t>(
-      num_histograms, stream, rmm::mr::get_current_device_resource_ref());
+    auto out_validities =
+      rmm::device_uvector<int8_t>(num_histograms, stream, rmm::mr::get_current_device_resource());
 
     auto const fill_percentile = [&](auto const sorted_validity_it) {
       auto const sorted_input_it =
@@ -307,7 +307,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
     }
   }
 
-  auto const default_mr = rmm::mr::get_current_device_resource_ref();
+  auto const default_mr = rmm::mr::get_current_device_resource();
 
   // We only check if there is any row in frequencies that are negative (invalid) or zero.
   auto check_invalid_and_zero =
@@ -439,7 +439,7 @@ std::unique_ptr<cudf::column> percentile_from_histogram(cudf::column_view const&
   auto const data_col       = cudf::structs_column_view{histograms}.get_sliced_child(0);
   auto const counts_col     = cudf::structs_column_view{histograms}.get_sliced_child(1);
 
-  auto const default_mr = rmm::mr::get_current_device_resource_ref();
+  auto const default_mr = rmm::mr::get_current_device_resource();
   auto const d_data     = cudf::column_device_view::create(data_col, stream);
   auto const d_percentages =
     cudf::detail::make_device_uvector_sync(percentages, stream, default_mr);

--- a/src/main/cpp/src/histogram.hpp
+++ b/src/main/cpp/src/histogram.hpp
@@ -52,7 +52,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(
   cudf::column_view const& frequencies,
   bool output_as_lists,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Compute percentiles from the given histograms and percentage values.
@@ -72,6 +72,6 @@ std::unique_ptr<cudf::column> percentile_from_histogram(
   std::vector<double> const& percentage,
   bool output_as_lists,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -38,7 +38,7 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> parse_uri_to_protocol(
   cudf::strings_column_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Parse host and copy from the input string column to the output string column.
@@ -51,7 +51,7 @@ std::unique_ptr<cudf::column> parse_uri_to_protocol(
 std::unique_ptr<cudf::column> parse_uri_to_host(
   cudf::strings_column_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Parse query and copy from the input string column to the output string column.
@@ -64,7 +64,7 @@ std::unique_ptr<cudf::column> parse_uri_to_host(
 std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Parse query and copy from the input string column to the output string column.
@@ -79,7 +79,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   std::string const& query_match,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Parse query and copy from the input string column to the output string column.
@@ -94,7 +94,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   cudf::strings_column_view const& query_match,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Parse path and copy from the input string column to the output string column.
@@ -107,6 +107,6 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
 std::unique_ptr<cudf::column> parse_uri_to_path(
   cudf::strings_column_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/regex_rewrite_utils.hpp
+++ b/src/main/cpp/src/regex_rewrite_utils.hpp
@@ -41,5 +41,5 @@ std::unique_ptr<cudf::column> literal_range_pattern(
   int const start,
   int const end,
   rmm::cuda_stream_view stream      = rmm::cuda_stream_default,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -223,7 +223,7 @@ build_string_row_offsets(table_view const& tbl,
                     std::back_inserter(offsets_iterators),
                     thrust::identity<bool>{});
     return make_device_uvector_sync(
-      offsets_iterators, stream, rmm::mr::get_current_device_resource_ref());
+      offsets_iterators, stream, rmm::mr::get_current_device_resource());
   }();
 
   auto const num_columns = static_cast<size_type>(d_offsets_iterators.size());
@@ -1540,11 +1540,11 @@ batch_data build_batches(size_type num_rows,
     last_row_end = row_end;
   }
 
-  return {std::move(batch_row_offsets),
-          make_device_uvector_async(
-            batch_row_boundaries, stream, rmm::mr::get_current_device_resource_ref()),
-          std::move(batch_row_boundaries),
-          std::move(row_batches)};
+  return {
+    std::move(batch_row_offsets),
+    make_device_uvector_async(batch_row_boundaries, stream, rmm::mr::get_current_device_resource()),
+    std::move(batch_row_boundaries),
+    std::move(row_batches)};
 }
 
 /**
@@ -1786,9 +1786,9 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   };
 
   auto dev_col_sizes = make_device_uvector_async(
-    column_info.column_sizes, stream, rmm::mr::get_current_device_resource_ref());
+    column_info.column_sizes, stream, rmm::mr::get_current_device_resource());
   auto dev_col_starts = make_device_uvector_async(
-    column_info.column_starts, stream, rmm::mr::get_current_device_resource_ref());
+    column_info.column_starts, stream, rmm::mr::get_current_device_resource());
 
   // Get the pointers to the input columnar data ready
   auto const data_begin = thrust::make_transform_iterator(tbl.begin(), [](auto const& c) {
@@ -1802,9 +1802,9 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   std::vector<bitmask_type const*> input_nm(nm_begin, nm_begin + tbl.num_columns());
 
   auto dev_input_data =
-    make_device_uvector_async(input_data, stream, rmm::mr::get_current_device_resource_ref());
+    make_device_uvector_async(input_data, stream, rmm::mr::get_current_device_resource());
   auto dev_input_nm =
-    make_device_uvector_async(input_nm, stream, rmm::mr::get_current_device_resource_ref());
+    make_device_uvector_async(input_nm, stream, rmm::mr::get_current_device_resource());
 
   // the first batch always exists unless we were sent an empty table
   auto const first_batch_size = batch_info.row_batches[0].row_count;
@@ -1867,8 +1867,8 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
   auto validity_tile_infos = detail::build_validity_tile_infos(
     tbl.num_columns(), num_rows, shmem_limit_per_tile, batch_info.row_batches);
 
-  auto dev_validity_tile_infos = make_device_uvector_async(
-    validity_tile_infos, stream, rmm::mr::get_current_device_resource_ref());
+  auto dev_validity_tile_infos =
+    make_device_uvector_async(validity_tile_infos, stream, rmm::mr::get_current_device_resource());
 
   auto const validity_offset = column_info.column_starts.back();
 
@@ -1916,9 +1916,9 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
       variable_data_begin, variable_data_begin + variable_width_table.num_columns());
 
     auto dev_variable_input_data = make_device_uvector_async(
-      variable_width_input_data, stream, rmm::mr::get_current_device_resource_ref());
+      variable_width_input_data, stream, rmm::mr::get_current_device_resource());
     auto dev_variable_col_output_offsets = make_device_uvector_async(
-      column_info.variable_width_column_starts, stream, rmm::mr::get_current_device_resource_ref());
+      column_info.variable_width_column_starts, stream, rmm::mr::get_current_device_resource());
 
     for (uint i = 0; i < batch_info.row_batches.size(); i++) {
       auto const batch_row_offset = batch_info.batch_row_boundaries[i];
@@ -2191,9 +2191,9 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   // fine
   CUDF_EXPECTS(size_per_row * num_rows <= child.size(), "The layout of the data appears to be off");
   auto dev_col_starts = make_device_uvector_async(
-    column_info.column_starts, stream, rmm::mr::get_current_device_resource_ref());
+    column_info.column_starts, stream, rmm::mr::get_current_device_resource());
   auto dev_col_sizes = make_device_uvector_async(
-    column_info.column_sizes, stream, rmm::mr::get_current_device_resource_ref());
+    column_info.column_sizes, stream, rmm::mr::get_current_device_resource());
 
   // Allocate the columns we are going to write into
   std::vector<std::unique_ptr<column>> output_columns;
@@ -2223,11 +2223,11 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     if (i.id() == type_id::STRING) {
       auto const int32type = data_type(type_id::INT32);
       auto offset_col =
-        make_col(int32type, num_rows, true, stream, rmm::mr::get_current_device_resource_ref());
+        make_col(int32type, num_rows, true, stream, rmm::mr::get_current_device_resource());
       string_row_offsets.push_back(offset_col->mutable_view().data<int32_t>());
       string_row_offset_columns.emplace_back(std::move(offset_col));
       auto length_col =
-        make_col(int32type, num_rows, false, stream, rmm::mr::get_current_device_resource_ref());
+        make_col(int32type, num_rows, false, stream, rmm::mr::get_current_device_resource());
       string_lengths.push_back(length_col->mutable_view().data<int32_t>());
       string_length_columns.emplace_back(std::move(length_col));
       // placeholder
@@ -2237,10 +2237,10 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     }
   }
 
-  auto dev_string_row_offsets = make_device_uvector_async(
-    string_row_offsets, stream, rmm::mr::get_current_device_resource_ref());
+  auto dev_string_row_offsets =
+    make_device_uvector_async(string_row_offsets, stream, rmm::mr::get_current_device_resource());
   auto dev_string_lengths =
-    make_device_uvector_async(string_lengths, stream, rmm::mr::get_current_device_resource_ref());
+    make_device_uvector_async(string_lengths, stream, rmm::mr::get_current_device_resource());
 
   // build the row_batches from the passed in list column
   std::vector<detail::row_batch> row_batches;
@@ -2248,9 +2248,9 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
     {detail::row_batch{child.size(), num_rows, device_uvector<size_type>(0, stream)}});
 
   auto dev_output_data =
-    make_device_uvector_async(output_data, stream, rmm::mr::get_current_device_resource_ref());
+    make_device_uvector_async(output_data, stream, rmm::mr::get_current_device_resource());
   auto dev_output_nm =
-    make_device_uvector_async(output_nm, stream, rmm::mr::get_current_device_resource_ref());
+    make_device_uvector_async(output_nm, stream, rmm::mr::get_current_device_resource());
 
   // only ever get a single batch when going from rows, so boundaries are 0, num_rows
   constexpr auto num_batches = 2;
@@ -2303,8 +2303,8 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   auto validity_tile_infos =
     detail::build_validity_tile_infos(schema.size(), num_rows, shmem_limit_per_tile, row_batches);
 
-  auto dev_validity_tile_infos = make_device_uvector_async(
-    validity_tile_infos, stream, rmm::mr::get_current_device_resource_ref());
+  auto dev_validity_tile_infos =
+    make_device_uvector_async(validity_tile_infos, stream, rmm::mr::get_current_device_resource());
 
   dim3 const validity_blocks(validity_tile_infos.size());
 
@@ -2393,9 +2393,9 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
       string_data_cols.push_back(std::move(string_data));
     }
     auto dev_string_col_offsets = make_device_uvector_async(
-      string_col_offset_ptrs, stream, rmm::mr::get_current_device_resource_ref());
+      string_col_offset_ptrs, stream, rmm::mr::get_current_device_resource());
     auto dev_string_data_cols = make_device_uvector_async(
-      string_data_col_ptrs, stream, rmm::mr::get_current_device_resource_ref());
+      string_data_col_ptrs, stream, rmm::mr::get_current_device_resource());
 
     dim3 const string_blocks(
       std::min(std::max(MIN_STRING_BLOCKS, num_rows / NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS),
@@ -2466,9 +2466,9 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
     CUDF_EXPECTS(size_per_row * num_rows == child.size(),
                  "The layout of the data appears to be off");
     auto dev_column_start =
-      make_device_uvector_async(column_start, stream, rmm::mr::get_current_device_resource_ref());
+      make_device_uvector_async(column_start, stream, rmm::mr::get_current_device_resource());
     auto dev_column_size =
-      make_device_uvector_async(column_size, stream, rmm::mr::get_current_device_resource_ref());
+      make_device_uvector_async(column_size, stream, rmm::mr::get_current_device_resource());
 
     // Allocate the columns we are going to write into
     std::vector<std::unique_ptr<column>> output_columns;

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -31,24 +31,24 @@ std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized
   cudf::table_view const& tbl,
   // TODO need something for validity
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows(
   cudf::table_view const& tbl,
   // TODO need something for validity
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::table> convert_from_rows(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/substring_index.cu
+++ b/src/main/cpp/src/substring_index.cu
@@ -124,11 +124,11 @@ std::unique_ptr<column> substring_index(strings_column_view const& strings,
   auto start_chars_pos_vec = make_column_from_scalar(numeric_scalar<size_type>(0, true, stream),
                                                      strings_count,
                                                      stream,
-                                                     rmm::mr::get_current_device_resource_ref());
+                                                     rmm::mr::get_current_device_resource());
   auto stop_chars_pos_vec  = make_column_from_scalar(numeric_scalar<size_type>(0, true, stream),
                                                     strings_count,
                                                     stream,
-                                                    rmm::mr::get_current_device_resource_ref());
+                                                    rmm::mr::get_current_device_resource());
 
   auto start_char_pos = start_chars_pos_vec->mutable_view().data<size_type>();
   auto end_char_pos   = stop_chars_pos_vec->mutable_view().data<size_type>();

--- a/src/main/cpp/src/substring_index.hpp
+++ b/src/main/cpp/src/substring_index.hpp
@@ -35,6 +35,6 @@ std::unique_ptr<cudf::column> substring_index(
   cudf::strings_column_view const& strings,
   cudf::string_scalar const& delimiter,
   cudf::size_type count,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -44,7 +44,7 @@ std::unique_ptr<cudf::column> convert_timestamp_to_utc(
   cudf::table_view const& transitions,
   cudf::size_type tz_index,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Convert input column timestamps in UTC to specified timezone
@@ -65,6 +65,6 @@ std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
   cudf::table_view const& transitions,
   cudf::size_type tz_index,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/utilities.cu
+++ b/src/main/cpp/src/utilities.cu
@@ -48,7 +48,7 @@ std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::transform(
     input.begin(), input.end(), h_input.begin(), [](auto mask) { return mask.data(); });
   auto d_input = cudf::detail::make_device_uvector_async(
-    h_input, stream, rmm::mr::get_current_device_resource_ref());
+    h_input, stream, rmm::mr::get_current_device_resource());
 
   std::unique_ptr<rmm::device_buffer> out =
     std::make_unique<rmm::device_buffer>(mask_size * sizeof(cudf::bitmask_type), stream, mr);

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -37,6 +37,6 @@ namespace spark_rapids_jni {
 std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -29,12 +29,12 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> interleave_bits(
   cudf::table_view const& tbl,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 std::unique_ptr<cudf::column> hilbert_index(
   int32_t const num_bits,
   cudf::table_view const& tbl,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -110,12 +110,8 @@ TEST_F(TimeZoneTest, ConvertToUTCSeconds)
                                     -28800L,
                                     1699537367L,
                                     568008000L};
-  auto const actual =
-    spark_rapids_jni::convert_timestamp_to_utc(ts_col,
-                                               *transitions,
-                                               1,
-                                               cudf::get_default_stream(),
-                                               rmm::mr::get_current_device_resource_ref());
+  auto const actual   = spark_rapids_jni::convert_timestamp_to_utc(
+    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -143,12 +139,8 @@ TEST_F(TimeZoneTest, ConvertToUTCMilliseconds)
                                    -28800000L,
                                    1699542834312L,
                                    568008000000L};
-  auto const actual =
-    spark_rapids_jni::convert_timestamp_to_utc(ts_col,
-                                               *transitions,
-                                               1,
-                                               cudf::get_default_stream(),
-                                               rmm::mr::get_current_device_resource_ref());
+  auto const actual   = spark_rapids_jni::convert_timestamp_to_utc(
+    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -176,12 +168,8 @@ TEST_F(TimeZoneTest, ConvertToUTCMicroseconds)
                                    -28800000000L,
                                    1699542834312000L,
                                    568008000000000L};
-  auto const actual =
-    spark_rapids_jni::convert_timestamp_to_utc(ts_col,
-                                               *transitions,
-                                               1,
-                                               cudf::get_default_stream(),
-                                               rmm::mr::get_current_device_resource_ref());
+  auto const actual   = spark_rapids_jni::convert_timestamp_to_utc(
+    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -209,12 +197,8 @@ TEST_F(TimeZoneTest, ConvertFromUTCSeconds)
     1699566167L,
     568036800L,
   };
-  auto const actual =
-    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
-                                                        *transitions,
-                                                        1,
-                                                        cudf::get_default_stream(),
-                                                        rmm::mr::get_current_device_resource_ref());
+  auto const actual = spark_rapids_jni::convert_utc_timestamp_to_timezone(
+    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -242,12 +226,8 @@ TEST_F(TimeZoneTest, ConvertFromUTCMilliseconds)
     1699571634312L,
     568036800000L,
   };
-  auto const actual =
-    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
-                                                        *transitions,
-                                                        1,
-                                                        cudf::get_default_stream(),
-                                                        rmm::mr::get_current_device_resource_ref());
+  auto const actual = spark_rapids_jni::convert_utc_timestamp_to_timezone(
+    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -275,12 +255,8 @@ TEST_F(TimeZoneTest, ConvertFromUTCMicroseconds)
     1699571634312000L,
     568036800000000L,
   };
-  auto const actual =
-    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
-                                                        *transitions,
-                                                        1,
-                                                        cudf::get_default_stream(),
-                                                        rmm::mr::get_current_device_resource_ref());
+  auto const actual = spark_rapids_jni::convert_utc_timestamp_to_timezone(
+    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }


### PR DESCRIPTION
Reverts NVIDIA/spark-rapids-jni#2372

This temporarily reverts https://github.com/NVIDIA/spark-rapids-jni/pull/2372 while we wait for RMM https://github.com/rapidsai/rmm/pull/1661 to be merged.

In response to comment by @harrism https://github.com/NVIDIA/spark-rapids-jni/pull/2372#issuecomment-2330474142