### PR TITLE
Fix kudo bug when concating validity buffer.

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableMerger.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableMerger.java
@@ -400,6 +400,9 @@ class KudoTableMerger implements SimpleSchemaVisitor {
      * @param numRows Number of rows to append.
      */
     void appendAllValid(int numRows) {
+      if (numRows <= 0) {
+        return;
+      }
       int curDestIntIdx = destOffset + (totalRowCount / 32) * 4;
       int curDestBitIdx = totalRowCount % 32;
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoConcatValidityTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoConcatValidityTest.java
@@ -316,6 +316,34 @@ public class KudoConcatValidityTest {
         }
     }
 
+    @Test
+    public void testConcatValidityWithEmpty() {
+      Random random = getRandom();
+      int accuArrLen = 0;
+      // Be careful with startRow, they are carefully designed to cover all test cases.
+      try (HostMemoryBuffer dest = HostMemoryBuffer.allocate(64)) {
+        KudoTableMerger.ValidityBufferMerger merger = new KudoTableMerger.ValidityBufferMerger(dest, 0, new int[64], new int[64]);
+
+        ValidityConcatArray arr1 = new ValidityConcatArray(3, 512, random, "Array 1", accuArrLen);
+        arr1.appendToDest(merger);
+        accuArrLen += arr1.array.length;
+
+
+        // Should not throw
+        merger.appendAllValid(0);
+
+        try (HostMemoryBuffer src = HostMemoryBuffer.allocate(32)) {
+          // Should not throw
+          merger.copyValidityBuffer(src, 0, new SliceInfo(0, 0));
+        }
+
+        boolean[] result = getValidityBuffer(dest, accuArrLen);
+        arr1.verifyData(result);
+      }
+    }
+
+
+
     private static class ValidityConcatArray {
       private final int startRow;
       private final int nullCount;


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Closes  https://github.com/NVIDIA/spark-rapids/issues/12147

When concating validity buffer, we need to add a check for row count, otherwise it's possible to reach high address of destination buffer.
 
