### PR TITLE
Update to latest cudf 24.12 and add cudftestutil_impl dependency to tests

### DIFF
--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -31,7 +31,8 @@ function(ConfigureTest CMAKE_TEST_NAME)
                    INSTALL_RPATH "\$ORIGIN/../../../lib"
     )
     target_link_libraries(${CMAKE_TEST_NAME} GTest::gtest_main GTest::gmock_main cudf::cudf
-                                             cudf::cudftestutil spark_rapids_jni)
+                                             cudf::cudftestutil cudf::cudftestutil_impl
+                                             spark_rapids_jni)
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
     install(
         TARGETS ${CMAKE_TEST_NAME}


### PR DESCRIPTION
Fixes #2503.  rapidsai/cudf#16839 changed the link dependencies for tests that use cudftestutil.