### PR TITLE
Disable kvikio remote I/O to avoid openssl dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,7 @@
                   <arg value="-DCUDF_USE_ARROW_STATIC=ON"/>
                   <arg value="-DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${CUDF_USE_PER_THREAD_DEFAULT_STREAM}" />
                   <arg value="-DCUDF_LARGE_STRINGS_DISABLED=ON"/>
+                  <arg value="-DKvikIO_REMOTE_SUPPORT=OFF"/>
                   <arg value="-DLIBCUDF_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DUSE_GDS=${USE_GDS}" />

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -44,7 +44,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "e64c3635e89e6792b169cdf657339f34921a603d",
+      "git_tag" : "dc536af29ccc60938b82fd8d3bd780873fcc8997",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "version" : "24.12"
     },


### PR DESCRIPTION
Fixes #2475.  Disables kvikio's remote I/O feature to avoid adding openssl dependencies to the build.  kvikio is not currently used by the RAPIDS Accelerator.