### PR TITLE
Improve `concat_json`

### DIFF
--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -91,7 +91,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
   // Check if the input rows are null, empty (containing only whitespaces), and may also check
   // for invalid JSON strings.
   // This will be returned to the caller to create null mask for the final output.
-  rmm::device_uvector<bool> should_be_nullify(input.size(), stream, mr);
+  rmm::device_uvector<bool> should_be_nullified(input.size(), stream, mr);
 
   thrust::for_each(
     rmm::exec_policy_nosync(stream),
@@ -100,7 +100,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
     [nullify_invalid_rows,
      input  = *d_input_ptr,
      output = thrust::make_zip_iterator(thrust::make_tuple(
-       is_valid_input.begin(), should_be_nullify.begin()))] __device__(int64_t tidx) {
+       is_valid_input.begin(), should_be_nullified.begin()))] __device__(int64_t tidx) {
       // Execute one warp per row to minimize thread divergence.
       if ((tidx % cudf::detail::warp_size) != 0) { return; }
       auto const idx = tidx / cudf::detail::warp_size;
@@ -212,7 +212,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
 
   return {std::move(concat_strings->release().data),
           delimiter,
-          std::make_unique<cudf::column>(std::move(should_be_nullify), rmm::device_buffer{}, 0)};
+          std::make_unique<cudf::column>(std::move(should_be_nullified), rmm::device_buffer{}, 0)};
 }
 
 std::unique_ptr<cudf::column> make_structs(std::vector<cudf::column_view> const& children,

--- a/src/main/cpp/src/json_utils.hpp
+++ b/src/main/cpp/src/json_utils.hpp
@@ -32,14 +32,35 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
-std::tuple<std::unique_ptr<cudf::column>, std::unique_ptr<rmm::device_buffer>, char> concat_json(
-  cudf::strings_column_view const& input,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
-
 std::unique_ptr<cudf::column> make_structs(
   std::vector<cudf::column_view> const& input,
   cudf::column_view const& is_null,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Concatenate the JSON objects given by a strings column into one single character buffer,
+ * in which each JSON objects is delimited by a special character that does not exist in the input.
+ *
+ * Beyond returning the concatenated buffer with delimiter, the function also returns a BOOL8
+ * column indicating which rows should be nullified after parsing the concatenated buffer. Each
+ * row of this column is a `true` value if the corresponding input row is either empty, containing
+ * only whitespaces, or invalid JSON object depending on the `nullify_invalid_rows` parameter.
+ *
+ * Note that an invalid JSON object in this context is a string that does not start with the `{`
+ * character after whitespaces.
+ *
+ * @param input The strings column containing input JSON objects
+ * @param nullify_invalid_rows Whether to nullify rows containing invalid JSON objects
+ * @param stream The CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate device memory of the table in the returned
+ * @return A tuple containing the concatenated JSON objects as a single buffer, the delimiter
+ *         character, and a BOOL8 column indicating which rows should be nullified after parsing
+ *         the concatenated buffer
+ */
+std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::column>> concat_json(
+  cudf::strings_column_view const& input,
+  bool nullify_invalid_rows         = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 


### PR DESCRIPTION
This PR improves `concat_json` in `json_utils.*`:
 * Remove some redundant code, and
 * Adds a boolean parameter `nullify_invalid_rows` to `concat_json`, allowing to control whether we should mark the input rows containing invalid JSON objects as "to be nullified" after parsing the input JSON strings.

The added parameter is to facilitate different behaviors of parsing JSON with varying types of schema. In particular, Spark's `from_json` will produce different null rows when specifying schema as map vs struct types:
```
scala> val df = Seq("{'teacher': 'abc', 'student': 'abc'}", "invalid", "null", "", "  ").toDF
df: org.apache.spark.sql.DataFrame = [value: string]

scala> df.show(false)
+------------------------------------+
|value                               |
+------------------------------------+
|{'teacher': 'abc', 'student': 'abc'}|
|invalid                             |
|null                                |
|                                    |
|                                    |
+------------------------------------+


scala> df.selectExpr("from_json(value, 'map<string,string>')").show(false)
+--------------------------------+
|entries                         |
+--------------------------------+
|{teacher -> abc, student -> abc}|
|null                            |
|null                            |
|null                            |
|null                            |
+--------------------------------+


scala> df.selectExpr("from_json(value, 'struct<teacher:string, student:string>')").show(false)
+----------------+
|from_json(value)|
+----------------+
|{abc, abc}      |
|{null, null}    |
|{null, null}    |
|null            |
|null            |
+----------------+
```