### PR TITLE
Apply groupby patch based on rapidsai/cudf#17985 to branch-24.12

### DIFF
--- a/patches/fix_groupby.patch
+++ b/patches/fix_groupby.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+index f0361ccced..8c446d4256 100644
+--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
++++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+@@ -222,6 +222,7 @@ CUDF_KERNEL void single_pass_shmem_aggs_kernel(cudf::size_type num_rows,
+   block.sync();
+ 
+   while (col_end < num_cols) {
++    block.sync();
+     if (block.thread_rank() == 0) {
+       calculate_columns_to_aggregate(col_start,
+                                      col_end,


### PR DESCRIPTION
This PR applies a patch to 24.12 that contains the core fix to the groupby algorithm that [was merged](https://github.com/rapidsai/cudf/pull/17985) into cuDF 25.02.