### PR TITLE
Remove explicit rmm logger link as it is implicit from libcudf

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -281,8 +281,6 @@ target_link_libraries(
     ${ARROW_LIB}
     ${PARQUET_LIB}
     ${THRIFT_LIB}
-  PUBLIC rmm::rmm
-  PRIVATE $<TARGET_NAME_IF_EXISTS:rmm::rmm_logger_impl>
 )
 rapids_cuda_set_runtime(spark_rapids_jni USE_STATIC ON)
 set_target_properties(spark_rapids_jni PROPERTIES LINK_LANGUAGE "CXX")

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -149,7 +149,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "f9b9f843466b2dcd8872f1707d274ad15be37324",
+      "git_tag" : "d4066fa611c803430c9bc5dbe8e243f89bb9a25c",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "version" : "25.02"
     },


### PR DESCRIPTION
After libcudf fixed their rmm logger link, we need to remove our explicit link to avoid duplicate definition errors.  The rmm logger will be picked up implicitly from libcudf.