### PR TITLE
Add zero copy data writer for kudo.

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/ByteArrayOutputStreamWriter.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/ByteArrayOutputStreamWriter.java
@@ -1,0 +1,81 @@
+package com.nvidia.spark.rapids.jni.kudo;
+
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+import ai.rapids.cudf.HostMemoryBuffer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class ByteArrayOutputStreamWriter implements DataWriter {
+  private static final Method ENSURE_CAPACITY;
+  private static final Field BUF;
+  private static final Field COUNT;
+
+  static {
+    try {
+      ENSURE_CAPACITY = ByteArrayOutputStream.class.getDeclaredMethod("ensureCapacity", int.class);
+      ENSURE_CAPACITY.setAccessible(true);
+
+      BUF = ByteArrayOutputStream.class.getDeclaredField("buf");
+      BUF.setAccessible(true);
+
+
+      COUNT = ByteArrayOutputStream.class.getDeclaredField("count");
+      COUNT.setAccessible(true);
+    } catch (NoSuchMethodException | NoSuchFieldException e) {
+      throw new RuntimeException("Failed to find ByteArrayOutputStream.ensureCapacity", e);
+    }
+  }
+
+  private final ByteArrayOutputStream out;
+
+  public ByteArrayOutputStreamWriter(ByteArrayOutputStream bout) {
+    requireNonNull(bout, "Byte array output stream can't be null");
+    this.out = bout;
+  }
+
+  @Override
+  public void reserve(int size) throws IOException {
+    try {
+      ENSURE_CAPACITY.invoke(out, size);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to invoke ByteArrayOutputStream.ensureCapacity", e);
+    }
+  }
+
+  @Override
+  public void writeInt(int v) throws IOException {
+    reserve(4 + out.size());
+    out.write((v >>> 24) & 0xFF);
+    out.write((v >>> 16) & 0xFF);
+    out.write((v >>>  8) & 0xFF);
+    out.write((v >>>  0) & 0xFF);
+  }
+
+  @Override
+  public void copyDataFrom(HostMemoryBuffer src, long srcOffset, long len) throws IOException {
+    reserve(toIntExact(out.size() + len));
+
+    try {
+      byte[] buf = (byte[]) BUF.get(out);
+      int count = out.size();
+
+      src.getBytes(buf, count, srcOffset, len);
+      COUNT.setInt(out, toIntExact(count + len));
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+  }
+
+  @Override
+  public void write(byte[] arr, int offset, int length) throws IOException {
+    out.write(arr, offset, length);
+  }
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/ByteArrayOutputStreamWriter.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/ByteArrayOutputStreamWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.nvidia.spark.rapids.jni.kudo;
 
 import static java.lang.Math.toIntExact;
@@ -9,6 +25,10 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+/**
+ * Adapter class which helps to save memory copy when shuffle manager uses {@link ByteArrayOutputStream} during
+ * serialization.
+ */
 public class ByteArrayOutputStreamWriter implements DataWriter {
   private static final Method ENSURE_CAPACITY;
   private static final Field BUF;

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/DataWriter.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/DataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,19 @@ import ai.rapids.cudf.HostMemoryBuffer;
 import java.io.IOException;
 
 /**
- * Visible for testing
+ * Output data writer for kudo serializer.
  */
-abstract class DataWriter {
+public interface DataWriter {
 
-  public abstract void writeInt(int i) throws IOException;
+  /**
+   * Write int in network byte order.
+   */
+  void writeInt(int i) throws IOException;
+
+  /**
+   * Reserve space in the buffer for the given size.
+   */
+  default void reserve(int size) throws IOException {}
 
   /**
    * Copy data from src starting at srcOffset and going for len bytes.
@@ -34,11 +42,12 @@ abstract class DataWriter {
    * @param srcOffset offset to start at.
    * @param len       amount to copy.
    */
-  public abstract void copyDataFrom(HostMemoryBuffer src, long srcOffset, long len) throws IOException;
+  void copyDataFrom(HostMemoryBuffer src, long srcOffset, long len) throws IOException;
 
-  public void flush() throws IOException {
-    // NOOP by default
-  }
+  void flush() throws IOException;
 
-  public abstract void write(byte[] arr, int offset, int length) throws IOException;
+  /**
+   * Copy part of byte array to this writer.
+   */
+  void write(byte[] arr, int offset, int length) throws IOException;
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/OpenByteArrayOutputStream.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/OpenByteArrayOutputStream.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni.kudo;
+
+import ai.rapids.cudf.HostMemoryBuffer;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class extends {@link ByteArrayOutputStream} to provide some internal methods to save copy.
+ */
+public class OpenByteArrayOutputStream extends ByteArrayOutputStream {
+
+  /**
+   * Creates a new byte array output stream. The buffer capacity is
+   * initially 32 bytes, though its size increases if necessary.
+   */
+  public OpenByteArrayOutputStream() {
+    this(32);
+  }
+
+  /**
+   * Creates a new byte array output stream, with a buffer capacity of
+   * the specified size, in bytes.
+   *
+   * @param   size   the initial size.
+   * @exception  IllegalArgumentException if size is negative.
+   */
+  public OpenByteArrayOutputStream(int size) {
+    super(size);
+  }
+
+  /**
+   * Get underlying byte array.
+   */
+  public byte[] getBuf() {
+    return buf;
+  }
+
+  /**
+   * Get actual number of bytes that have been written to this output stream.
+   * @return Number of bytes written to this output stream. Note that this maybe smaller than length of
+   *      {@link OpenByteArrayOutputStream#getBuf()}.
+   */
+  public int getCount() {
+    return count;
+  }
+
+  /**
+   * Increases the capacity if necessary to ensure that it can hold
+   * at least the number of elements specified by the minimum
+   * capacity argument.
+   *
+   * <br/>
+   *
+   * This code is copied from jdk's implementation.
+   *
+   * @param minCapacity the desired minimum capacity
+   * @throws OutOfMemoryError if {@code minCapacity < 0}.  This is
+   * interpreted as a request for the unsatisfiably large capacity
+   * {@code (long) Integer.MAX_VALUE + (minCapacity - Integer.MAX_VALUE)}.
+   */
+  public void reserve(int minCapacity) {
+    // overflow-conscious code
+    if (minCapacity - buf.length > 0)
+      grow(minCapacity);
+  }
+
+  /**
+   * The maximum size of array to allocate.
+   * Some VMs reserve some header words in an array.
+   * Attempts to allocate larger arrays may result in
+   * OutOfMemoryError: Requested array size exceeds VM limit
+   */
+  private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+  /**
+   * Increases the capacity to ensure that it can hold at least the
+   * number of elements specified by the minimum capacity argument.
+   *
+   * @param minCapacity the desired minimum capacity
+   */
+  private void grow(int minCapacity) {
+    // overflow-conscious code
+    int oldCapacity = buf.length;
+    int newCapacity = oldCapacity << 1;
+    if (newCapacity - minCapacity < 0)
+      newCapacity = minCapacity;
+    if (newCapacity - MAX_ARRAY_SIZE > 0)
+      newCapacity = hugeCapacity(minCapacity);
+    buf = Arrays.copyOf(buf, newCapacity);
+  }
+
+  private static int hugeCapacity(int minCapacity) {
+    if (minCapacity < 0) // overflow
+      throw new OutOfMemoryError();
+    return (minCapacity > MAX_ARRAY_SIZE) ?
+            Integer.MAX_VALUE :
+            MAX_ARRAY_SIZE;
+  }
+
+  /**
+   * Copy from {@link HostMemoryBuffer} to this output stream.
+   * @param srcBuf {@link HostMemoryBuffer} to copy from.
+   * @param offset Start position in source {@link HostMemoryBuffer}.
+   * @param length Number of bytes to copy.
+   */
+  public void write(HostMemoryBuffer srcBuf, long offset, int length) {
+    requireNonNull(srcBuf, "Source buf can't be null!");
+    reserve(count + length);
+    srcBuf.getBytes(buf, count, offset, length);
+    count += length;
+  }
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializerTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

1. Add `reserve` method in `DataWriter` so that kudo data writer could reserve memory before actual writing happens. This helps avoiding unnecessay allocation and copy.
2. Add `OpenByteArrayOutputStream` and its corresponding data writer. `OpenByteArrayOutputStream` could be used in customized shuffle manager to save memory.
3. Add `ByteArrayOutputStreamWriter` which helps saving memory copy without introducing any changes to shuffle manager.



