### PR TITLE
Improve docker image to enable `gcc-toolset` by default

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -23,17 +23,23 @@
 ARG CUDA_VERSION=11.8.0
 ARG OS_RELEASE=8
 ARG TARGETPLATFORM=linux/amd64
+
+# Software versions for development
+ARG TOOLSET_VERSION=11
+ARG CMAKE_VERSION=3.30.4
+ARG CCACHE_VERSION=4.6
+
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
-ARG TOOLSET_VERSION=11
+
 ### Install basic requirements
 # pin urllib3<2.0 for https://github.com/psf/requests/issues/6432
 RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSION} python39 zlib-devel maven tar wget patch ninja-build git && \
   alternatives --set python /usr/bin/python3 && \
   python -m pip install requests 'urllib3<2.0'
 
-# Enable the toolset by default for all users
+# Enable the toolset by default for bash shell
 RUN echo "source scl_source enable gcc-toolset-${TOOLSET_VERSION}" >> /etc/bashrc
 
 # Execute every time a new non-interactive bash shell is started to enable gcc-toolset
@@ -42,8 +48,6 @@ ENV BASH_ENV=/etc/bashrc
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 
-# 3.22.3: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
-ARG CMAKE_VERSION=3.30.4
 # default x86_64 from x86 build, aarch64 cmake for arm build
 ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
@@ -52,7 +56,6 @@ RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/down
 ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
 
 # ccache for interactive builds
-ARG CCACHE_VERSION=4.6
 RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
    tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
    rm ccache-${CCACHE_VERSION}.tar.gz && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -24,14 +24,17 @@ ARG CUDA_VERSION=11.8.0
 ARG OS_RELEASE=8
 ARG TARGETPLATFORM=linux/amd64
 
-# Software versions for development
+# multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
+# check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
+FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
+
+### Software versions for development
 ARG TOOLSET_VERSION=11
 ARG CMAKE_VERSION=3.30.4
 ARG CCACHE_VERSION=4.6
 
-# multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
-# check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
-FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
+# Default x86_64 from x86 build, aarch64 cmake for arm build
+ARG CMAKE_ARCH=x86_64
 
 ### Install basic requirements
 # pin urllib3<2.0 for https://github.com/psf/requests/issues/6432
@@ -48,8 +51,6 @@ ENV BASH_ENV=/etc/bashrc
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 
-# default x86_64 from x86 build, aarch64 cmake for arm build
-ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    tar zxf cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    rm cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -32,6 +32,13 @@ ARG TOOLSET_VERSION=11
 RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSION} python39 zlib-devel maven tar wget patch ninja-build git && \
   alternatives --set python /usr/bin/python3 && \
   python -m pip install requests 'urllib3<2.0'
+
+# Enable the toolset by default for all users
+RUN echo "source scl_source enable gcc-toolset-${TOOLSET_VERSION}" >> /etc/bashrc
+
+# Execute every time a new non-interactive bash shell is started to enable gcc-toolset
+ENV BASH_ENV=/etc/bashrc
+
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -54,7 +54,9 @@ RUN mkdir -m 777 /usr/local/rapids /rapids
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    tar zxf cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    rm cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz
-ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
+
+# Make version-less alias for external reference such as when cmake is called by an IDE outside of the container
+RUN ln -s /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin/cmake /usr/local/bin/cmake
 
 # ccache for interactive builds
 RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \


### PR DESCRIPTION
This modify the docker image to enable `gcc-toolset` by default for non-interactive containers. By doing so, we can invoke the container's `cmake ` with the correct version of `gcc`:
```
❯ docker run spark-rapids-jni-build:11.8.0-devel-rockylinux8 bash -c "cmake --version && g++ --version"
==========
== CUDA ==
==========

CUDA Version 11.8.0
...
cmake version 3.28.6
...
g++ (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)
```

Previously, this call executes `cmake` with the default system's `gcc` version `8.5`.