### PR TITLE
Optimize `Hive hash` computation for nested types

### DIFF
--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/src/main/cpp/benchmarks/CMakeLists.txt
@@ -81,5 +81,8 @@ ConfigureBench(BLOOM_FILTER_BENCH
 ConfigureBench(GET_JSON_OBJECT_BENCH
   get_json_object.cu)
 
+ConfigureBench(HASH_BENCH
+  hash.cu)
+
 ConfigureBench(PARSE_URI_BENCH
   parse_uri.cpp)

--- a/src/main/cpp/benchmarks/hash.cu
+++ b/src/main/cpp/benchmarks/hash.cu
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmarks/common/generate_input.hpp>
+
+#include <cudf_test/column_utilities.hpp>
+#include <cudf/io/types.hpp>
+#include <hash.hpp>
+#include <nvbench/nvbench.cuh>
+
+constexpr auto min_width  = 10;
+constexpr auto max_width  = 10;
+
+static void xxhash64(nvbench::state& state)
+{
+  std::size_t const size_bytes = static_cast<cudf::size_type>(state.get_int64("size_bytes"));
+  //cudf::size_type const list_depth = static_cast<cudf::size_type>(state.get_int64("list_depth"));
+  
+  data_profile const table_profile =
+    data_profile_builder()
+      .no_validity()
+      //.distribution(cudf::type_id::LIST, distribution_id::NORMAL, min_width, max_width)
+      //.list_depth(list_depth)
+      //.list_type(cudf::type_id::INT32);
+      .struct_types(std::vector<cudf::type_id>{cudf::type_id::BOOL8, cudf::type_id::INT32, cudf::type_id::FLOAT32});
+
+  auto const input_table = create_random_table(
+    std::vector<cudf::type_id>{cudf::type_id::STRUCT},
+    table_size_bytes{size_bytes},
+    table_profile);
+
+  auto const stream = cudf::get_default_stream();
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
+  state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch, auto& timer) {
+               timer.start();
+               auto const output = spark_rapids_jni::hive_hash(*input_table);
+               stream.synchronize();
+               timer.stop();
+             });
+
+  auto const time            = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+  state.add_global_memory_reads<nvbench::int8_t>(size_bytes);
+}
+
+NVBENCH_BENCH(xxhash64)
+  .set_name("hash")
+  .add_int64_axis("size_bytes", {50'000'000, 100'000'000, 250'000'000,500'000'000, 1'000'000'000}); // 50MB, 100MB, 250MB, 500MB, 1GB
+  //.add_int64_axis("list_depth", {1, 2, 4});

--- a/src/main/cpp/benchmarks/hash.cu
+++ b/src/main/cpp/benchmarks/hash.cu
@@ -56,7 +56,7 @@ static void xxhash64(nvbench::state& state)
   state.add_global_memory_reads<nvbench::int8_t>(size_bytes);
 }
 
-NVBENCH_BENCH(xxhash64)
+NVBENCH_BENCH(hash)
   .set_name("hash")
   .add_int64_axis("size_bytes", {50'000'000, 100'000'000, 250'000'000,500'000'000, 1'000'000'000}); // 50MB, 100MB, 250MB, 500MB, 1GB
   //.add_int64_axis("list_depth", {1, 2, 4});

--- a/src/main/cpp/benchmarks/hash.cu
+++ b/src/main/cpp/benchmarks/hash.cu
@@ -63,7 +63,6 @@ static void hash(nvbench::state& state)
                timer.stop();
              });
 
-  auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
   state.add_global_memory_reads<nvbench::int8_t>(size_bytes);
 }
 

--- a/src/main/cpp/benchmarks/hash.cu
+++ b/src/main/cpp/benchmarks/hash.cu
@@ -17,30 +17,31 @@
 #include <benchmarks/common/generate_input.hpp>
 
 #include <cudf_test/column_utilities.hpp>
