### PR TITLE
Put in updated patch to disable shared memory aggregations

### DIFF
--- a/patches/disable_shared_agg.patch
+++ b/patches/disable_shared_agg.patch
@@ -1,0 +1,21 @@
+diff --git a/cpp/src/groupby/hash/compute_aggregations.cuh b/cpp/src/groupby/hash/compute_aggregations.cuh
+index b97c8ddf88..4134b5d068 100644
+--- a/cpp/src/groupby/hash/compute_aggregations.cuh
++++ b/cpp/src/groupby/hash/compute_aggregations.cuh
+@@ -69,15 +69,7 @@ rmm::device_uvector<cudf::size_type> compute_aggregations(
+   auto const available_shmem_size = get_available_shared_memory_size(grid_size);
+   auto const offsets_buffer_size  = compute_shmem_offsets_size(flattened_values.num_columns()) * 2;
+   auto const data_buffer_size     = available_shmem_size - offsets_buffer_size;
+-  auto const is_shared_memory_compatible = std::all_of(
+-    requests.begin(), requests.end(), [&](cudf::groupby::aggregation_request const& request) {
+-      if (cudf::is_dictionary(request.values.type())) { return false; }
+-      // Ensure there is enough buffer space to store local aggregations up to the max cardinality
+-      // for shared memory aggregations
+-      auto const size = cudf::type_dispatcher<cudf::dispatch_storage_type>(request.values.type(),
+-                                                                           size_of_functor{});
+-      return data_buffer_size >= (size * GROUPBY_CARDINALITY_THRESHOLD);
+-    });
++  auto const is_shared_memory_compatible = false;
+ 
+   // Performs naive global memory aggregations when the workload is not compatible with shared
+   // memory, such as when aggregating dictionary columns or when there is insufficient dynamic


### PR DESCRIPTION
This will disable the shared memory feature in CUDF again. The patch was slightly updated to match the new code in CUDF.