### PR TITLE
Sort the entries for each map in map column according to the keys in each map

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -200,6 +200,7 @@ add_library(
   src/HistogramJni.cpp
   src/HostTableJni.cpp
   src/JSONUtilsJni.cpp
+  src/MapJni.cpp
   src/NativeParquetJni.cpp
   src/ParseURIJni.cpp
   src/RegexRewriteUtilsJni.cpp
@@ -223,6 +224,7 @@ add_library(
   src/get_json_object.cu
   src/histogram.cu
   src/json_utils.cu
+  src/map.cu
   src/murmur_hash.cu
   src/parse_uri.cu
   src/regex_rewrite_utils.cu

--- a/src/main/cpp/src/MapJni.cpp
+++ b/src/main/cpp/src/MapJni.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "jni_utils.hpp"
+#include "map.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+extern "C" {
+
+JNIEXPORT jlong Java_com_nvidia_spark_rapids_jni_Map_sort(
+  JNIEnv* env, jclass, jlong map_haldle, jboolean is_descending, jboolean is_null_smallest)
+{
+  JNI_NULL_CHECK(env, map_haldle, "column is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    auto sort_order = is_descending ? cudf::order::DESCENDING : cudf::order::ASCENDING;
+    auto null_order = is_null_smallest ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
+    cudf::column_view const& map_view = *reinterpret_cast<cudf::column_view const*>(map_haldle);
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::sort_map_column(map_view, sort_order, null_order));
+  }
+
+  CATCH_STD(env, 0);
+}
+}

--- a/src/main/cpp/src/MapJni.cpp
+++ b/src/main/cpp/src/MapJni.cpp
@@ -18,32 +18,20 @@
 #include "jni_utils.hpp"
 #include "map.hpp"
 
