### PR TITLE
[auto-merge] bot-auto-merge-branch-24.10 to branch-24.12 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -44,7 +44,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "3e0509f389c300781715c0c6f30a6fe2eb03c1e7",
+      "git_tag" : "42e0d727e4044f7941a62e97d8f68fd14c24d02f",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "version" : "24.10"
     },
@@ -141,7 +141,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "ab6e2961d7b8f833f688775e941c4e2ed2bd4d8a",
+      "git_tag" : "99e237ef6a42321a6bbd28b7aab9e4cc4105e6a3",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "version" : "24.10"
     },


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-24.10` to create a PR keeping `branch-24.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.