### PR TITLE
Refactor `HostColumnsVisitor` in kudo to remove generic type.

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableHeaderCalc.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableHeaderCalc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableHeaderCalc.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableHeaderCalc.java
@@ -35,7 +35,7 @@ import static java.lang.Math.toIntExact;
  * {@link HostColumnsVisitor}.
  * </p>
  */
-class KudoTableHeaderCalc implements HostColumnsVisitor<Void> {
+class KudoTableHeaderCalc implements HostColumnsVisitor {
   private final SliceInfo root;
   private final int numFlattenedCols;
   private final byte[] bitset;
@@ -66,7 +66,7 @@ class KudoTableHeaderCalc implements HostColumnsVisitor<Void> {
   }
 
   @Override
-  public Void visitStruct(HostColumnVectorCore col, List<Void> children) {
+  public void visitStruct(HostColumnVectorCore col) {
     SliceInfo parent = sliceInfos.getLast();
 
     long validityBufferLength = 0;
@@ -78,11 +78,10 @@ class KudoTableHeaderCalc implements HostColumnsVisitor<Void> {
 
     totalDataLen += validityBufferLength;
     this.setHasValidity(col.hasValidityVector());
-    return null;
   }
 
   @Override
-  public Void preVisitList(HostColumnVectorCore col) {
+  public void preVisitList(HostColumnVectorCore col) {
     SliceInfo parent = sliceInfos.getLast();
 
 
@@ -114,19 +113,16 @@ class KudoTableHeaderCalc implements HostColumnsVisitor<Void> {
     }
 
     sliceInfos.addLast(current);
-    return null;
   }
 
   @Override
-  public Void visitList(HostColumnVectorCore col, Void preVisitResult, Void childResult) {
+  public void visitList(HostColumnVectorCore col) {
     sliceInfos.removeLast();
-
-    return null;
   }
 
 
   @Override
-  public Void visit(HostColumnVectorCore col) {
+  public void visit(HostColumnVectorCore col) {
     SliceInfo parent = sliceInfos.peekLast();
     long validityBufferLen = dataLenOfValidityBuffer(col, parent);
     long offsetBufferLen = dataLenOfOffsetBuffer(col, parent);
@@ -137,8 +133,6 @@ class KudoTableHeaderCalc implements HostColumnsVisitor<Void> {
     this.totalDataLen += validityBufferLen + offsetBufferLen + dataBufferLen;
 
     this.setHasValidity(col.hasValidityVector());
-
-    return null;
   }
 
   private void setHasValidity(boolean hasValidityBuffer) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/SlicedBufferSerializer.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/SlicedBufferSerializer.java
@@ -41,7 +41,7 @@ import java.util.List;
  * For more details about the kudo format, please refer to {@link KudoSerializer}.
  * </p>
  */
-class SlicedBufferSerializer implements HostColumnsVisitor<Void> {
+class SlicedBufferSerializer implements HostColumnsVisitor {
   private final SliceInfo root;
   private final BufferType bufferType;
   private final DataWriter writer;
@@ -67,17 +67,17 @@ class SlicedBufferSerializer implements HostColumnsVisitor<Void> {
   }
 
   @Override
-  public Void visitStruct(HostColumnVectorCore col, List<Void> children) {
+  public void visitStruct(HostColumnVectorCore col) {
     SliceInfo parent = sliceInfos.peekLast();
 
     try {
       switch (bufferType) {
         case VALIDITY:
           totalDataLen += this.copySlicedValidity(col, parent);
-          return null;
+          return;
         case OFFSET:
         case DATA:
-          return null;
+          return;
         default:
           throw new IllegalArgumentException("Unexpected buffer type: " + bufferType);
       }
@@ -88,7 +88,7 @@ class SlicedBufferSerializer implements HostColumnsVisitor<Void> {
   }
 
   @Override
-  public Void preVisitList(HostColumnVectorCore col) {
+  public void preVisitList(HostColumnVectorCore col) {
     SliceInfo parent = sliceInfos.getLast();
 
 
@@ -126,29 +126,27 @@ class SlicedBufferSerializer implements HostColumnsVisitor<Void> {
     sliceInfos.addLast(current);
 
     totalDataLen += bytesCopied;
-    return null;
   }
 
   @Override
-  public Void visitList(HostColumnVectorCore col, Void preVisitResult, Void childResult) {
+  public void visitList(HostColumnVectorCore col) {
     sliceInfos.removeLast();
-    return null;
   }
 
   @Override
-  public Void visit(HostColumnVectorCore col) {
+  public void visit(HostColumnVectorCore col) {
     SliceInfo parent = sliceInfos.getLast();
     try {
       switch (bufferType) {
         case VALIDITY:
           totalDataLen += this.copySlicedValidity(col, parent);
-          return null;
+          return;
         case OFFSET:
           totalDataLen += this.copySlicedOffset(col, parent);
-          return null;
+          return;
         case DATA:
           totalDataLen += this.copySlicedData(col, parent);
-          return null;
+          return;
         default:
           throw new IllegalArgumentException("Unexpected buffer type: " + bufferType);
       }

--- a/src/main/java/com/nvidia/spark/rapids/jni/schema/HostColumnsVisitor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/schema/HostColumnsVisitor.java
@@ -48,37 +48,33 @@ import java.util.List;
  *
  * </p>
  *
- * @param <T> Return type when visiting intermediate nodes.
  */
-public interface HostColumnsVisitor<T> {
+public interface HostColumnsVisitor {
     /**
      * Visit a struct column.
      * @param col the struct column to visit
-     * @param children the results of visiting the children
      * @return the result of visiting the struct column
      */
-    T visitStruct(HostColumnVectorCore col, List<T> children);
+    void visitStruct(HostColumnVectorCore col);
 
     /**
      * Visit a list column before actually visiting its child.
      * @param col the list column to visit
      * @return the result of visiting the list column
      */
-    T preVisitList(HostColumnVectorCore col);
+    void preVisitList(HostColumnVectorCore col);
 
     /**
      * Visit a list column after visiting its child.
      * @param col the list column to visit
-     * @param preVisitResult the result of visiting the list column before visiting its child
-     * @param childResult the result of visiting the child
      * @return the result of visiting the list column
      */
-    T visitList(HostColumnVectorCore col, T preVisitResult, T childResult);
+    void visitList(HostColumnVectorCore col);
 
     /**
      * Visit a column that is a primitive type.
      * @param col the column to visit
      * @return the result of visiting the column
      */
-    T visit(HostColumnVectorCore col);
+    void visit(HostColumnVectorCore col);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/schema/HostColumnsVisitor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/schema/HostColumnsVisitor.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2024, NVIDIA CORPORATION.
+ *  Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/schema/Visitors.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/schema/Visitors.java
@@ -54,35 +54,6 @@ public class Visitors {
         return visitor.visitTopSchema(schema, childrenResult);
     }
 
-    public static void visitSchema(Schema schema, SchemaVisitor2 visitor) {
-        requireNonNull(schema, "schema cannot be null");
-        requireNonNull(visitor, "visitor cannot be null");
-
-        for (int i = 0; i < schema.getNumChildren(); i++) {
-            visitSchemaInner(schema.getChild(i), visitor);
-        }
-        visitor.visitTopSchema(schema);
-    }
-
-    private static void visitSchemaInner(Schema schema, SchemaVisitor2 visitor) {
-        switch (schema.getType().getTypeId()) {
-            case STRUCT:
-                for (int i=0; i<schema.getNumChildren(); i++) {
-                    visitSchemaInner(schema.getChild(i), visitor);
-                }
-                visitor.visitStruct(schema);
-                break;
-            case LIST:
-                visitor.preVisitList(schema);
-                visitSchemaInner(schema.getChild(0), visitor);
-                visitor.visitList(schema);
-                break;
-            default:
-                visitor.visit(schema);
-                break;
-        }
-    }
-
     private static <T, P, R> T visitSchemaInner(Schema schema, SchemaVisitor<T, P, R> visitor) {
         switch (schema.getType().getTypeId()) {
             case STRUCT:

--- a/src/main/java/com/nvidia/spark/rapids/jni/schema/Visitors.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/schema/Visitors.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2024, NVIDIA CORPORATION.
+ *  Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Closes #2907 .

Current all `HostColumnsVisitor`'s generic type is `Void`,  this pr removes generic type in `HostColumnsVisitor` to avoid unnecessary allocation when visiting.