### PR TITLE
Replace calls to cudf's deprecated functions

### DIFF
--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1054,7 +1054,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
     rmm::exec_policy_nosync(stream), d_error_check.begin(), d_error_check.end(), 0);
 
   kernel_launcher::exec(input, d_path_data, d_max_path_depth_exceeded, stream);
-  auto h_error_check = cudf::detail::make_host_vector_sync(d_error_check, stream);
+  auto h_error_check = cudf::detail::make_host_vector(d_error_check, stream);
   auto has_no_oob    = check_error(h_error_check);
 
   std::vector<cudf::device_span<thrust::pair<char const*, cudf::size_type> const>>
@@ -1136,7 +1136,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
   thrust::uninitialized_fill(
     rmm::exec_policy_nosync(stream), d_error_check.begin(), d_error_check.end(), 0);
   kernel_launcher::exec(input, d_path_data, d_max_path_depth_exceeded, stream);
-  h_error_check = cudf::detail::make_host_vector_sync(d_error_check, stream);
+  h_error_check = cudf::detail::make_host_vector(d_error_check, stream);
   has_no_oob    = check_error(h_error_check);
 
   // The last kernel call should not encounter any out-of-bound write.

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -329,7 +329,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
                        check_valid[idx] = static_cast<int8_t>(frequencies[idx] > 0);
                      });
 
-  auto const h_checks = cudf::detail::make_std_vector_sync(check_invalid_and_zero, stream);
+  auto const h_checks = cudf::detail::make_std_vector(check_invalid_and_zero, stream);
   CUDF_EXPECTS(!h_checks.front(),  // check invalid (negative) frequencies
                "The input frequencies must not contain negative values.",
                std::invalid_argument);
@@ -439,10 +439,9 @@ std::unique_ptr<cudf::column> percentile_from_histogram(cudf::column_view const&
   auto const data_col       = cudf::structs_column_view{histograms}.get_sliced_child(0);
   auto const counts_col     = cudf::structs_column_view{histograms}.get_sliced_child(1);
 
-  auto const default_mr = rmm::mr::get_current_device_resource();
-  auto const d_data     = cudf::column_device_view::create(data_col, stream);
-  auto const d_percentages =
-    cudf::detail::make_device_uvector_sync(percentages, stream, default_mr);
+  auto const default_mr    = rmm::mr::get_current_device_resource();
+  auto const d_data        = cudf::column_device_view::create(data_col, stream);
+  auto const d_percentages = cudf::detail::make_device_uvector(percentages, stream, default_mr);
 
   // Attach histogram labels to the input.
   auto histogram_labels =

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -78,8 +78,8 @@ constexpr auto MAX_STRING_BLOCKS                   = MAX_BATCH_SIZE;
 #pragma nv_diag_suppress static_var_with_dynamic_init
 
 using namespace cudf;
+using detail::make_device_uvector;
 using detail::make_device_uvector_async;
-using detail::make_device_uvector_sync;
 using rmm::device_uvector;
 
 namespace spark_rapids_jni {
@@ -222,8 +222,7 @@ build_string_row_offsets(table_view const& tbl,
                     stencil,
                     std::back_inserter(offsets_iterators),
                     thrust::identity<bool>{});
-    return make_device_uvector_sync(
-      offsets_iterators, stream, rmm::mr::get_current_device_resource());
+    return make_device_uvector(offsets_iterators, stream, rmm::mr::get_current_device_resource());
   }();
 
   auto const num_columns = static_cast<size_type>(d_offsets_iterators.size());

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -1771,7 +1771,7 @@ std::unique_ptr<cudf::table> shuffle_assemble(shuffle_split_metadata const& meta
   // assembled rows, null counts, etc
   auto [column_info, column_instance_info, per_partition_metadata_size] =
     assemble_build_column_info(metadata, partitions, partition_offsets, stream, temp_mr);
-  auto h_column_info = cudf::detail::make_std_vector_sync(column_info, stream);
+  auto h_column_info = cudf::detail::make_std_vector(column_info, stream);
 
   // generate the (empty) output buffers based on the column info.
   // generate the copy batches to be performed to copy data to the output buffers


### PR DESCRIPTION
This fixes compiler warning when calling to cudf's deprecated functions, replacing these function calls by calling to the alternative ones. These deprecated functions are just renamed so there should not be any changes in the implementation.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/3144.