### PR TITLE
Rename variable `MAX_NESTED_DEPTH` to `MAX_STACK_DEPTH`

### DIFF
--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -37,7 +37,7 @@ using hive_hash_value_t = int32_t;
 constexpr hive_hash_value_t HIVE_HASH_FACTOR = 31;
 constexpr hive_hash_value_t HIVE_INIT_HASH   = 0;
 
-constexpr int MAX_NESTED_DEPTH = 8;
+constexpr int MAX_STACK_DEPTH = 8;
 
 hive_hash_value_t __device__ inline compute_int(int32_t key) { return key; }
 
@@ -368,7 +368,7 @@ class hive_device_row_hasher {
       // The default constructor of `col_stack_frame` is deleted, so it can not allocate an array
       // of `col_stack_frame` directly.
       // Instead leverage the byte array to create the col_stack_frame array.
-      alignas(col_stack_frame) char stack_wrapper[sizeof(col_stack_frame) * MAX_NESTED_DEPTH];
+      alignas(col_stack_frame) char stack_wrapper[sizeof(col_stack_frame) * MAX_STACK_DEPTH];
       auto col_stack = reinterpret_cast<col_stack_frame*>(stack_wrapper);
       int stack_size = 0;
 
@@ -462,11 +462,11 @@ void check_nested_depth(cudf::table_view const& input)
 
   for (auto i = 0; i < input.num_columns(); i++) {
     cudf::column_view const& col = input.column(i);
-    CUDF_EXPECTS(get_nested_depth(col) <= MAX_NESTED_DEPTH,
+    CUDF_EXPECTS(get_nested_depth(col) <= MAX_STACK_DEPTH,
                  "The " + std::to_string(i) +
                    "-th column exceeds the maximum allowed nested depth. " +
                    "Current depth: " + std::to_string(get_nested_depth(col)) + ", " +
-                   "Maximum allowed depth: " + std::to_string(MAX_NESTED_DEPTH));
+                   "Maximum allowed depth: " + std::to_string(MAX_STACK_DEPTH));
   }
 }
 

--- a/src/main/cpp/src/xxhash64.cu
+++ b/src/main/cpp/src/xxhash64.cu
@@ -34,7 +34,7 @@ namespace {
 using hash_value_type = int64_t;
 using half_size_type  = int32_t;
 
-constexpr int MAX_NESTED_DEPTH = 8;
+constexpr int MAX_STACK_DEPTH = 8;
 
 constexpr __device__ inline int64_t rotate_bits_left_signed(hash_value_type h, int8_t r)
 {
@@ -451,7 +451,7 @@ class device_row_hasher {
       // The default constructor of `col_stack_frame` is deleted, so it can not allocate an array
       // of `col_stack_frame` directly.
       // Instead leverage the byte array to create the col_stack_frame array.
-      alignas(col_stack_frame) char stack_wrapper[sizeof(col_stack_frame) * MAX_NESTED_DEPTH];
+      alignas(col_stack_frame) char stack_wrapper[sizeof(col_stack_frame) * MAX_STACK_DEPTH];
       auto col_stack = reinterpret_cast<col_stack_frame*>(stack_wrapper);
       int stack_size = 0;
 
@@ -535,11 +535,11 @@ void check_nested_depth(cudf::table_view const& input)
 
   for (auto i = 0; i < input.num_columns(); i++) {
     cudf::column_view const& col = input.column(i);
-    CUDF_EXPECTS(get_nested_depth(col) <= MAX_NESTED_DEPTH,
+    CUDF_EXPECTS(get_nested_depth(col) <= MAX_STACK_DEPTH,
                  "The " + std::to_string(i) +
                    "-th column exceeds the maximum allowed nested depth. " +
                    "Current depth: " + std::to_string(get_nested_depth(col)) + ", " +
-                   "Maximum allowed depth: " + std::to_string(MAX_NESTED_DEPTH));
+                   "Maximum allowed depth: " + std::to_string(MAX_STACK_DEPTH));
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
### Description

This PR updates the constant `MAX_NESTED_DEPTH` to `MAX_STACK_DEPTH` to better reflect the current implementation. With recent performance improvements aimed at saving stack depth, it is more appropriate to rename it to `MAX_STACK_DEPTH`.

### Changes Made

- Renamed `MAX_NESTED_DEPTH` to `MAX_STACK_DEPTH`.