### PR TITLE
Fix path to `rapids_config.cmake`

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CUDF_CPP_BUILD_DIR
 # libcudf's kvikio dependency requires this to be set when statically linking CUDA runtime
 set(CUDA_STATIC_RUNTIME ON)
 
-include("${CUDF_DIR}/rapids_config.cmake")
+include("${CUDF_DIR}/cmake/rapids_config.cmake")
 include(rapids-cmake)
 include(rapids-cpm)
 include(rapids-cuda)


### PR DESCRIPTION
As cudf has move its `rapids_config.cmake`, we need to update the reference path to it.