### PR TITLE
Fix field name matching in `get_json_object` with escaped characters

### DIFF
--- a/src/main/cpp/src/json_parser.cuh
+++ b/src/main/cpp/src/json_parser.cuh
@@ -978,7 +978,7 @@ class json_parser {
 
     if (!to_match.is_null()) {
       for (cudf::size_type i = 0; i < bytes; i++) {
-        if (!(to_match.eof() && to_match.current_char() == buff[i])) { return false; }
+        if (to_match.eof() || to_match.current_char() != buff[i]) { return false; }
         to_match.next();
       }
     }

--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -776,6 +776,18 @@ public class GetJsonObjectTest {
     }
   }
 
+  @Test
+  void getJsonObjectTest_NamesWithEscapedCharacters() {
+    JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
+        namedPath("data")
+    };
+    try (ColumnVector input = ColumnVector.fromStrings(
+        "{'data': 'TEST1'}", "{'\\u0064\\u0061t\\u0061': 'TEST2'}");
+         ColumnVector expected = ColumnVector.fromStrings("TEST1", "TEST2");
+         ColumnVector output = JSONUtils.getJsonObject(input, query)) {
+      assertColumnsAreEqual(expected, output);
+    }
+  }
 
   private JSONUtils.PathInstructionJni wildcardPath() {
     return new JSONUtils.PathInstructionJni(JSONUtils.PathInstructionType.WILDCARD, "", -1);


### PR DESCRIPTION
This fixes a bug in the matching code in `json_parser.cuh` that incorrectly checks for character matching, which results in an incorrect output when the input JSON string contains escaped characters in field names.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2397.

Note that the opposite case, when the JSON paths contain escaped characters in name instructions is still not supported.