### PR TITLE
Fix spdlog compilation to unblock submodule sync

### DIFF
--- a/src/main/cpp/cmake/get_spdlog.cmake
+++ b/src/main/cpp/cmake/get_spdlog.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/src/main/cpp/cmake/get_spdlog.cmake
+++ b/src/main/cpp/cmake/get_spdlog.cmake
@@ -15,6 +15,7 @@
 # Use CPM to find or clone speedlog
 function(find_and_configure_spdlog)
 
+  set(CPM_DOWNLOAD_spdlog ON)
   include(${rapids-cmake-dir}/cpm/spdlog.cmake)
   rapids_cpm_spdlog(
     FMT_OPTION "EXTERNAL_FMT_HO"

--- a/src/main/cpp/cmake/get_spdlog.cmake
+++ b/src/main/cpp/cmake/get_spdlog.cmake
@@ -19,6 +19,7 @@ function(find_and_configure_spdlog)
   rapids_cpm_spdlog(
     FMT_OPTION "EXTERNAL_FMT_HO"
   )
+  set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 endfunction()
 


### PR DESCRIPTION
This adds `fPIC` compilation flag to `spdlog`, fixing the build issue when linking with `spdlog` as reported in https://github.com/NVIDIA/spark-rapids-jni/issues/2914.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2914.