### PR TITLE
Copyright header check [skip ci]

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -37,9 +37,8 @@ jobs:
             *.scala,
             *.py,
             *.sh,
-            */Dockerfile*,
-            */Jenkinsfile*,
+            *Dockerfile*,
+            *Jenkinsfile*,
             *.yml
           excluded_file_patterns: |
-            *target/*
-            *patches/*
+            patches/*

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -42,4 +42,7 @@ jobs:
             *Jenkinsfile*,
             *.yml,
             *.yaml,
-            *.txt
+            *.txt,
+            *.xml,
+            *.fbs,
+            build/*

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -41,5 +41,5 @@ jobs:
             */Jenkinsfile*,
             *.yml
           excluded_file_patterns: |
-            */target/*
-            */patches/*
+            *target/*
+            *patches/*

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -1,0 +1,44 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow to check copyright/license header
+name: license header check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  license-header-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
+
+      - name: license-header-check
+        uses: YanxuanLiu/spark-rapids-common/license-header-check@license-header-check
+        with:
+          included_file_patterns: |
+            *.cpp,
+            *.java,
+            *.scala,
+            *.py,
+            *.sh,
+            */Dockerfile*,
+            */Jenkinsfile*,
+            *.yml
+          excluded_file_patterns: |
+            */target/*

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 5
 
       - name: license-header-check
-        uses: NVIDIA/spark-rapids-common/license-header-check@main
+        uses: YanxuanLiu/spark-rapids-common/license-header-check@license-check
         with:
           included_file_patterns: |
             *.cpp,

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -33,12 +33,13 @@ jobs:
         with:
           included_file_patterns: |
             *.cpp,
+            *.hpp,
+            *.cu,
+            *.cuh,
             *.java,
-            *.scala,
-            *.py,
             *.sh,
             *Dockerfile*,
             *Jenkinsfile*,
-            *.yml
-          excluded_file_patterns: |
-            patches/*
+            *.yml,
+            *.yaml,
+            *.txt

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 5
 
       - name: license-header-check
-        uses: YanxuanLiu/spark-rapids-common/license-header-check@license-check
+        uses: NVIDIA/spark-rapids-common/license-header-check@main
         with:
           included_file_patterns: |
             *.cpp,

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 5
 
       - name: license-header-check
-        uses: YanxuanLiu/spark-rapids-common/license-header-check@license-header-check
+        uses: YanxuanLiu/spark-rapids-common/license-header-check@license-check
         with:
           included_file_patterns: |
             *.cpp,

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -42,3 +42,4 @@ jobs:
             *.yml
           excluded_file_patterns: |
             */target/*
+            */patches/*


### PR DESCRIPTION
fix #2571
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Add github workflow `license-header-check` to check copyright/license header for files in Pull Request. 

A common action https://github.com/NVIDIA/spark-rapids-common/blob/main/license-header-check/action.yml is used for the check. The action requires an argument `included_file_patterns` for the scale of files to check. Users can also input argument `excluded_file_patterns` to exclude files based on included files. 

If files without copyright header `Copyright (c) .*, NVIDIA CORPORATION.` or with expired date exists, the workflow would return failed. 