### PR TITLE
Prepare the arg to disable kvikIO remote IO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@
                   <arg value="-DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${CUDF_USE_PER_THREAD_DEFAULT_STREAM}" />
                   <arg value="-DCUDF_LARGE_STRINGS_DISABLED=ON"/>
                   <arg value="-DKvikIO_REMOTE_SUPPORT=OFF"/>
+                  <arg value="-DCUDF_KVIKIO_REMOTE_IO=OFF"/>
                   <arg value="-DLIBCUDF_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DUSE_GDS=${USE_GDS}" />


### PR DESCRIPTION
part of https://github.com/NVIDIA/spark-rapids-jni/issues/2581

prepare the arg to help the submodule sync pipeline work correctly after https://github.com/rapidsai/cudf/pull/17291 