### PR TITLE
[auto-merge] bot-auto-merge-branch-25.02 to branch-25.04 [skip ci] [bot]

### DIFF
--- a/patches/fix_groupby.patch
+++ b/patches/fix_groupby.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+index f0361ccced..8c446d4256 100644
+--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
++++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+@@ -222,6 +222,7 @@ CUDF_KERNEL void single_pass_shmem_aggs_kernel(cudf::size_type num_rows,
+   block.sync();
+ 
+   while (col_end < num_cols) {
++    block.sync();
+     if (block.thread_rank() == 0) {
+       calculate_columns_to_aggregate(col_start,
+                                      col_end,

--- a/thirdparty/cudf-pins/rapids-cmake.sha
+++ b/thirdparty/cudf-pins/rapids-cmake.sha
@@ -1,1 +1,1 @@
-adc9a4f9d688f8aad175dff2c8f7f34cf0e26c95
+0f6d4d61694fbe3e2dcc32493f9ffbdfd031e0f2

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -132,7 +132,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "deab5799f3e4226cb8a49acf2199c03b14941ee4",
+      "git_tag" : "7b422c00f3541e2472e8d1047b7c3bb4e83c7e2c",
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
       "version" : "0.0.1"
     },
@@ -209,9 +209,9 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "29922d77e62ee28df7c90f06cddaf87eb46ca4b4",
+      "git_tag" : "ecb81c2c3c17252fcd5a902af9789debb234426b",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
-      "version" : "25.02"
+      "version" : "25.04"
     },
     "nanoarrow" : 
     {
@@ -251,7 +251,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "8968ab3337f31c845d4e3bf6c55ae89242ded22b",
+      "git_tag" : "46070bb255482f0782ca840ae45de9354380e298",
       "git_url" : "https://github.com/rapidsai/rapids-logger.git",
       "version" : "0.1.0"
     },
@@ -259,9 +259,9 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "17ba5ed882ed656180a0ac3e5cac2ad535c5956c",
+      "git_tag" : "0d6083b4f3e880b9b299c3ab083f563be00a085b",
       "git_url" : "https://github.com/rapidsai/rmm.git",
-      "version" : "25.02"
+      "version" : "25.04"
     },
     "spdlog" : 
     {


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-25.02` to create a PR keeping `branch-25.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.