### PR TITLE
Fix a race condition that happens on shutdown of the SparkResourceAdaptor

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -72,7 +72,6 @@ public class SparkResourceAdaptor
   public SparkResourceAdaptor(RmmEventHandlerResourceAdaptor<RmmDeviceMemoryResource> wrapped,
       String logLoc) {
     super(wrapped);
-    // We are going to exit, so ignore the exception
     Thread watchDog = new Thread(() -> {
       try {
         while (isOpen()) {


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/12038

This does not fix all potential race conditions, but it does fix this one and helps to mitigate the others a little more. But the others should never occur in practice unless the spark worker is shutting down in an error case already.