### PR TITLE
Expose max nesting depth in hash function to plugin

### DIFF
--- a/src/main/cpp/src/HashJni.cpp
+++ b/src/main/cpp/src/HashJni.cpp
@@ -21,9 +21,9 @@
 
 extern "C" {
 
-JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_Hash_getMaxNestedDepth(JNIEnv* env, jclass)
+JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_Hash_getMaxStackDepth(JNIEnv* env, jclass)
 {
-  return spark_rapids_jni::MAX_NESTED_DEPTH;
+  return spark_rapids_jni::MAX_STACK_DEPTH;
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_murmurHash32(

--- a/src/main/cpp/src/HashJni.cpp
+++ b/src/main/cpp/src/HashJni.cpp
@@ -24,7 +24,6 @@ extern "C" {
 JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_Hash_getMaxNestedDepth(JNIEnv* env, jclass)
 {
   try {
-    cudf::jni::auto_set_device(env);
     return spark_rapids_jni::MAX_NESTED_DEPTH;
   }
   CATCH_STD(env, 0);

--- a/src/main/cpp/src/HashJni.cpp
+++ b/src/main/cpp/src/HashJni.cpp
@@ -21,6 +21,15 @@
 
 extern "C" {
 
+JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_Hash_getMaxNestedDepth(JNIEnv* env, jclass)
+{
+  try {
+    cudf::jni::auto_set_device(env);
+    return spark_rapids_jni::MAX_NESTED_DEPTH;
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_murmurHash32(
   JNIEnv* env, jclass, jint seed, jlongArray column_handles)
 {

--- a/src/main/cpp/src/HashJni.cpp
+++ b/src/main/cpp/src/HashJni.cpp
@@ -23,10 +23,7 @@ extern "C" {
 
 JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_Hash_getMaxNestedDepth(JNIEnv* env, jclass)
 {
-  try {
-    return spark_rapids_jni::MAX_NESTED_DEPTH;
-  }
-  CATCH_STD(env, 0);
+  return spark_rapids_jni::MAX_NESTED_DEPTH;
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_murmurHash32(

--- a/src/main/cpp/src/hash.hpp
+++ b/src/main/cpp/src/hash.hpp
@@ -25,7 +25,7 @@
 namespace spark_rapids_jni {
 
 constexpr int64_t DEFAULT_XXHASH64_SEED = 42;
-constexpr int MAX_NESTED_DEPTH          = 8;
+constexpr int MAX_STACK_DEPTH           = 8;
 
 /**
  * @brief Computes the murmur32 hash value of each row in the input set of columns.

--- a/src/main/cpp/src/hash.hpp
+++ b/src/main/cpp/src/hash.hpp
@@ -25,7 +25,7 @@
 namespace spark_rapids_jni {
 
 constexpr int64_t DEFAULT_XXHASH64_SEED = 42;
-constexpr int MAX_NESTED_DEPTH = 8;
+constexpr int MAX_NESTED_DEPTH          = 8;
 
 /**
  * @brief Computes the murmur32 hash value of each row in the input set of columns.

--- a/src/main/cpp/src/hash.hpp
+++ b/src/main/cpp/src/hash.hpp
@@ -25,6 +25,7 @@
 namespace spark_rapids_jni {
 
 constexpr int64_t DEFAULT_XXHASH64_SEED = 42;
+constexpr int MAX_NESTED_DEPTH = 8;
 
 /**
  * @brief Computes the murmur32 hash value of each row in the input set of columns.

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -15,6 +15,7 @@
  */
 
 #include "hash.cuh"
+#include "hash.hpp"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
@@ -36,8 +37,6 @@ using hive_hash_value_t = int32_t;
 
 constexpr hive_hash_value_t HIVE_HASH_FACTOR = 31;
 constexpr hive_hash_value_t HIVE_INIT_HASH   = 0;
-
-constexpr int MAX_NESTED_DEPTH = 8;
 
 hive_hash_value_t __device__ inline compute_int(int32_t key) { return key; }
 

--- a/src/main/cpp/src/xxhash64.cu
+++ b/src/main/cpp/src/xxhash64.cu
@@ -15,6 +15,7 @@
  */
 
 #include "hash.cuh"
+#include "hash.hpp"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/utilities/algorithm.cuh>
@@ -33,8 +34,6 @@ namespace {
 
 using hash_value_type = int64_t;
 using half_size_type  = int32_t;
-
-constexpr int MAX_NESTED_DEPTH = 8;
 
 constexpr __device__ inline int64_t rotate_bits_left_signed(hash_value_type h, int8_t r)
 {

--- a/src/main/java/com/nvidia/spark/rapids/jni/Hash.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Hash.java
@@ -25,6 +25,8 @@ public class Hash {
   // there doesn't appear to be a useful constant in spark to reference. this could break.
   static final long DEFAULT_XXHASH64_SEED = 42;
 
+  public static final int MAX_NESTED_DEPTH = getMaxNestedDepth();
+
   static {
     NativeDepsLoader.loadNativeDeps();
   }
@@ -100,6 +102,8 @@ public class Hash {
     }
     return new ColumnVector(hiveHash(columnViews));
   }
+
+  private static native int getMaxNestedDepth();
 
   private static native long murmurHash32(int seed, long[] viewHandles) throws CudfException;
   

--- a/src/main/java/com/nvidia/spark/rapids/jni/Hash.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Hash.java
@@ -25,7 +25,7 @@ public class Hash {
   // there doesn't appear to be a useful constant in spark to reference. this could break.
   static final long DEFAULT_XXHASH64_SEED = 42;
 
-  public static final int MAX_NESTED_DEPTH = getMaxNestedDepth();
+  public static final int MAX_STACK_DEPTH = getMaxStackDepth();
 
   static {
     NativeDepsLoader.loadNativeDeps();
@@ -102,7 +102,7 @@ public class Hash {
     return new ColumnVector(hiveHash(columnViews));
   }
 
-  private static native int getMaxNestedDepth();
+  private static native int getMaxStackDepth();
 
   private static native long murmurHash32(int seed, long[] viewHandles) throws CudfException;
   


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2681

This PR includes the following changes:

1. Moved the definition of `MAX_NESTED_DEPTH` from the specific hash function to `hash.hpp`.
2. Exposed the value of this parameter to plugin.