### PR TITLE
make KudoTable extendable

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTable.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTable.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTable.java
@@ -32,8 +32,9 @@ import static java.util.Objects.requireNonNull;
  * data.
  */
 public class KudoTable implements AutoCloseable {
-  private final KudoTableHeader header;
-  private final HostMemoryBuffer buffer;
+  protected final KudoTableHeader header;
+  protected HostMemoryBuffer buffer;
+  protected long length = 0L;
 
   /**
    * Create a kudo table.
@@ -46,6 +47,9 @@ public class KudoTable implements AutoCloseable {
     requireNonNull(header, "Header must not be null");
     this.header = header;
     this.buffer = buffer;
+    if (buffer != null) {
+      this.length = buffer.getLength();
+    }
   }
 
   /**
@@ -82,6 +86,10 @@ public class KudoTable implements AutoCloseable {
 
   public HostMemoryBuffer getBuffer() {
     return buffer;
+  }
+
+  public long getLength() {
+    return length;
   }
 
   @Override


### PR DESCRIPTION
To finish https://github.com/NVIDIA/spark-rapids/issues/12215 without https://github.com/NVIDIA/spark-rapids/issues/12169,  we need to at least make KudoTable extendable, so that we can create a `SpillableKudoTable` in the plugin repo extending KudoTable, and encapsulate the spilling ability in `SpillableKudoTable`