### PR TITLE
Fix UnsatisfiedLinkError in some rare cases

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/Hash.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Hash.java
@@ -22,14 +22,14 @@ import ai.rapids.cudf.CudfException;
 import ai.rapids.cudf.NativeDepsLoader;
 
 public class Hash {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
   // there doesn't appear to be a useful constant in spark to reference. this could break.
   static final long DEFAULT_XXHASH64_SEED = 42;
 
   public static final int MAX_STACK_DEPTH = getMaxStackDepth();
-
-  static {
-    NativeDepsLoader.loadNativeDeps();
-  }
 
   /**
    * Create a new vector containing spark's 32-bit murmur3 hash of each row in the table.


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids-jni/issues/2699

## why this issue occurs
The original code is:
``` java
public class Hash {
  public static final int MAX_STACK_DEPTH = getMaxStackDepth();

  static {
    NativeDepsLoader.loadNativeDeps();
  }

  private static native int getMaxStackDepth();
}
```
The JVM will first execute:
```java
public static final int MAX_STACK_DEPTH = getMaxStackDepth();
```
then:
```java
  static {
    NativeDepsLoader.loadNativeDeps();
  }
```
`getMaxStackDepth` is a native function which is in the JNI so file.
If do not load native so first, the `getMaxStackDepth` can not be used and it reports: `UnsatisfiedLinkError`

## why this issue do not occur in most cases
If other classes already loaded the JNI so file, then it does not report this error.
e.g.:
```java
JSONUtils.MAX_PATH_DEPTH
Hash.MAX_STACK_DEPTH
```
The above call seq will not report error, becasue `JSONUtils.MAX_PATH_DEPTH` will trigger loading JNI so file.

## fix
Load the JNI so file first in `Hash`

Signed-off-by: Chong Gao <res_life@163.com>