+
 #include <cudf/io/types.hpp>
+
 #include <hash.hpp>
 #include <nvbench/nvbench.cuh>
 
-constexpr auto min_width  = 10;
-constexpr auto max_width  = 10;
+constexpr auto min_width = 10;
+constexpr auto max_width = 10;
 
-static void xxhash64(nvbench::state& state)
+static void hash(nvbench::state& state)
 {
   std::size_t const size_bytes = static_cast<cudf::size_type>(state.get_int64("size_bytes"));
-  //cudf::size_type const list_depth = static_cast<cudf::size_type>(state.get_int64("list_depth"));
-  
+  // cudf::size_type const list_depth = static_cast<cudf::size_type>(state.get_int64("list_depth"));
+
   data_profile const table_profile =
     data_profile_builder()
       .no_validity()
       //.distribution(cudf::type_id::LIST, distribution_id::NORMAL, min_width, max_width)
       //.list_depth(list_depth)
       //.list_type(cudf::type_id::INT32);
-      .struct_types(std::vector<cudf::type_id>{cudf::type_id::BOOL8, cudf::type_id::INT32, cudf::type_id::FLOAT32});
+      .struct_types(std::vector<cudf::type_id>{
+        cudf::type_id::BOOL8, cudf::type_id::INT32, cudf::type_id::FLOAT32});
 
   auto const input_table = create_random_table(
-    std::vector<cudf::type_id>{cudf::type_id::STRUCT},
-    table_size_bytes{size_bytes},
-    table_profile);
+    std::vector<cudf::type_id>{cudf::type_id::STRUCT}, table_size_bytes{size_bytes}, table_profile);
 
   auto const stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
@@ -52,11 +53,15 @@ static void xxhash64(nvbench::state& state)
                timer.stop();
              });
 
-  auto const time            = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+  auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
   state.add_global_memory_reads<nvbench::int8_t>(size_bytes);
 }
 
