### PR TITLE
fix premature concensus in OOM state machine due to TIMED_WAITING thread state

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/ThreadStateRegistry.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ThreadStateRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/ThreadStateRegistry.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/ThreadStateRegistry.java
@@ -54,13 +54,15 @@ class ThreadStateRegistry {
         // fall through
       case WAITING:
         // fall through
-      case TIMED_WAITING:
-        return true;
       case TERMINATED:
         // Technically there is a race with `!t.isAlive` check above, and dead is as good as
         // blocked.
         return true;
       default:
+        // For the case of TIMED_WAITING, we don't want to consider it blocked because with
+        // a backend producer thread blocking on a BlockingQueue, a task (even if it is actually
+        // running) will be treated as a blocked task. So this will cause premature concensus on
+        // "all blocked" state in OOM state machine.
         return false;
     }
   }


### PR DESCRIPTION
This PR contributes to https://github.com/NVIDIA/spark-rapids/issues/12311 by fixing a premature case caused by uncessarily treating TIMED_WAITING state as a blocked state