-#include <cudf/column/column_factories.hpp>
-#include <cudf/column/column_view.hpp>
-#include <cudf/lists/lists_column_view.hpp>
-#include <cudf/null_mask.hpp>
-#include <cudf/sorting.hpp>
-#include <cudf/table/table_view.hpp>
-#include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/error.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
-#include <rmm/resource_ref.hpp>
-
 extern "C" {
 
-JNIEXPORT jlong Java_com_nvidia_spark_rapids_jni_Map_sort(
-  JNIEnv* env, jclass, jlong map_haldle, jboolean is_descending, jboolean is_null_smallest)
+JNIEXPORT jlong Java_com_nvidia_spark_rapids_jni_Map_sort(JNIEnv* env,
+                                                          jclass,
+                                                          jlong map_haldle,
+                                                          jboolean is_descending)
 {
   JNI_NULL_CHECK(env, map_haldle, "column is null", 0);
 
   try {
     cudf::jni::auto_set_device(env);
     auto sort_order = is_descending ? cudf::order::DESCENDING : cudf::order::ASCENDING;
-    auto null_order = is_null_smallest ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
     cudf::column_view const& map_view = *reinterpret_cast<cudf::column_view const*>(map_haldle);
-    return cudf::jni::release_as_jlong(
-      spark_rapids_jni::sort_map_column(map_view, sort_order, null_order));
+    return cudf::jni::release_as_jlong(spark_rapids_jni::sort_map_column(map_view, sort_order));
   }
 
   CATCH_STD(env, 0);

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -34,7 +34,6 @@ namespace spark_rapids_jni {
 
 std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& map_column,
                                               cudf::order sort_order,
-                                              cudf::null_order null_order,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
@@ -52,18 +51,18 @@ std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& map_colum
                                             cudf::table_view{{keys}},
                                             segments,
                                             {sort_order},
-                                            {null_order},
+                                            {},  // Map keys MUST be not null
                                             stream,
                                             mr);
   stream.synchronize();
   std::vector<std::unique_ptr<cudf::column>> k_v = sorted->release();
 
+  // Note: The keys in a map MUST not be null, so the struct<Key, Value> MUST not be null too.
+  // Of course, the null count is zero for struct<Key Value> column
   auto mask = cudf::create_null_mask(keys.size(), cudf::mask_state::UNALLOCATED, stream, mr);
   stream.synchronize();
-
   auto sorted_struct =
     cudf::make_structs_column(keys.size(), std::move(k_v), 0, std::move(mask), stream, mr);
-  stream.synchronize();
 
   // clone segments
   auto copied_segements = cudf::make_numeric_column(cudf::data_type(segments.type().id()),
@@ -72,15 +71,12 @@ std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& map_colum
                                                     stream,
                                                     mr);
   stream.synchronize();
-
   CUDF_CUDA_TRY(cudaMemcpyAsync(copied_segements->mutable_view().data<int32_t>(),
                                 segments.data<int32_t>(),
                                 segments.size() * sizeof(int32_t),
                                 cudaMemcpyDeviceToDevice,
                                 stream.value()));
   stream.synchronize();
-
-  printf("mydebug: success \n");
 
   return cudf::make_lists_column(lists_of_structs.size(),
                                  std::move(copied_segements),  // offsets

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -55,11 +55,11 @@ std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& input,
                                             stream,
                                             mr);
 
-  return cudf::make_lists_column(lists_of_structs.size(),
+  return cudf::make_lists_column(input.size(),
                                  std::make_unique<cudf::column>(segments),  // copy segment offsets
                                  std::move(sorted->release().front()),      // child column
-                                 lists_of_structs.null_count(),
-                                 cudf::copy_bitmask(lists_of_structs.parent(), stream, mr),
+                                 input.null_count(),
+                                 cudf::copy_bitmask(input, stream, mr),
                                  stream,
                                  mr);
 }

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -43,8 +43,10 @@ std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& map_colum
                "maps_column_view input must have exactly 1 child (STRUCT) column.");
   CUDF_EXPECTS(structs.num_children() == 2,
                "maps_column_view key-value struct must have exactly 2 children.");
-  auto keys     = structs.child(0);
-  auto values   = structs.child(1);
+  auto keys   = structs.child(0);
+  auto values = structs.child(1);
+  CUDF_EXPECTS(structs.null_count() == 0, "maps_column_view key-value struct must have no null.");
+  CUDF_EXPECTS(keys.null_count() == 0, "maps_column_view keys must have no null.");
   auto segments = lists_of_structs.offsets();
 
   auto sorted = cudf::segmented_sort_by_key(cudf::table_view{{keys, values}},

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "jni_utils.hpp"
+#include "map.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+namespace spark_rapids_jni {
+
+std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& map_column,
+                                              cudf::order sort_order,
+                                              cudf::null_order null_order,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr)
+{
+  auto const& lists_of_structs = cudf::lists_column_view(map_column);
+  auto const structs           = lists_of_structs.child();
+  CUDF_EXPECTS(structs.type().id() == cudf::type_id::STRUCT,
+               "maps_column_view input must have exactly 1 child (STRUCT) column.");
+  CUDF_EXPECTS(structs.num_children() == 2,
+               "maps_column_view key-value struct must have exactly 2 children.");
+  auto keys     = structs.child(0);
+  auto values   = structs.child(1);
+  auto segments = lists_of_structs.offsets();
+
+  auto sorted = cudf::segmented_sort_by_key(cudf::table_view{{keys, values}},
+                                            cudf::table_view{{keys}},
+                                            segments,
+                                            {sort_order},
+                                            {null_order},
+                                            stream,
+                                            mr);
+  stream.synchronize();
+  std::vector<std::unique_ptr<cudf::column>> k_v = sorted->release();
+
+  auto mask = cudf::create_null_mask(keys.size(), cudf::mask_state::UNALLOCATED, stream, mr);
+  stream.synchronize();
+
+  auto sorted_struct =
+    cudf::make_structs_column(keys.size(), std::move(k_v), 0, std::move(mask), stream, mr);
+  stream.synchronize();
+
+  // clone segments
+  auto copied_segements = cudf::make_numeric_column(cudf::data_type(segments.type().id()),
+                                                    segments.size(),
+                                                    cudf::mask_state::UNALLOCATED,
+                                                    stream,
+                                                    mr);
+  stream.synchronize();
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(copied_segements->mutable_view().data<int32_t>(),
+                                segments.data<int32_t>(),
+                                segments.size() * sizeof(int32_t),
+                                cudaMemcpyDeviceToDevice,
+                                stream.value()));
+  stream.synchronize();
+
+  printf("mydebug: success \n");
+
+  return cudf::make_lists_column(lists_of_structs.size(),
+                                 std::move(copied_segements),  // offsets
+                                 std::move(sorted_struct),     // child column
+                                 lists_of_structs.null_count(),
+                                 cudf::copy_bitmask(lists_of_structs.parent(), stream, mr),
+                                 stream,
+                                 mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -26,6 +26,6 @@ std::unique_ptr<cudf::column> sort_map_column(
   cudf::column_view const& map_column,
   cudf::order sort_order,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-#include "cudf_jni_apis.hpp"
-#include "jni_utils.hpp"
-
-#include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cudf/lists/lists_column_view.hpp>
-#include <cudf/null_mask.hpp>
-#include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
@@ -34,7 +26,6 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> sort_map_column(
   cudf::column_view const& map_column,
   cudf::order sort_order,
-  cudf::null_order null_order,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -22,10 +22,22 @@
 
 namespace spark_rapids_jni {
 
+/**
+ * Sort entries for each map in map column according to the keys of each map.
+ * Note:
+ *   The keys of map MUST not be null.
+ *   Assume that maps do not have duplicate keys.
+ *
+ * @param input Input map column, should in LIST(STRUCT(KEY, VALUE)) type.
+ * @param sort_order Ascending or descending order
+ * @return Sorted map according to the sort order of the key column in map.
+ * @throws cudf::logic_error If the input column is not a LIST(STRUCT(KEY, VALUE)) column or the
+ * keys contain nulls.
+ */
 std::unique_ptr<cudf::column> sort_map_column(
-  cudf::column_view const& map_column,
+  cudf::column_view const& input,
   cudf::order sort_order,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
-}
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -27,6 +27,8 @@ namespace spark_rapids_jni {
  * Note:
  *   The keys of map MUST not be null.
  *   Assume that maps do not have duplicate keys.
+ *   Do not normalize/sort the nested maps in `KEY` column; This means
+ *   Only consider the first level LIST(STRUCT(KEY, VALUE)) as map type.
  *
  * @param input Input map column, should in LIST(STRUCT(KEY, VALUE)) type.
  * @param sort_order Ascending or descending order

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "jni_utils.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+namespace spark_rapids_jni {
+
+std::unique_ptr<cudf::column> sort_map_column(
+  cudf::column_view const& map_column,
+  cudf::order sort_order,
+  cudf::null_order null_order,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+
+}

--- a/src/main/cpp/src/map.hpp
+++ b/src/main/cpp/src/map.hpp
@@ -15,11 +15,10 @@
  */
 
 #include <cudf/column/column_view.hpp>
-#include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/resource_ref.hpp>
 
 namespace spark_rapids_jni {
 
@@ -27,6 +26,6 @@ std::unique_ptr<cudf::column> sort_map_column(
   cudf::column_view const& map_column,
   cudf::order sort_order,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
 
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/Map.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Map.java
@@ -35,6 +35,8 @@ public class Map {
    * Note:
    *   The keys of map MUST not be null.
    *   Assume that maps do not have duplicate keys.
+   *   Do not normalize/sort the nested maps in `KEY` column; This means
+   *   Only consider the first level LIST(STRUCT(KEY, VALUE)) as map type.
    *
    * @param cv           Input map column, should in LIST(STRUCT(KEY, VALUE))
    *                     type.

--- a/src/main/java/com/nvidia/spark/rapids/jni/Map.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Map.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.ColumnView;
+import ai.rapids.cudf.CudfException;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.NativeDepsLoader;
+
+/**
+ * APIs for map column operations.
+ */
+public class Map {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  /**
+   * Sort map column according to the key column in it.
+   * 
+   * @param cv             Input map column, should in LIST<STRUCT<KEY, VALUE>> type.
+   * @param isDescending   True if sort in descending order, false if sort in
+   *                       ascending order
+   * @param isNullSmallest True if null is considered smallest, false if null is
+   *                       considered largest
+   * @return Sorted map according to the sort order of the key column in map.
+   */
+  public static ColumnVector sort(ColumnView cv, boolean isDescending, boolean isNullSmallest) {
+    assert (cv.getType().equals(DType.LIST));
+    long r = sort(cv.getNativeView(), isDescending, isNullSmallest);
+    return new ColumnVector(r);
+  }
+
+  private static native long sort(long handle, boolean isDescending, boolean isNullSmallest) throws CudfException;
+}
+

--- a/src/main/java/com/nvidia/spark/rapids/jni/Map.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Map.java
@@ -32,15 +32,15 @@ public class Map {
 
   /**
    * Sort entries for each map in map column according to the keys of each map.
-   * Note: The keys of map MUST not be null. This implementation does not check if
-   * all the keys are non-null, and does not check if all the struct(key, value)
-   * are non-null. The caller MUST pass in valid map column.
+   * Note: The keys of map MUST not be null.
    * 
    * @param cv           Input map column, should in LIST(STRUCT(KEY, VALUE))
    *                     type.
    * @param isDescending True if sort in descending order, false if sort in
    *                     ascending order
    * @return Sorted map according to the sort order of the key column in map.
+   * @throws CudfException If the input column is not a LIST(STRUCT(KEY, VALUE))
+   *                       column or the keys contain nulls.
    */
   public static ColumnVector sort(ColumnView cv, boolean isDescending, boolean isNullSmallest) {
     assert (cv.getType().equals(DType.LIST));

--- a/src/main/java/com/nvidia/spark/rapids/jni/Map.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Map.java
@@ -42,7 +42,7 @@ public class Map {
    * @throws CudfException If the input column is not a LIST(STRUCT(KEY, VALUE))
    *                       column or the keys contain nulls.
    */
-  public static ColumnVector sort(ColumnView cv, boolean isDescending, boolean isNullSmallest) {
+  public static ColumnVector sort(ColumnView cv, boolean isDescending) {
     assert (cv.getType().equals(DType.LIST));
     long r = sort(cv.getNativeView(), isDescending);
     return new ColumnVector(r);

--- a/src/main/java/com/nvidia/spark/rapids/jni/Map.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Map.java
@@ -31,21 +31,23 @@ public class Map {
   }
 
   /**
-   * Sort map column according to the key column in it.
+   * Sort entries for each map in map column according to the keys of each map.
+   * Note: The keys of map MUST not be null. This implementation does not check if
+   * all the keys are non-null, and does not check if all the struct(key, value)
+   * are non-null. The caller MUST pass in valid map column.
    * 
-   * @param cv             Input map column, should in LIST<STRUCT<KEY, VALUE>> type.
-   * @param isDescending   True if sort in descending order, false if sort in
-   *                       ascending order
-   * @param isNullSmallest True if null is considered smallest, false if null is
-   *                       considered largest
+   * @param cv           Input map column, should in LIST(STRUCT(KEY, VALUE))
+   *                     type.
+   * @param isDescending True if sort in descending order, false if sort in
+   *                     ascending order
    * @return Sorted map according to the sort order of the key column in map.
    */
   public static ColumnVector sort(ColumnView cv, boolean isDescending, boolean isNullSmallest) {
     assert (cv.getType().equals(DType.LIST));
-    long r = sort(cv.getNativeView(), isDescending, isNullSmallest);
+    long r = sort(cv.getNativeView(), isDescending);
     return new ColumnVector(r);
   }
 
-  private static native long sort(long handle, boolean isDescending, boolean isNullSmallest) throws CudfException;
+  private static native long sort(long handle, boolean isDescending) throws CudfException;
 }
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/Map.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Map.java
@@ -32,8 +32,10 @@ public class Map {
 
   /**
    * Sort entries for each map in map column according to the keys of each map.
-   * Note: The keys of map MUST not be null.
-   * 
+   * Note:
+   *   The keys of map MUST not be null.
+   *   Assume that maps do not have duplicate keys.
+   *
    * @param cv           Input map column, should in LIST(STRUCT(KEY, VALUE))
    *                     type.
    * @param isDescending True if sort in descending order, false if sort in

--- a/src/test/java/com/nvidia/spark/rapids/jni/MapTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/MapTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.*;
+
+import org.junit.jupiter.api.Test;
+
+import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class MapTest {
+
+  @Test
+  void sort() {
+    // Map is List<Struct<KEY, VALUE>>
+    List<HostColumnVector.StructData> map1 = Arrays.asList(
+        new HostColumnVector.StructData(Arrays.asList(5, 2)),
+        new HostColumnVector.StructData(Arrays.asList(4, 1)));
+    List<HostColumnVector.StructData> map2 = Arrays.asList(
+        new HostColumnVector.StructData(Arrays.asList(2, 1)),
+        new HostColumnVector.StructData(Arrays.asList(4, 3)));
+
+    List<HostColumnVector.StructData> sorted_map1 = Arrays.asList(
+        new HostColumnVector.StructData(Arrays.asList(4, 1)),
+        new HostColumnVector.StructData(Arrays.asList(5, 2)));
+    List<HostColumnVector.StructData> sorted_map2 = map2;
+
+    HostColumnVector.StructType structType = new HostColumnVector.StructType(true,
+        Arrays.asList(new HostColumnVector.BasicType(true, DType.INT32),
+            new HostColumnVector.BasicType(true, DType.INT32)));
+    try (ColumnVector cv = ColumnVector.fromLists(
+        new HostColumnVector.ListType(true, structType), map1, map2);
+        ColumnVector res = Map.sort(cv, false, true);
+        ColumnVector expected = ColumnVector.fromLists(
+            new HostColumnVector.ListType(true, structType), sorted_map1, sorted_map2)) {
+
+      assertColumnsAreEqual(expected, res);
+    }
+  }
+
+}
+

--- a/src/test/java/com/nvidia/spark/rapids/jni/MapTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/MapTest.java
@@ -47,7 +47,7 @@ public class MapTest {
             new HostColumnVector.BasicType(true, DType.INT32)));
     try (ColumnVector cv = ColumnVector.fromLists(
         new HostColumnVector.ListType(true, structType), map1, map2);
-        ColumnVector res = Map.sort(cv, false, true);
+        ColumnVector res = Map.sort(cv, false);
         ColumnVector expected = ColumnVector.fromLists(
             new HostColumnVector.ListType(true, structType), sorted_map1, sorted_map2)) {
 


### PR DESCRIPTION
closes #2927

Map in CUDF is List<struct<KEY, VALUE>>.
First sort struct<KEY, VALUE> using `cudf::segmented_sort_by_key`, then construct list column.

Signed-off-by: Chong Gao <res_life@163.com>