-NVBENCH_BENCH(hash)
-  .set_name("hash")
-  .add_int64_axis("size_bytes", {50'000'000, 100'000'000, 250'000'000,500'000'000, 1'000'000'000}); // 50MB, 100MB, 250MB, 500MB, 1GB
-  //.add_int64_axis("list_depth", {1, 2, 4});
+NVBENCH_BENCH(hash).set_name("hash").add_int64_axis(
+  "size_bytes",
+  {50'000'000,
+   100'000'000,
+   250'000'000,
+   500'000'000,
+   1'000'000'000});  // 50MB, 100MB, 250MB, 500MB, 1GB
+//.add_int64_axis("list_depth", {1, 2, 4});

--- a/src/main/cpp/benchmarks/hash.cu
+++ b/src/main/cpp/benchmarks/hash.cu
@@ -60,7 +60,6 @@ static void hash(nvbench::state& state)
                timer.start();
                // `hive_hash` can be substituted with other hash functions
                spark_rapids_jni::hive_hash(*input_table);
-               stream.synchronize();
                timer.stop();
              });
 

--- a/src/main/cpp/benchmarks/hash.cu
+++ b/src/main/cpp/benchmarks/hash.cu
@@ -55,14 +55,10 @@ static void hash(nvbench::state& state)
 
   auto const stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  state.exec(nvbench::exec_tag::timer | nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch, auto& timer) {
-               timer.start();
-               // `hive_hash` can be substituted with other hash functions
-               spark_rapids_jni::hive_hash(*input_table);
-               timer.stop();
-             });
-
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    // `hive_hash` can be substituted with other hash functions
+    spark_rapids_jni::hive_hash(*input_table);
+  });
   state.add_global_memory_reads<nvbench::int8_t>(size_bytes);
 }
 

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -542,7 +542,7 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
     if (root_col.type().id() == cudf::type_id::LIST ||
         root_col.type().id() == cudf::type_id::STRUCT) {
       // Construct the `flattened_column_views` by level order traversal
-      nested_column_map.push_back(flattened_column_views.size());
+      nested_column_map.push_back(static_cast<cudf::size_type>(flattened_column_views.size()));
       flattened_column_views.push_back(root_col);
       // flattened_column_views[idx] is the next column to process
       for (auto idx = nested_column_map.back();

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -550,7 +550,7 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
            idx++) {
         auto const col = flattened_column_views[idx];
         if (col.type().id() == cudf::type_id::LIST) {
-          first_child_index.push_back(flattened_column_views.size());
+          first_child_index.push_back(static_cast<cudf::size_type>(flattened_column_views.size()));
           flattened_column_views.push_back(cudf::lists_column_view(col).offsets());
           flattened_column_views.push_back(cudf::lists_column_view(col).get_sliced_child(stream));
         } else if (col.type().id() == cudf::type_id::STRUCT) {

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -191,13 +191,7 @@ class hive_device_row_hasher {
       _table.end(),
       HIVE_INIT_HASH,
       cuda::proclaim_return_type<hive_hash_value_t>(
-        [row_index,
-         nulls                  = _check_nulls,
-         table                  = _table,
-         flattened_column_views = _flattened_column_views,
-         first_child_index      = _first_child_index,
-         nested_column_map      = _nested_column_map] __device__(auto hash, auto const& column) {
-          auto col_idx  = &column - table.begin();
+        [=] __device__(auto const hash, auto const col_idx) {
           auto cur_hash = cudf::type_dispatcher(
             column.type(),
             element_hasher_adapter{

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -554,7 +554,7 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
           flattened_column_views.push_back(cudf::lists_column_view(col).offsets());
           flattened_column_views.push_back(cudf::lists_column_view(col).get_sliced_child(stream));
         } else if (col.type().id() == cudf::type_id::STRUCT) {
-          first_child_index.push_back(flattened_column_views.size());
+          first_child_index.push_back(static_cast<cudf::size_type>(flattened_column_views.size()));
           for (auto child_idx = 0; child_idx < col.num_children(); child_idx++) {
             flattened_column_views.push_back(
               cudf::structs_column_view(col).get_sliced_child(child_idx, stream));

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -448,6 +448,8 @@ class hive_device_row_hasher {
               if (child_info.upper_bound_idx_or_basic_col_idx > child_idx_begin) {
                 col_stack[stack_size++].init(
                   child_col_idx, curr_row_idx, child_idx_begin, child_info);
+              } else {
+                top.update_cur_hash(HIVE_INIT_HASH);
               }
               break;
             }
@@ -499,6 +501,8 @@ class hive_device_row_hasher {
             if (child_info.upper_bound_idx_or_basic_col_idx > child_idx_begin) {
               col_stack[stack_size++].init(
                 child_col_idx, top.get_idx_to_process(), child_idx_begin, child_info);
+            } else {
+              top.update_cur_hash(HIVE_INIT_HASH);
             }
             top.get_and_inc_idx_to_process();
           }

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -569,10 +569,10 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
   [[maybe_unused]] auto [device_view_owners, flattened_column_device_views] =
     cudf::contiguous_copy_column_device_views<cudf::column_device_view>(flattened_column_views,
                                                                         stream);
-  auto first_child_index_view =
-    cudf::detail::make_device_uvector_async(first_child_index, stream, cudf::get_current_device_resource_ref());
-  auto nested_column_map_view =
-    cudf::detail::make_device_uvector_async(nested_column_map, stream, cudf::get_current_device_resource_ref());
+  auto first_child_index_view = cudf::detail::make_device_uvector_async(
+    first_child_index, stream, cudf::get_current_device_resource_ref());
+  auto nested_column_map_view = cudf::detail::make_device_uvector_async(
+    nested_column_map, stream, cudf::get_current_device_resource_ref());
 
   bool const nullable   = has_nested_nulls(input);
   auto const input_view = cudf::table_device_view::create(input, stream);

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -204,7 +204,8 @@ class hive_device_row_hasher {
           auto const col_hash =
             (col_info.type_id == cudf::type_id::LIST || col_info.type_id == cudf::type_id::STRUCT)
               ? hash_adapter.hash_nested(col_index, row_index)
-              : cudf::type_dispatcher(cudf::data_type{col_info.type_id},
+              : cudf::type_dispatcher<cudf::experimental::dispatch_void_if_nested>(
+                  cudf::data_type{col_info.type_id},
                                       hash_adapter,
                                       _basic_cdvs[col_info.nested_num_children_or_basic_col_idx],
                                       row_index);

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -234,13 +234,6 @@ class hive_device_row_hasher {
       return this->hash_functor.template operator()<T>(col, row_index);
     }
 
-    template <typename T, CUDF_ENABLE_IF(cudf::is_nested<T>())>
-    __device__ hive_hash_value_t operator()(cudf::column_device_view const&,
-                                            cudf::size_type) const noexcept
-    {
-      CUDF_UNREACHABLE("Invalid execution path for nested types.");
-    }
-
     /**
      * @brief A structure to keep track of the computation for nested types.
      */

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -241,7 +241,7 @@ class hive_device_row_hasher {
      */
     struct col_stack_frame {
      private:
-      cudf::size_type _col_idx;     // the column has only one row
+      cudf::size_type _col_idx;     // the column index in the flattened array
       cudf::size_type _row_idx;     // the index of the row in the column
       int _idx_to_process;          // the index of child or element to process next
       hive_hash_value_t _cur_hash;  // current hash value of the column

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -166,7 +166,7 @@ class hive_device_row_hasher {
                                           cudf::table_device_view t,
                                           cudf::column_device_view* flattened_column_views,
                                           cudf::size_type* first_child_index,
-                                          cudf::size_type* nested_column_map)
+                                          cudf::size_type* nested_column_map) noexcept
     : _check_nulls{check_nulls},
       _table{t},
       _flattened_column_views{flattened_column_views},

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -158,7 +158,7 @@ struct col_info {
   // Column type id.
   cudf::type_id type_id;
 
-  // Store the the upper bound of number of elements for lists column, or the upper bound of
+  // Store the upper bound of number of elements for lists column, or the upper bound of
   // number of children for structs column, or column index in `basic_cdvs` for basic types.
   cudf::size_type upper_bound_idx_or_basic_col_idx;
 };

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -206,9 +206,9 @@ class hive_device_row_hasher {
               ? hash_adapter.hash_nested(col_index, row_index)
               : cudf::type_dispatcher<cudf::experimental::dispatch_void_if_nested>(
                   cudf::data_type{col_info.type_id},
-                                      hash_adapter,
-                                      _basic_cdvs[col_info.nested_num_children_or_basic_col_idx],
-                                      row_index);
+                  hash_adapter,
+                  _basic_cdvs[col_info.nested_num_children_or_basic_col_idx],
+                  row_index);
           return HIVE_HASH_FACTOR * hash + col_hash;
         }));
   }

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -538,8 +538,7 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
   // `input` to the index in `flattened_column_views`
   std::vector<cudf::size_type> nested_column_map;
 
-  for (auto i = 0; i < input.num_columns(); i++) {
-    auto const& root_col = input.column(i);
+  for (auto const& root_col : input) {
     if (root_col.type().id() == cudf::type_id::LIST ||
         root_col.type().id() == cudf::type_id::STRUCT) {
       // Construct the `flattened_column_views` by level order traversal

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -386,7 +386,7 @@ class hive_device_row_hasher {
      * @note This function is only enabled for nested column types.
      */
     template <typename T, CUDF_ENABLE_IF(cudf::is_nested<T>())>
-    __device__ hive_hash_value_t operator()(cudf::column_device_view const& col,
+    __device__ hive_hash_value_t operator()(cudf::column_device_view const&,
                                             cudf::size_type row_index) const noexcept
     {
       auto curr_col_idx = _nested_column_map[_col_idx];

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -192,11 +192,11 @@ class hive_device_row_hasher {
       HIVE_INIT_HASH,
       cuda::proclaim_return_type<hive_hash_value_t>(
         [row_index,
-         nulls                  = this->_check_nulls,
-         table                  = this->_table,
-         flattened_column_views = this->_flattened_column_views,
-         first_child_index      = this->_first_child_index,
-         nested_column_map = this->_nested_column_map] __device__(auto hash, auto const& column) {
+         nulls                  = _check_nulls,
+         table                  = _table,
+         flattened_column_views = _flattened_column_views,
+         first_child_index      = _first_child_index,
+         nested_column_map      = _nested_column_map] __device__(auto hash, auto const& column) {
           cudf::size_type col_idx = &column - table.begin();
           auto cur_hash           = cudf::type_dispatcher(
             column.type(),
@@ -250,7 +250,7 @@ class hive_device_row_hasher {
       __device__ col_stack_frame() = default;
 
       __device__ col_stack_frame(cudf::size_type col_idx, cudf::size_type row_idx)
-        : _col_idx(col_idx), _row_idx(row_idx), _cur_hash(HIVE_INIT_HASH), _idx_to_process(0)
+        : _col_idx(col_idx), _row_idx(row_idx), _idx_to_process(0), _cur_hash(HIVE_INIT_HASH)
       {
       }
 
@@ -392,8 +392,8 @@ class hive_device_row_hasher {
     __device__ hive_hash_value_t operator()(cudf::column_device_view const& col,
                                             cudf::size_type row_index) const noexcept
     {
-      cudf::size_type curr_col_idx = _nested_column_map[this->_col_idx];
-      cudf::size_type curr_row_idx = row_index;
+      auto curr_col_idx = _nested_column_map[_col_idx];
+      auto curr_row_idx = row_index;
 
       col_stack_frame col_stack[MAX_STACK_DEPTH];
       int stack_size          = 0;

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -580,7 +580,7 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
   stream.synchronize();
 
   // Compute the hash value for each row
-  thrust::tabulate(rmm::exec_policy(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream),
                    output_view.begin<hive_hash_value_t>(),
                    output_view.end<hive_hash_value_t>(),
                    hive_device_row_hasher<hive_hash_function, bool>(nullable,

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -591,7 +591,8 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
                                                                     first_child_index_view.data(),
                                                                     nested_column_map_view.data()));
 
-  // Ensure that the output is ready before returning
+  // Push data from host vectors `first_child_index` and `nested_column_map` to device
+  // before they are destroyed.
   stream.synchronize();
   return output;
 }

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -388,7 +388,6 @@ class hive_device_row_hasher {
      * If the child column is of primitive type, the hash value of the list column can be directly
      * computed.
      *
-     * @tparam T The type of the column
      * @param col_index The index of the column in the original input table
      * @param row_index The index of the row to compute the hash for
      * @return The computed hive hash value

--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -534,14 +534,15 @@ std::unique_ptr<cudf::column> hive_hash(cudf::table_view const& input,
            idx++) {
         auto const col = flattened_column_views[idx];
         if (col.type().id() == cudf::type_id::LIST) {
+          auto const list_col = cudf::lists_column_view(col);
           first_child_index.push_back(static_cast<cudf::size_type>(flattened_column_views.size()));
-          flattened_column_views.push_back(cudf::lists_column_view(col).offsets());
-          flattened_column_views.push_back(cudf::lists_column_view(col).get_sliced_child(stream));
+          flattened_column_views.push_back(list_col.offsets());
+          flattened_column_views.push_back(list_col.get_sliced_child(stream));
         } else if (col.type().id() == cudf::type_id::STRUCT) {
+          auto const struct_col = cudf::structs_column_view(col);
           first_child_index.push_back(static_cast<cudf::size_type>(flattened_column_views.size()));
           for (auto child_idx = 0; child_idx < col.num_children(); child_idx++) {
-            flattened_column_views.push_back(
-              cudf::structs_column_view(col).get_sliced_child(child_idx, stream));
+            flattened_column_views.push_back(struct_col.get_sliced_child(child_idx, stream));
           }
         } else {
           first_child_index.push_back(-1);

--- a/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
@@ -847,6 +847,25 @@ public class HashTest {
   }
 
   @Test
+  void testHiveHashCornerCases() {
+    try (ColumnVector emptyListCV = ColumnVector.fromLists(
+             new ListType(true, new BasicType(true, DType.INT32)),
+             Collections.emptyList());
+         ColumnVector int1 = ColumnVector.fromBoxedInts(1);
+         ColumnVector int2 = ColumnVector.fromBoxedInts(2);
+         ColumnView structContainsEmptyList = ColumnView.makeStructView(int1, emptyListCV, int2);
+         ColumnView structContainsNoChild = ColumnVector.makeStructView(1);
+         ColumnView nestedStruct = ColumnView.makeStructView(int1, structContainsNoChild, int2);
+         ColumnVector result1 = Hash.hiveHash(new ColumnView[]{structContainsEmptyList});
+         ColumnVector result2 = Hash.hiveHash(new ColumnView[]{nestedStruct});
+         ColumnVector expected1 = ColumnVector.fromInts(963);
+         ColumnVector expected2 = ColumnVector.fromInts(963)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+    }
+  }
+
+  @Test
   void testHiveHashNestedDepthExceedsLimit() {
     try (ColumnVector nestedIntListCV = ColumnVector.fromLists(
             new ListType(true, new ListType(true, new BasicType(true, DType.INT32))),

--- a/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HashTest.java
@@ -856,12 +856,18 @@ public class HashTest {
          ColumnView structContainsEmptyList = ColumnView.makeStructView(int1, emptyListCV, int2);
          ColumnView structContainsNoChild = ColumnVector.makeStructView(1);
          ColumnView nestedStruct = ColumnView.makeStructView(int1, structContainsNoChild, int2);
+         ColumnVector nestedListCV = ColumnVector.fromLists(
+             new ListType(true, new ListType(true, new BasicType(true, DType.INT32))),
+             Arrays.asList(Collections.singletonList(1), null, Collections.singletonList(2)));
          ColumnVector result1 = Hash.hiveHash(new ColumnView[]{structContainsEmptyList});
          ColumnVector result2 = Hash.hiveHash(new ColumnView[]{nestedStruct});
+         ColumnVector result3 = Hash.hiveHash(new ColumnView[]{nestedListCV});
          ColumnVector expected1 = ColumnVector.fromInts(963);
-         ColumnVector expected2 = ColumnVector.fromInts(963)) {
+         ColumnVector expected2 = ColumnVector.fromInts(963);
+         ColumnVector expected3 = ColumnVector.fromInts(963)) {
       assertColumnsAreEqual(expected1, result1);
       assertColumnsAreEqual(expected2, result2);
+      assertColumnsAreEqual(expected3, result3);
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
# Main Optimization: 
Flatten nested columns in advance, reducing the size of the `stack_frame`.

# Possible Further Optimization: 
- Make various hash functions share the logic for flattening nested types, but `xxhash64` does not require `_cur_hash`, which presents a challenge for unification.

# Benchmark:
1. Environment: NVIDIA TITAN RTX
2. Sizes: 50MB, 100MB, 500MB, 1GB
- schema: `struct`  with a depth of `max_depth`, with the basic type being `INT32`,` FLOAT32` and `STRING`
```
|  size_bytes  |  max_depth  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |          Diff |   %Diff |  Status  |
|--------------|-------------|------------|-------------|------------|-------------|---------------|---------|----------|
|   50000000   |      1      | 609.823 us |      56.37% | 452.706 us |       8.10% |   -157.117 us | -25.76% |   FAST   |
|  100000000   |      1      | 958.429 us |      32.03% | 606.708 us |      66.13% |   -351.722 us | -36.70% |   FAST   |
|  500000000   |      1      |   3.981 ms |      10.85% |   2.091 ms |       1.65% |  -1889.419 us | -47.46% |   FAST   |
|  1000000000  |      1      |   7.716 ms |       5.89% |   3.929 ms |       0.50% |  -3786.579 us | -49.08% |   FAST   |
|   50000000   |      2      |   1.493 ms |       1.52% | 555.161 us |       5.56% |   -937.916 us | -62.82% |   FAST   |
|  100000000   |      2      |   2.760 ms |       0.61% | 892.648 us |       3.01% |  -1867.525 us | -67.66% |   FAST   |
|  500000000   |      2      |  13.026 ms |       0.39% |   3.539 ms |      16.46% |  -9487.762 us | -72.83% |   FAST   |
|  1000000000  |      2      |  25.811 ms |       0.28% |   6.790 ms |       0.59% | -19021.039 us | -73.69% |   FAST   |
|   50000000   |      4      |   2.530 ms |       7.86% |   1.094 ms |       0.66% |  -1436.823 us | -56.78% |   FAST   |
|  100000000   |      4      |   4.850 ms |       5.51% |   1.946 ms |       1.25% |  -2903.567 us | -59.87% |   FAST   |
|  500000000   |      4      |  23.405 ms |       0.13% |   8.761 ms |       0.47% | -14643.401 us | -62.57% |   FAST   |
|  1000000000  |      4      |  46.649 ms |       0.20% |  17.254 ms |       2.64% | -29395.025 us | -63.01% |   FAST   |
|   50000000   |      8      |   4.468 ms |       0.68% |   2.102 ms |       0.53% |  -2366.352 us | -52.96% |   FAST   |
|  100000000   |      8      |   8.731 ms |       0.44% |   3.953 ms |       0.42% |  -4777.431 us | -54.72% |   FAST   |
|  500000000   |      8      |  42.672 ms |       0.08% |  18.808 ms |       0.39% | -23863.937 us | -55.92% |   FAST   |
|  1000000000  |      8      |  85.191 ms |       0.05% |  37.338 ms |       0.30% | -47853.264 us | -56.17% |   FAST   |
```
- schema: `list` with a depth of `max_depth`, with the basic type being `INT32`
```
|  size_bytes  |  max_depth  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |           Diff |   %Diff |  Status  |
|--------------|-------------|------------|-------------|------------|-------------|----------------|---------|----------|
|   50000000   |      1      | 474.191 us |       5.38% | 467.645 us |      36.75% |      -6.546 us |  -1.38% |   SAME   |
|  100000000   |      1      | 682.398 us |      47.04% | 604.959 us |      65.52% |     -77.439 us | -11.35% |   SAME   |
|  500000000   |      1      |   2.523 ms |      10.46% |   2.630 ms |      11.76% |     106.458 us |   4.22% |   SAME   |
|  1000000000  |      1      |   4.800 ms |       0.20% |   3.370 ms |      10.34% |   -1429.947 us | -29.79% |   FAST   |
|   50000000   |      2      | 890.665 us |       1.14% | 867.720 us |       1.51% |     -22.946 us |  -2.58% |   FAST   |
|  100000000   |      2      |   1.858 ms |       0.55% |   1.832 ms |       1.02% |     -25.131 us |  -1.35% |   FAST   |
|  500000000   |      2      |   9.657 ms |       4.41% |   9.763 ms |       0.44% |     105.982 us |   1.10% |   SLOW   |
|  1000000000  |      2      |  19.158 ms |       2.73% |  19.139 ms |       0.26% |     -19.141 us |  -0.10% |   SAME   |
|   50000000   |      4      |   9.557 ms |       0.41% |   8.215 ms |       0.20% |   -1341.963 us | -14.04% |   FAST   |
|  100000000   |      4      |   9.596 ms |       0.20% |   8.235 ms |       0.21% |   -1360.763 us | -14.18% |   FAST   |
|  500000000   |      4      |  10.212 ms |       0.35% |   8.836 ms |       0.36% |   -1375.577 us | -13.47% |   FAST   |
|  1000000000  |      4      |  18.739 ms |       0.80% |  10.990 ms |       0.25% |   -7748.325 us | -41.35% |   FAST   |
|   50000000   |      8      |   3.643 us |      20.58% |   5.008 us |      12.68% |       1.365 us |  37.48% |   SLOW   |
|  100000000   |      8      |   3.612 us |      19.83% |   4.869 us |      13.84% |       1.257 us |  34.80% |   SLOW   |
|  500000000   |      8      |   19.112 s |        inf% |   18.441 s |        inf% | -671019.531 us |  -3.51% |   SAME   |
|  1000000000  |      8      |   19.252 s |        inf% |   18.581 s |        inf% | -670972.656 us |  -3.49% |   SAME   |
```
- schema: `list` with a depth of `max_depth`, with the basic type being `STRING`
```
|  size_bytes  |  max_depth  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |         Diff |   %Diff |  Status  |
|--------------|-------------|------------|-------------|------------|-------------|--------------|---------|----------|
|   50000000   |      1      |   1.225 ms |      34.18% |   1.238 ms |      34.57% |    12.566 us |   1.03% |   SAME   |
|  100000000   |      1      |   2.469 ms |       0.32% |   2.474 ms |       0.32% |     5.280 us |   0.21% |   SAME   |
|  500000000   |      1      |  11.670 ms |       0.13% |  11.631 ms |       0.48% |   -39.053 us |  -0.33% |   FAST   |
|  1000000000  |      1      |  23.225 ms |       0.32% |  23.167 ms |       0.24% |   -57.943 us |  -0.25% |   FAST   |
|   50000000   |      2      | 986.634 us |       0.99% | 959.146 us |       1.21% |   -27.489 us |  -2.79% |   FAST   |
|  100000000   |      2      |   4.743 ms |       0.87% |   4.753 ms |       0.84% |     9.306 us |   0.20% |   SAME   |
|  500000000   |      2      |  35.896 ms |       0.59% |  39.882 ms |       0.34% |     3.986 ms |  11.10% |   SLOW   |
|  1000000000  |      2      |  74.205 ms |       0.29% |  82.584 ms |       0.31% |     8.379 ms |  11.29% |   SLOW   |
|   50000000   |      4      |  33.784 ms |       0.11% |  32.820 ms |       0.10% |  -964.448 us |  -2.85% |   FAST   |
|  100000000   |      4      |  34.308 ms |       0.11% |  33.523 ms |       0.22% |  -784.787 us |  -2.29% |   FAST   |
|  500000000   |      4      |  34.769 ms |       0.22% |  34.006 ms |       0.12% |  -763.420 us |  -2.20% |   FAST   |
|  1000000000  |      4      |  35.852 ms |       0.16% |  34.705 ms |       0.11% | -1147.547 us |  -3.20% |   FAST   |
|   50000000   |      8      |   4.155 us |      18.74% |   4.042 us |      18.08% |    -0.113 us |  -2.72% |   SAME   |
|  100000000   |      8      |   3.960 us |      18.35% |   3.965 us |      19.00% |     0.005 us |   0.12% |   SAME   |
|  500000000   |      8      |   4.157 us |      24.39% |   4.064 us |      17.89% |    -0.092 us |  -2.22% |   SAME   |
|  1000000000  |      8      |   52.247 s |        inf% |   52.920 s |        inf% |   673.637 ms |   1.29% |   SAME   |
```