### PR TITLE
Add utils for cast string to timestamp

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -52,7 +52,7 @@ public class GpuTimeZoneDB {
   // For the timezone database, we store the transitions in a ColumnVector that is a list of 
   // structs. The type of this column vector is:
   //   LIST<STRUCT<utcInstant: int64, localInstant: int64, offset: int32>>
-  private static Map<String, Integer> zoneIdToTable;
+  private static java.util.Map<String, Integer> zoneIdToTable;
 
   // host column STRUCT<tz_name: string, index_to_transition_table: int, is_DST: int8>,
   // sorted by time zone, is used to query index to transition table and if tz is DST
@@ -452,7 +452,7 @@ public class GpuTimeZoneDB {
    * @param zoneIdToTable   is a map from non-normalized time zone to index in transition table
    */
   private static HostColumnVector getTimeZoneInfo(List<String> sortedTimezones,
-      Map<String, Integer> zoneIdToTable) {
+      java.util.Map<String, Integer> zoneIdToTable) {
     HostColumnVector.DataType type = new HostColumnVector.StructType(false,
         new HostColumnVector.BasicType(false, DType.STRING),
         new HostColumnVector.BasicType(false, DType.INT32),

--- a/src/test/java/com/nvidia/spark/rapids/jni/TimeZoneTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/TimeZoneTest.java
@@ -377,5 +377,17 @@ public class TimeZoneTest {
       assertColumnsAreEqual(expected, actual);
     }
   }
+
+    @Test
+  void nonNonNormalizedTimezone() {
+    GpuTimeZoneDB.verifyDatabaseCached();
+    List transitions;
+
+    transitions = GpuTimeZoneDB.getHostTransitions("Etc/GMT");
+    assertNotNull(transitions);
+
+    transitions = GpuTimeZoneDB.getHostTransitions("Z");
+    assertNotNull(transitions);
+  }
   
 }


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/10035
closes https://github.com/NVIDIA/spark-rapids-jni/issues/1721


### Description
Casting string to timestamp requires more info in `GpuTimeZoneDB`:

1. If a timezone is DST

  Requires checking timezones in timestamp strings are all non-DST
  if has any timestamp is greater than the threshold e.g.: 2200,  it means do not support for all timezones.  We then should check if there is any non-DST timezone, if has: 1. fallback to cpu. 2. throw exception not support. 

2. Require non-normalized timezone names
Currently GpuTimeZoneDB only records normalized timezone names.
But timestamp strings can contains non-normalized timezone names.

E.g.:
  ZoneId.of("Etc/GMT").normalized.getId = Z;
  ZoneId.of("Etc/GMT+0").normalized.getId = Z
Both '2025-01-01 00:00:00 Etc/GMT' and '2025-01-01 00:00:00 Z' are valid timestamp strings.
`zoneIdToTable` should have entries:
Z -> index_of_Z
Etc/GMT -> index_of_Z
Etc/GMT+0 -> index_of_Z
Currently only has the first entry.

3. `zoneIdToTable` should also record short IDs.

ZoneId.SHORT_IDS

4. Make sure all the timezones are loaded.

### Changes
1.  Add timeZoneInfo which can query DST and transition index
```scala
  // host column STRUCT<tz_name: string, index_to_transition_table: int, is_DST: int8>,
  // sorted by time zone, is used to query index to transition table and if tz is DST
  private static HostColumnVector timeZoneInfo;
```

2. Let `zoneIdToTable` record non-normalized timezones

3. Record shoort IDs

```scala
zoneId = ZoneId.of(tz).normalized()
```
=>
```scala
zoneId = ZoneId.of(nonNormalizedTz, ZoneId.SHORT_IDS).normalized()
```

4. Make sure all the timezones are loaded.
Casting string with timezone to timestamp needs loading all timezone is successful. All valid time zones may be included in the timestamp strings.
If it has a timezone unloaded, then kernel can not decide if the missed timezone is valid.

Signed-off-by: Chong Gao <res_life@163.com>