### PR TITLE
[auto-merge] bot-auto-merge-branch-25.02 to branch-25.04 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -247,7 +247,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "401483cc4498a7082355c796fcdf1fe2eafe331c",
+      "git_tag" : "dcd37acbe58c73192f74bd6bb1ec5f1b9f1f2dd4",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "version" : "25.02"
     },

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -247,7 +247,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "dcd37acbe58c73192f74bd6bb1ec5f1b9f1f2dd4",
+      "git_tag" : "401483cc4498a7082355c796fcdf1fe2eafe331c",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "version" : "25.02"
     },


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-25.02` to create a PR keeping `branch-25.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.