### PR TITLE
Add sanity check for kudo offset buffer

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializer.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializer.java
@@ -161,7 +161,7 @@ import java.util.stream.IntStream;
  *  </ol>
  */
 public class KudoSerializer {
-
+  static final boolean KUDO_SANITY_CHECK = Boolean.getBoolean("com.nvidia.spark.rapids.jni.kudo.check");
   private static final byte[] PADDING = new byte[64];
   private static final BufferType[] ALL_BUFFER_TYPES =
       new BufferType[] {BufferType.VALIDITY, BufferType.OFFSET,

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableMerger.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableMerger.java
@@ -234,17 +234,19 @@ class KudoTableMerger implements SimpleSchemaVisitor {
           int lastOffset = offsetOf(tableIdx, rowCnt);
           long inputOffset = offsetOffsets[tableIdx];
 
-          if (firstOffset < 0 || lastOffset < firstOffset) {
-            int[] offsetValues = new int[rowCnt];
-            for (int i = 0; i < rowCnt; i++) {
-              offsetValues[i] = offsetOf(tableIdx, i);
+          if (KUDO_SANITY_CHECK) {
+            if (firstOffset < 0 || lastOffset < firstOffset) {
+              int[] offsetValues = new int[rowCnt];
+              for (int i = 0; i < rowCnt; i++) {
+                offsetValues[i] = offsetOf(tableIdx, i);
+              }
+              LOG.error("Invalid offset values: [{}], table index: {}, row count: {}, " +
+                      "first offset: {}, last offset: {}, kudo table header: {}",
+                  Arrays.toString(offsetValues), tableIdx, rowCnt, firstOffset, lastOffset,
+                  kudoTables[tableIdx].getHeader());
+              throw new IllegalArgumentException("Invalid kudo offset buffer content, first offset: "
+                  + firstOffset + ", last offset: " + lastOffset);
             }
-            LOG.error("Invalid offset values: [{}], table index: {}, row count: {}, " +
-                    "first offset: {}, last offset: {}, kudo table header: {}",
-                Arrays.toString(offsetValues), tableIdx, rowCnt, firstOffset, lastOffset,
-                kudoTables[tableIdx].getHeader());
-            throw new IllegalArgumentException("Invalid kudo offset buffer content, first offset: "
-                + firstOffset + ", last offset: " + lastOffset);
           }
 
           while (rowCnt > 0) {


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Related https://github.com/NVIDIA/spark-rapids/issues/12369

Add sanity check for offset values.
