### PR TITLE
Add parameter to control `start` and `length` validation in `GpuListSlice`

### DIFF
--- a/src/main/cpp/src/ListSliceJni.cpp
+++ b/src/main/cpp/src/ListSliceJni.cpp
@@ -20,7 +20,7 @@
 extern "C" {
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceIntInt(
-  JNIEnv* env, jclass, jlong input_column, jint start, jint length)
+  JNIEnv* env, jclass, jlong input_column, jint start, jint length, jboolean check_start_length)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   try {
@@ -29,13 +29,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     // The following constructor expects that the type of the input_column is LIST.
     // If the type is not LIST, an exception will be thrown.
     cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
-    return cudf::jni::release_as_jlong(spark_rapids_jni::list_slice(lcv, start, length));
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::list_slice(lcv, start, length, check_start_length));
   }
   CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceIntCol(
-  JNIEnv* env, jclass, jlong input_column, jint start, jlong length)
+  JNIEnv* env, jclass, jlong input_column, jint start, jlong length, jboolean check_start_length)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, length, "length column is null", 0);
@@ -46,13 +47,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     // If the type is not LIST, an exception will be thrown.
     cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     auto const& length_cv = *reinterpret_cast<cudf::column_view const*>(length);
-    return cudf::jni::release_as_jlong(spark_rapids_jni::list_slice(lcv, start, length_cv));
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::list_slice(lcv, start, length_cv, check_start_length));
   }
   CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceColInt(
-  JNIEnv* env, jclass, jlong input_column, jlong start, jint length)
+  JNIEnv* env, jclass, jlong input_column, jlong start, jint length, jboolean check_start_length)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, start, "start column is null", 0);
@@ -63,13 +65,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     // If the type is not LIST, an exception will be thrown.
     cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     auto const& start_cv = *reinterpret_cast<cudf::column_view const*>(start);
-    return cudf::jni::release_as_jlong(spark_rapids_jni::list_slice(lcv, start_cv, length));
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::list_slice(lcv, start_cv, length, check_start_length));
   }
   CATCH_STD(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceColCol(
-  JNIEnv* env, jclass, jlong input_column, jlong start, jlong length)
+  JNIEnv* env, jclass, jlong input_column, jlong start, jlong length, jboolean check_start_length)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, start, "start column is null", 0);
@@ -82,7 +85,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     cudf::lists_column_view lcv{*reinterpret_cast<cudf::column_view const*>(input_column)};
     auto const& start_cv  = *reinterpret_cast<cudf::column_view const*>(start);
     auto const& length_cv = *reinterpret_cast<cudf::column_view const*>(length);
