### PR TITLE
Update submodule sync to run buildcpp target [skip ci]

### DIFF
--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -75,7 +75,7 @@ set +e
 # Don't do a full build. Just try to update/build CUDF with no patches on top of it.
 # calling the antrun directly skips applying patches and also only builds
 # libcudf
-${MVN} antrun:run@build-libcudf ${MVN_MIRROR} \
+${MVN} antrun:run@buildcpp ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -Dlibcudf.dependency.mode=latest \


### PR DESCRIPTION
context at https://github.com/NVIDIA/spark-rapids-jni/issues/2678#issuecomment-2537708045

follow up of https://github.com/NVIDIA/spark-rapids-jni/pull/2677

verified in the internal run