### PR TITLE
Add more debug info for copy_if failure

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -133,7 +133,7 @@
             ],
             "type" : "diff"
           },
-          "issue" : "Improve Thrust scan compile times by reducing the number of kernels generated [https://github.com/rapidsai/cudf/pull/8183]"
+          "issue" : "More debug info for potential copy_if failures reported in [https://github.com/NVIDIA/spark-rapids/issues/12066]"
         }
       ],
       "version" : "2.7.0"

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -108,6 +108,32 @@
             "type" : "diff"
           },
           "issue" : "Improve Thrust scan compile times by reducing the number of kernels generated [https://github.com/rapidsai/cudf/pull/8183]"
+        },
+        {
+          "fixed_in" : "",
+          "inline_patch" : 
+          {
+            "content" : 
+            [
+              "diff --git a/thrust/thrust/system/cuda/detail/copy_if.h b/thrust/thrust/system/cuda/detail/copy_if.h",
+              "index 19dd014f5..3cba72c51 100644",
+              "--- a/thrust/thrust/system/cuda/detail/copy_if.h",
+              "+++ b/thrust/thrust/system/cuda/detail/copy_if.h",
+              "@@ -245,7 +245,8 @@ THRUST_RUNTIME_FUNCTION OutputIt copy_if(",
+              "     dispatch64_t::dispatch,",
+              "     num_items,",
+              "     (policy, temp_storage, temp_storage_bytes, first, stencil, output, predicate, num_items_fixed));",
+              "-  cuda_cub::throw_on_error(status, \"copy_if failed on 2nd step\");",
+              "+  auto err_msg = \"copy_if failed on 2nd step with temp_storage_bytes = \" + std::to_string(temp_storage_bytes) +",
+              "+                                     \" and num_items = \" + std::to_string(num_items);",
+              "+  cuda_cub::throw_on_error(status, err_msg.c_str());",
+              " ",
+              "   return output;",
+              " }"
+            ],
+            "type" : "diff"
+          },
+          "issue" : "Improve Thrust scan compile times by reducing the number of kernels generated [https://github.com/rapidsai/cudf/pull/8183]"
         }
       ],
       "version" : "2.7.0"


### PR DESCRIPTION
A new query failure was reported in https://github.com/NVIDIA/spark-rapids/issues/12066. This query failure was because of `cudaErrorIllegalAddress`. There were lots of call stacks reporting the same error in the logs, and all of them were pointing to async memory copies except for one. The call stack of the exception looked like this:

```
25/02/04 10:50:42 ERROR RapidsExecutorPlugin: Stopping the Executor based on exception being a fatal CUDA error: ai.rapids.cudf.CudaFatalException: copy_if failed on 2nd step: cudaErrorIllegalAddress: an illegal memory access was encountered
	at ai.rapids.cudf.Table.filter(Native Method)
	at ai.rapids.cudf.Table.filter(Table.java:2505)
	at org.apache.spark.sql.rapids.execution.HashOuterJoinIterator.$anonfun$getFinalBatch$5(GpuHashJoin.scala:923)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at org.apache.spark.sql.rapids.execution.HashOuterJoinIterator.$anonfun$getFinalBatch$4(GpuHashJoin.scala:922)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at org.apache.spark.sql.rapids.execution.HashOuterJoinIterator.$anonfun$getFinalBatch$3(GpuHashJoin.scala:920)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at org.apache.spark.sql.rapids.execution.HashOuterJoinIterator.$anonfun$getFinalBatch$2(GpuHashJoin.scala:919)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at org.apache.spark.sql.rapids.execution.HashOuterJoinIterator.$anonfun$getFinalBatch$1(GpuHashJoin.scala:918)
	at com.nvidia.spark.rapids.Arm$.withResource(Arm.scala:30)
	at org.apache.spark.sql.rapids.execution.HashOuterJoinIterator.getFinalBatch(GpuHashJoin.scala:914)
...
```

Given that this is the only non memory copy, it seems more suspicious than others. However, as I was never able to reproduce this issue locally, I am not sure where the error occurred exactly. As such, I'd like to add more debug information about the failure, so that we would at least know if we tried to access an address outside of memory allocated when the error occurs again.