### PR TITLE
Update to use vulnerability-scan runner [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ jobs:
   Vulnerability-scan:
     name: Vulnerability scan
     needs: [Authorization]
-    runs-on: ubuntu-latest
+    runs-on: vulnerability-scan
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Required by ProdSec team to enable new malware scan.

note: this change does not enable the malware scan directly but try to change to use the new shared runner within NVIDIA org. 

After merging this change, we will need to ask the Blossom team to enable the actual malware scan internally 