### PR TITLE
Fix a corner case in the SparkResourceAdaptor state machine

### DIFF
--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkTest.java
@@ -1262,7 +1262,9 @@ public class RmmSparkTest {
         RmmSpark.removeDedicatedThreadAssociation(threadId, taskId);
       }
     });
-    assertEquals(11, rmmEventHandler.getAllocationCount());
+    // We retry the failed allocation for the last thread before going into
+    // the BUFN state. So we have 22 allocations instead of the expected 11
+    assertEquals(22, rmmEventHandler.getAllocationCount());
   }
 
   @Test


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/12158

But it is not there are no real test changes as a part of this because it we are not set up for testing spill in spark-rapids-jni.