### PR TITLE
Add support for `org.apache.spark.sql.catalyst.expressions.Bin`

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -211,6 +211,7 @@ add_library(
   src/case_when.cu
   src/cast_decimal_to_string.cu
   src/cast_float_to_string.cu
+  src/cast_long_to_binary_string.cu
   src/cast_string.cu
   src/cast_string_to_float.cu
   src/datetime_rebase.cu

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -156,6 +156,21 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal
   CATCH_CAST_EXCEPTION(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromLongToBinary(
+  JNIEnv* env, jclass, jlong input_column)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+
+    auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::long_to_binary_string(cv, cudf::get_default_stream()));
+  }
+  CATCH_CAST_EXCEPTION(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersWithBase(
   JNIEnv* env, jclass, jlong input_column, jint base, jboolean ansi_enabled, jint j_dtype)
 {

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -41,7 +41,7 @@ struct long_to_binary_string_fn {
     auto const value = d_longs.element<int64_t>(idx);
     char* d_buffer   = d_chars + d_offsets[idx];
     for (auto i = d_sizes[idx] - 1; i >= 0; --i) {
-      *d_buffer++ = '0' + ((value & (1LL << i)) >> i);
+      *d_buffer++ = '0' + ((value & (1UL << i)) >> i);
     }
   }
 

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -41,9 +41,7 @@ struct long_to_binary_string_fn {
 
   __device__ cudf::size_type compute_output_size(LongType value)
   {
-    auto const size = 64 - __clzll(value);
-    // If the value is 0, the size should be 1
-    return size > 0 ? size : 1;
+    return max(64 - __clzll(value), 1);  // If the value is 0, the output size should be 1
   }
 
   __device__ void long_to_binary_string(cudf::size_type idx)

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -41,7 +41,7 @@ struct long_to_binary_string_fn {
     auto const value = d_longs.element<int64_t>(idx);
     char* d_buffer   = d_chars + d_offsets[idx];
     for (auto i = d_sizes[idx] - 1; i >= 0; --i) {
-      *d_buffer++ = value & (1LL << i) ? '1' : '0';
+      *d_buffer++ = '0' + ((value & (1LL << i)) >> i);
     }
   }
 

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cast_string.hpp"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/strings/detail/strings_children.cuh>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+namespace spark_rapids_jni {
+
+namespace detail {
+namespace {
+
+template <typename LongType>
+struct long_to_binary_string_fn {
+  cudf::column_device_view d_longs;
+  cudf::size_type* d_sizes;
+  char* d_chars;
+  cudf::detail::input_offsetalator d_offsets;
+
+  __device__ cudf::size_type compute_output_size(LongType value)
+  {
+    auto const size = 64 - __clzll(value);
+    // If the value is 0, the size should be 1
+    return size > 0 ? size : 1;
+  }
+
+  __device__ void long_to_binary_string(cudf::size_type idx)
+  {
+    auto const value = d_longs.element<LongType>(idx);
+    char* d_buffer   = d_chars + d_offsets[idx];
+    for (auto i = d_sizes[idx] - 1; i >= 0; --i) {
+      *d_buffer++ = value & (1LL << i) ? '1' : '0';
+    }
+  }
+
+  __device__ void operator()(cudf::size_type idx)
+  {
+    if (d_longs.is_null(idx)) {
+      if (d_chars == nullptr) { d_sizes[idx] = 0; }
+      return;
+    }
+    if (d_chars != nullptr) {
+      long_to_binary_string(idx);
+    } else {
+      d_sizes[idx] = compute_output_size(d_longs.element<LongType>(idx));
+    }
+  }
+};
+
+struct dispatch_long_to_binary_string_fn {
+  template <typename LongType, CUDF_ENABLE_IF(std::is_same_v<LongType, std::int64_t>)>
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr) const
+  {
+    auto const d_column = cudf::column_device_view::create(input, stream);
+
+    auto [offsets, chars] = cudf::strings::detail::make_strings_children(
+      long_to_binary_string_fn<LongType>{*d_column}, input.size(), stream, mr);
+
+    return cudf::make_strings_column(input.size(),
+                                     std::move(offsets),
+                                     chars.release(),
+                                     input.null_count(),
+                                     cudf::detail::copy_bitmask(input, stream, mr));
+  }
+
+  template <typename LongType, CUDF_ENABLE_IF(not std::is_same_v<LongType, std::int64_t>)>
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
+                                           rmm::cuda_stream_view,
+                                           rmm::device_async_resource_ref) const
+  {
+    CUDF_FAIL("Values for long_to_binary_string function must be a long type.");
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& input,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::device_async_resource_ref mr)
+{
+  if (input.is_empty()) return cudf::make_empty_column(cudf::type_id::STRING);
+  return type_dispatcher(input.type(), dispatch_long_to_binary_string_fn{}, input, stream, mr);
+}
+
+}  // namespace detail
+
+// external API
+std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& input,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::long_to_binary_string(input, stream, mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -22,7 +22,6 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
@@ -31,22 +30,15 @@ namespace spark_rapids_jni {
 
 namespace detail {
 namespace {
-
-template <typename LongType>
 struct long_to_binary_string_fn {
   cudf::column_device_view d_longs;
   cudf::size_type* d_sizes;
   char* d_chars;
   cudf::detail::input_offsetalator d_offsets;
 
-  __device__ cudf::size_type compute_output_size(LongType value)
-  {
-    return max(64 - __clzll(value), 1);  // If the value is 0, the output size should be 1
-  }
-
   __device__ void long_to_binary_string(cudf::size_type idx)
   {
-    auto const value = d_longs.element<LongType>(idx);
+    auto const value = d_longs.element<int64_t>(idx);
     char* d_buffer   = d_chars + d_offsets[idx];
     for (auto i = d_sizes[idx] - 1; i >= 0; --i) {
       *d_buffer++ = value & (1LL << i) ? '1' : '0';
@@ -62,35 +54,9 @@ struct long_to_binary_string_fn {
     if (d_chars != nullptr) {
       long_to_binary_string(idx);
     } else {
-      d_sizes[idx] = compute_output_size(d_longs.element<LongType>(idx));
+      // If the value is 0, the size should be 1
+      d_sizes[idx] = max(1, 64 - __clzll(d_longs.element<int64_t>(idx)));
     }
-  }
-};
-
-struct dispatch_long_to_binary_string_fn {
-  template <typename LongType, CUDF_ENABLE_IF(std::is_same_v<LongType, std::int64_t>)>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
-                                           rmm::cuda_stream_view stream,
-                                           rmm::device_async_resource_ref mr) const
-  {
-    auto const d_column = cudf::column_device_view::create(input, stream);
-
-    auto [offsets, chars] = cudf::strings::detail::make_strings_children(
-      long_to_binary_string_fn<LongType>{*d_column}, input.size(), stream, mr);
-
-    return cudf::make_strings_column(input.size(),
-                                     std::move(offsets),
-                                     chars.release(),
-                                     input.null_count(),
-                                     cudf::detail::copy_bitmask(input, stream, mr));
-  }
-
-  template <typename LongType, CUDF_ENABLE_IF(not std::is_same_v<LongType, std::int64_t>)>
-  std::unique_ptr<cudf::column> operator()(cudf::column_view const&,
-                                           rmm::cuda_stream_view,
-                                           rmm::device_async_resource_ref) const
-  {
-    CUDF_FAIL("Values for long_to_binary_string function must be a long type.");
   }
 };
 
@@ -101,7 +67,19 @@ std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& inp
                                                     rmm::device_async_resource_ref mr)
 {
   if (input.is_empty()) return cudf::make_empty_column(cudf::type_id::STRING);
-  return type_dispatcher(input.type(), dispatch_long_to_binary_string_fn{}, input, stream, mr);
+
+  CUDF_EXPECTS(input.type().id() == cudf::type_id::INT64, "Input column must be long type");
+
+  auto const d_column = cudf::column_device_view::create(input, stream);
+
+  auto [offsets, chars] = cudf::strings::detail::make_strings_children(
+    long_to_binary_string_fn{*d_column}, input.size(), stream, mr);
+
+  return cudf::make_strings_column(input.size(),
+                                   std::move(offsets),
+                                   chars.release(),
+                                   input.null_count(),
+                                   cudf::detail::copy_bitmask(input, stream, mr));
 }
 
 }  // namespace detail

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -133,4 +133,9 @@ std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
+std::unique_ptr<cudf::column> long_to_binary_string(
+  cudf::column_view const& input,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -58,6 +58,9 @@ ConfigureTest(FORMAT_FLOAT
 ConfigureTest(CAST_FLOAT_TO_STRING
     cast_float_to_string.cpp)
 
+ConfigureTest(CAST_LONG_TO_BINARY_STRING
+    cast_long_to_binary_string.cpp)
+
 ConfigureTest(DATETIME_REBASE
     datetime_rebase.cpp)
 

--- a/src/main/cpp/tests/cast_long_to_binary_string.cpp
+++ b/src/main/cpp/tests/cast_long_to_binary_string.cpp
@@ -31,12 +31,18 @@ struct LongToBinaryStringTests : public cudf::test::BaseFixture {};
 
 TEST_F(LongToBinaryStringTests, FromLongToBinary)
 {
-  auto const longs = cudf::test::fixed_width_column_wrapper<int64_t>{0L, 1L, 10L, -0L, -1L};
+  auto const longs = cudf::test::fixed_width_column_wrapper<int64_t>{
+    0L, 1L, 10L, -1L, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::min()};
 
   auto results = spark_rapids_jni::long_to_binary_string(longs, cudf::get_default_stream());
 
   auto const expected = cudf::test::strings_column_wrapper{
-    "0", "1", "1010", "0", "1111111111111111111111111111111111111111111111111111111111111111"};
+    "0",
+    "1",
+    "1010",
+    "1111111111111111111111111111111111111111111111111111111111111111",
+    "111111111111111111111111111111111111111111111111111111111111111",
+    "1000000000000000000000000000000000000000000000000000000000000000"};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected, verbosity);
 }

--- a/src/main/cpp/tests/cast_long_to_binary_string.cpp
+++ b/src/main/cpp/tests/cast_long_to_binary_string.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <rmm/device_uvector.hpp>
+
+#include <cast_string.hpp>
+
+#include <limits>
+
+using namespace cudf;
+
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::FIRST_ERROR};
+
+struct LongToBinaryStringTests : public cudf::test::BaseFixture {};
+
+TEST_F(LongToBinaryStringTests, FromLongToBinary)
+{
+  auto const longs = cudf::test::fixed_width_column_wrapper<int64_t>{0L, 1L, 10L, -0L, -1L};
+
+  auto results = spark_rapids_jni::long_to_binary_string(longs, cudf::get_default_stream());
+
+  auto const expected = cudf::test::strings_column_wrapper{
+    "0", "1", "1010", "0", "1111111111111111111111111111111111111111111111111111111111111111"};
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected, verbosity);
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -111,6 +111,10 @@ public class CastStrings {
     return new ColumnVector(fromDecimal(cv.getNativeView()));
   }
 
+  public static ColumnVector fromLongToBinary(ColumnView cv) {
+    return new ColumnVector(fromLongToBinary(cv.getNativeView()));
+  }
+
   /**
    * Convert a string column to a given floating-point type column.
    *
@@ -160,6 +164,7 @@ public class CastStrings {
   private static native long fromDecimal(long nativeColumnView);
   private static native long fromFloatWithFormat(long nativeColumnView, int digits);
   private static native long fromFloat(long nativeColumnView);
+  private static native long fromLongToBinary(long nativeColumnView);
   private static native long toIntegersWithBase(long nativeColumnView, int base,
     boolean ansiEnabled, int dtype);
   private static native long fromIntegersWithBase(long nativeColumnView, int base);

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -272,6 +272,18 @@ public class CastStringsTest {
     }
   }
 
+  @Test
+  void castFromLongToBinaryStringTest() {
+    try (ColumnVector v0 = ColumnVector.fromBoxedLongs(null, 0L, 1L, 10L, -1L, Long.MAX_VALUE, Long.MIN_VALUE);
+         ColumnVector result = CastStrings.fromLongToBinary(v0);
+         ColumnVector expected = ColumnVector.fromStrings(null, "0", "1", "1010",
+         "1111111111111111111111111111111111111111111111111111111111111111",
+         "111111111111111111111111111111111111111111111111111111111111111",
+         "1000000000000000000000000000000000000000000000000000000000000000")) {
+          AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
   private void convTestInternal(Table input, Table expected, int fromBase) {
     try(
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), fromBase, false,


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Contribute to https://github.com/NVIDIA/spark-rapids/issues/11648

This PR adds support for `org.apache.spark.sql.catalyst.expressions.Bin`.
What it does is taking a `long` and outputting its binary representation.