### PR TITLE
Add CODEOWNERS file with team [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Build-related
+/.github/  @NVIDIA/sparkrapids-cicd-codeowners
+/build/    @NVIDIA/sparkrapids-cicd-codeowners
+/ci/       @NVIDIA/sparkrapids-cicd-codeowners
+/patches/  @NVIDIA/sparkrapids-cicd-codeowners
+pom.xml    @NVIDIA/sparkrapids-cicd-codeowners


### PR DESCRIPTION
Add codeowners file for JNI repo. initialize with dedicated CICD codeowners