-    return cudf::jni::release_as_jlong(spark_rapids_jni::list_slice(lcv, start_cv, length_cv));
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::list_slice(lcv, start_cv, length_cv, check_start_length));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/list_slice.cu
+++ b/src/main/cpp/src/list_slice.cu
@@ -109,7 +109,10 @@ CUDF_KERNEL void compute_starts_and_sizes_kernel(size_type const* offsets_of_inp
   // start cannot be 0
   start = start < 0 ? length_of_list + start : start - 1;
   // If the original start is out of [-length_of_list, length_of_list], will produce an empty list
-  // If `check_start_length` is false, set the output size to 0 to avoid out-of-bound access
+  // If `check_start_length` is false, will not check the legality of start and length.
+  // If original start is 0 or length is negative, set the output size to 0 to avoid out-of-bound
+  // access. The result for this row will be an empty list or null(since the output mask will be
+  // reset according to the input mask, start mask and length mask)
   if (start < 0 || start >= length_of_list || length <= 0) {
     d_sizes[tid] = 0;
     return;

--- a/src/main/cpp/src/list_slice.hpp
+++ b/src/main/cpp/src/list_slice.hpp
@@ -58,9 +58,9 @@ namespace spark_rapids_jni {
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
- * @param check_start_length Whether to check the validity of @p start and @p length, when set to
- * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
- * the behavior is undefined if there are any invalid values
+ * @param check_start_length Whether to validate @p start and @p length (defaults to true). If set
+ * to false, the caller must ensure @p start and @p length are valid; otherwise, the behavior is
+ * undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -111,9 +111,9 @@ std::unique_ptr<cudf::column> list_slice(
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
- * @param check_start_length Whether to check the validity of @p start and @p length, when set to
- * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
- * the behavior is undefined if there are any invalid values
+ * @param check_start_length Whether to validate @p start and @p length (defaults to true). If set
+ * to false, the caller must ensure @p start and @p length are valid; otherwise, the behavior is
+ * undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -164,9 +164,9 @@ std::unique_ptr<cudf::column> list_slice(
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
- * @param check_start_length Whether to check the validity of @p start and @p length, when set to
- * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
- * the behavior is undefined if there are any invalid values
+ * @param check_start_length Whether to validate @p start and @p length (defaults to true). If set
+ * to false, the caller must ensure @p start and @p length are valid; otherwise, the behavior is
+ * undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -227,9 +227,9 @@ std::unique_ptr<cudf::column> list_slice(
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
- * @param check_start_length Whether to check the validity of @p start and @p length, when set to
- * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
- * the behavior is undefined if there are any invalid values
+ * @param check_start_length Whether to validate @p start and @p length (defaults to true). If set
+ * to false, the caller must ensure @p start and @p length are valid; otherwise, the behavior is
+ * undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length

--- a/src/main/cpp/src/list_slice.hpp
+++ b/src/main/cpp/src/list_slice.hpp
@@ -58,6 +58,9 @@ namespace spark_rapids_jni {
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
+ * @param check_start_length Whether to check the validity of @p start and @p length, when set to
+ * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
+ * the behavior is undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -66,6 +69,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::lists_column_view const& input,
   cudf::size_type const start,
   cudf::size_type const length,
+  bool check_start_length           = true,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
@@ -107,6 +111,9 @@ std::unique_ptr<cudf::column> list_slice(
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
+ * @param check_start_length Whether to check the validity of @p start and @p length, when set to
+ * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
+ * the behavior is undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -115,6 +122,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::lists_column_view const& input,
   cudf::size_type const start,
   cudf::column_view const& length,
+  bool check_start_length           = true,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
@@ -156,6 +164,9 @@ std::unique_ptr<cudf::column> list_slice(
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
+ * @param check_start_length Whether to check the validity of @p start and @p length, when set to
+ * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
+ * the behavior is undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -164,6 +175,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::lists_column_view const& input,
   cudf::column_view const& start,
   cudf::size_type const length,
+  bool check_start_length           = true,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
@@ -215,6 +227,9 @@ std::unique_ptr<cudf::column> list_slice(
  * @param input The input lists column to slice
  * @param start The index of the first element to slice in each row(1-based, negative for reverse)
  * @param length The number of elements to slice in each row
+ * @param check_start_length Whether to check the validity of @p start and @p length, when set to
+ * false, the caller is responsible for ensuring the validity of @p start and @p length, otherwise
+ * the behavior is undefined if there are any invalid values
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate all returned device memory
  * @return The result column with elements in each row sliced according to @p start and @p length
@@ -223,6 +238,7 @@ std::unique_ptr<cudf::column> list_slice(
   cudf::lists_column_view const& input,
   cudf::column_view const& start,
   cudf::column_view const& length,
+  bool check_start_length           = true,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
@@ -207,7 +207,7 @@ public class GpuListSliceUtils {
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, ColumnView start, ColumnView length) {
-        return new ColumnVector(listSliceColCol(cv.getNativeView(), start.getNativeView(), length.getNativeView(), true));
+        return listSlice(cv, start, length, true);
     }
 
     public static ColumnVector listSlice(ColumnView cv, ColumnView start, ColumnView length, boolean checkStartLength) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
@@ -61,7 +61,7 @@ public class GpuListSliceUtils {
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, int start, int length) {
-        return new ColumnVector(listSliceIntInt(cv.getNativeView(), start, length, true));
+        return listSlice(cv, start, length, true);
     }
 
     public static ColumnVector listSlice(ColumnView cv, int start, int length, boolean checkStartLength) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
@@ -153,7 +153,7 @@ public class GpuListSliceUtils {
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, ColumnView start, int length) {
-        return new ColumnVector(listSliceColInt(cv.getNativeView(), start.getNativeView(), length, true));
+        return listSlice(cv, start, length, true);
     }
 
     public static ColumnVector listSlice(ColumnView cv, ColumnView start, int length, boolean checkStartLength) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
@@ -107,7 +107,7 @@ public class GpuListSliceUtils {
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, int start, ColumnView length) {
-        return new ColumnVector(listSliceIntCol(cv.getNativeView(), start, length.getNativeView(), true));
+        return listSlice(cv, start, length, true);
     }
 
     public static ColumnVector listSlice(ColumnView cv, int start, ColumnView length, boolean checkStartLength) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuListSliceUtils.java
@@ -55,10 +55,17 @@ public class GpuListSliceUtils {
      * @param cv    the column of lists to slice
      * @param start the integer offset at which to begin slicing
      * @param length the integer length of elements to include in the slice
+     * @param checkStartLength whether to check the validity of start and length, when set to false,
+     * the caller is responsible for ensuring the validity of start and length, otherwise the
+     * behavior is undefined if there are any invalid values
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, int start, int length) {
-        return new ColumnVector(listSliceIntInt(cv.getNativeView(), start, length));
+        return new ColumnVector(listSliceIntInt(cv.getNativeView(), start, length, true));
+    }
+
+    public static ColumnVector listSlice(ColumnView cv, int start, int length, boolean checkStartLength) {
+        return new ColumnVector(listSliceIntInt(cv.getNativeView(), start, length, checkStartLength));
     }
 
     /**
@@ -94,10 +101,17 @@ public class GpuListSliceUtils {
      * @param cv    the column of lists to slice
      * @param start the integer offset at which to begin slicing
      * @param length the column view specifying the lengths for each list slice
+     * @param checkStartLength whether to check the validity of start and length, when set to false,
+     * the caller is responsible for ensuring the validity of start and length, otherwise the
+     * behavior is undefined if there are any invalid values
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, int start, ColumnView length) {
-        return new ColumnVector(listSliceIntCol(cv.getNativeView(), start, length.getNativeView()));
+        return new ColumnVector(listSliceIntCol(cv.getNativeView(), start, length.getNativeView(), true));
+    }
+
+    public static ColumnVector listSlice(ColumnView cv, int start, ColumnView length, boolean checkStartLength) {
+        return new ColumnVector(listSliceIntCol(cv.getNativeView(), start, length.getNativeView(), checkStartLength));
     }
 
     /**
@@ -133,10 +147,17 @@ public class GpuListSliceUtils {
      * @param cv    the column of lists to slice
      * @param start the column view specifying the start offsets for each list slice
      * @param length the integer length of elements to include in the slice
+     * @param checkStartLength whether to check the validity of start and length, when set to false,
+     * the caller is responsible for ensuring the validity of start and length, otherwise the
+     * behavior is undefined if there are any invalid values
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, ColumnView start, int length) {
-        return new ColumnVector(listSliceColInt(cv.getNativeView(), start.getNativeView(), length));
+        return new ColumnVector(listSliceColInt(cv.getNativeView(), start.getNativeView(), length, true));
+    }
+
+    public static ColumnVector listSlice(ColumnView cv, ColumnView start, int length, boolean checkStartLength) {
+        return new ColumnVector(listSliceColInt(cv.getNativeView(), start.getNativeView(), length, checkStartLength));
     }
 
     /**
@@ -180,17 +201,24 @@ public class GpuListSliceUtils {
      * @param cv    the column of lists to slice
      * @param start the column view specifying the start offsets for each list slice
      * @param length the column view specifying the lengths for each list slice
+     * @param checkStartLength whether to check the validity of start and length, when set to false,
+     * the caller is responsible for ensuring the validity of start and length, otherwise the
+     * behavior is undefined if there are any invalid values
      * @return a new {@code ColumnVector} containing the sliced lists
      */
     public static ColumnVector listSlice(ColumnView cv, ColumnView start, ColumnView length) {
-        return new ColumnVector(listSliceColCol(cv.getNativeView(), start.getNativeView(), length.getNativeView()));
+        return new ColumnVector(listSliceColCol(cv.getNativeView(), start.getNativeView(), length.getNativeView(), true));
     }
 
-    private static native long listSliceIntInt(long listColumnView, int start, int length);
+    public static ColumnVector listSlice(ColumnView cv, ColumnView start, ColumnView length, boolean checkStartLength) {
+        return new ColumnVector(listSliceColCol(cv.getNativeView(), start.getNativeView(), length.getNativeView(), checkStartLength));
+    }
 
-    private static native long listSliceIntCol(long listColumnView, int start, long lengthColumnView);
+    private static native long listSliceIntInt(long listColumnView, int start, int length, boolean check_start_length);
 
-    private static native long listSliceColInt(long listColumnView, long startColumnView, int length);
+    private static native long listSliceIntCol(long listColumnView, int start, long lengthColumnView, boolean check_start_length);
 
-    private static native long listSliceColCol(long listColumnView, long startColumnView, long lengthColumnView);
+    private static native long listSliceColInt(long listColumnView, long startColumnView, int length, boolean check_start_length);
+
+    private static native long listSliceColCol(long listColumnView, long startColumnView, long lengthColumnView, boolean check_start_length);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
Contributes to https://github.com/NVIDIA/spark-rapids/issues/12203

This PR adds a parameter to control whether to validate the legality of `start` and `length` for `GpuListSlice`. 

Since the plugin side needs to check the validity of `start` and `length`, this parameter is added to avoid double validation.