### PR TITLE
[POST cleanup] Remove the kvikIO workaround KvikIO_REMOTE_SUPPORT=OFF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,6 @@
                   <arg value="-DCUDF_USE_ARROW_STATIC=ON"/>
                   <arg value="-DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${CUDF_USE_PER_THREAD_DEFAULT_STREAM}" />
                   <arg value="-DCUDF_LARGE_STRINGS_DISABLED=ON"/>
-                  <arg value="-DKvikIO_REMOTE_SUPPORT=OFF"/>
                   <arg value="-DCUDF_KVIKIO_REMOTE_IO=OFF"/>
                   <arg value="-DLIBCUDF_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />
                   <arg value="-DRMM_LOGGING_LEVEL=${RMM_LOGGING_LEVEL}" />


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids-jni/issues/2581 and https://github.com/NVIDIA/spark-rapids-jni/issues/2580

remove `-DKvikIO_REMOTE_SUPPORT=OFF` after https://github.com/rapidsai/cudf/pull/17291 is synced by submodule CI
