### PR TITLE
Fix compile warnings and errors

### DIFF
--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/functional>
 #include <thrust/binary_search.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/gather.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -431,7 +431,7 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
   auto [result_bitmask, null_count] =
     cudf::detail::valid_if(null_mask.begin(),
                            null_mask.end(),
-                           thrust::identity<bool>{},
+                           cuda::std::identity{},
                            cudf::get_default_stream(),
                            rmm::mr::get_current_device_resource());
 
@@ -515,7 +515,7 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
   auto [result_bitmask, null_count] =
     cudf::detail::valid_if(null_mask.begin(),
                            null_mask.end() - 1,
-                           thrust::identity<bool>{},
+                           cuda::std::identity{},
                            cudf::get_default_stream(),
                            rmm::mr::get_current_device_resource());
 
@@ -639,7 +639,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
           auto valids = valid_dist(engine, num_rows);
           return cudf::detail::valid_if(valids.begin(),
                                         valids.end(),
-                                        thrust::identity<bool>{},
+                                        cuda::std::identity{},
                                         cudf::get_default_stream(),
                                         rmm::mr::get_current_device_resource());
         }
@@ -671,7 +671,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
 }
 
 template <typename T>
-struct clamp_down : public thrust::unary_function<T, T> {
+struct clamp_down {
   T max;
   clamp_down(T max) : max(max) {}
   __host__ __device__ T operator()(T x) const { return min(x, max); }
@@ -729,7 +729,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
 
     auto [null_mask, null_count] = cudf::detail::valid_if(valids.begin(),
                                                           valids.end(),
-                                                          thrust::identity<bool>{},
+                                                          cuda::std::identity{},
                                                           cudf::get_default_stream(),
                                                           rmm::mr::get_current_device_resource());
     list_column                  = cudf::make_lists_column(

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@
 #include <thrust/for_each.h>
 #include <thrust/generate.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/optional.h>
 #include <thrust/transform.h>
 
 using namespace cudf;

--- a/src/main/cpp/src/datetime_truncate.cu
+++ b/src/main/cpp/src/datetime_truncate.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <cuda/std/optional>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
@@ -303,7 +303,7 @@ std::unique_ptr<cudf::column> truncate_datetime(cudf::column_view const& datetim
   }
 
   auto [null_mask, null_count] =
-    cudf::detail::valid_if(validity.begin(), validity.end(), thrust::identity{}, stream, mr);
+    cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
   output->set_null_mask(null_count > 0 ? std::move(null_mask) : rmm::device_buffer{0, stream, mr},
                         null_count);
   return output;

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 #include <thrust/tabulate.h>
 
 #include <cmath>
@@ -1409,7 +1409,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
                                stream);
 
   auto [null_mask, null_count] =
-    cudf::detail::valid_if(validity.begin(), validity.end(), thrust::identity{}, stream, mr);
+    cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
   if (null_count > 0) { output->set_null_mask(std::move(null_mask), null_count); }
 
   return {std::move(output), has_failure.value(stream)};

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -97,25 +97,6 @@ struct chunked256 {
 
   inline __device__ bool gte_unsigned(chunked256 const& other) const { return !lt_unsigned(other); }
 
-  inline __device__ int leading_zeros() const
-  {
-    if (sign() < 0) {
-      chunked256 tmp = *this;
-      tmp.negate();
-      return tmp.leading_zeros();
-    }
-
-    int ret = 0;
-    for (int i = 3; i >= 0; i--) {
-      if (chunks[i] == 0) {
-        ret += 64;
-      } else {
-        ret += __clzll(chunks[i]);
-        return ret;
-      }
-    }
-  }
-
   inline __device__ __int128_t as_128_bits() const
   {
     return (static_cast<__int128_t>(chunks[1]) << 64) | chunks[0];
@@ -516,6 +497,7 @@ inline __device__ chunked256 pow_ten(int exp)
     default:
       // This is not a supported value...
       assert(0);
+      return chunked256();
   }
 }
 

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@
 
 #include <cub/device/device_segmented_reduce.cuh>
 #include <cuda/functional>
+#include <cuda/std/functional>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tabulate.h>
@@ -188,7 +188,7 @@ std::unique_ptr<cudf::column> cast_strings_to_booleans(cudf::column_view const& 
     });
 
   auto [null_mask, null_count] =
-    cudf::detail::valid_if(validity.begin(), validity.end(), thrust::identity{}, stream, mr);
+    cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
   output->set_null_mask(null_count > 0 ? std::move(null_mask) : rmm::device_buffer{0, stream, mr},
                         null_count);
 
@@ -239,7 +239,7 @@ std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& 
   auto const [null_mask, null_count] =
     cudf::detail::valid_if(valids.begin(),
                            valids.end(),
-                           thrust::identity{},
+                           cuda::std::identity{},
                            stream,
                            cudf::get_current_device_resource_ref());
   // If the null count doesn't change, just use the input column for conversion.

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -32,9 +32,9 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table_view.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/binary_search.h>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
@@ -218,7 +218,7 @@ struct percentile_dispatcher {
     }
 
     auto [null_mask, null_count] = cudf::detail::valid_if(
-      out_validities.begin(), out_validities.end(), thrust::identity{}, stream, mr);
+      out_validities.begin(), out_validities.end(), cuda::std::identity{}, stream, mr);
     if (null_count > 0) { return {std::move(percentiles), std::move(null_mask), null_count}; }
 
     return {std::move(percentiles), rmm::device_buffer{}, 0};
@@ -409,7 +409,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
     // the null mask.
     // By doing so, the input rows corresponding to zero frequencies will be output as empty lists.
     auto [null_mask, null_count] = cudf::detail::valid_if(
-      check_valid.begin(), check_valid.end(), thrust::identity{}, stream, default_mr);
+      check_valid.begin(), check_valid.end(), cuda::std::identity{}, stream, default_mr);
     lists_histograms->set_null_mask(std::move(null_mask), null_count);
     lists_histograms = cudf::detail::purge_nonempty_nulls(lists_histograms->view(), stream, mr);
     lists_histograms->set_null_mask(rmm::device_buffer{}, 0);
@@ -421,7 +421,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
 
     // We nullify the values corresponding to zero frequencies.
     auto [null_mask, null_count] = cudf::detail::valid_if(
-      check_valid.begin(), check_valid.end(), thrust::identity{}, stream, mr);
+      check_valid.begin(), check_valid.end(), cuda::std::identity{}, stream, mr);
     return make_structs_histogram(std::move(null_mask), null_count);
   }
 }

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_histogram.cuh>
+#include <cuda/std/functional>
 #include <thrust/find.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
@@ -190,7 +190,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
   auto const delimiter = static_cast<char>(thrust::distance(zero_level_it, first_zero_count_pos));
 
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    is_valid_input.begin(), is_valid_input.end(), thrust::identity{}, stream, default_mr);
+    is_valid_input.begin(), is_valid_input.end(), cuda::std::identity{}, stream, default_mr);
   // If the null count doesn't change, just use the input column for concatenation.
   auto const input_applied_null =
     null_count == input.null_count()

--- a/src/main/cpp/src/number_converter.cu
+++ b/src/main/cpp/src/number_converter.cu
@@ -94,6 +94,7 @@ __device__ char byte_to_char(int byte_value)
     return static_cast<char>('A' + (byte_value - 10));
   } else {
     cudf_assert(false);
+    return 0;
   }
 }
 

--- a/src/main/cpp/src/number_converter.cu
+++ b/src/main/cpp/src/number_converter.cu
@@ -22,6 +22,7 @@
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/types.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/count.h>
 #include <thrust/for_each.h>
 #include <thrust/pair.h>
@@ -395,7 +396,7 @@ std::unique_ptr<cudf::column> convert_impl(cudf::size_type num_rows,
 
   // make null mask and null count
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    out_mask.data(), out_mask.data() + out_mask.size(), thrust::identity<bool>{}, stream, mr);
+    out_mask.data(), out_mask.data() + out_mask.size(), cuda::std::identity{}, stream, mr);
 
   return cudf::make_strings_column(num_rows,
                                    std::move(offsets),

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -42,6 +42,7 @@
 #include <cooperative_groups.h>
 #include <cuda/barrier>
 #include <cuda/functional>
+#include <cuda/std/functional>
 #include <thrust/binary_search.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -221,7 +222,7 @@ build_string_row_offsets(table_view const& tbl,
                     itr + tbl.num_columns(),
                     stencil,
                     std::back_inserter(offsets_iterators),
-                    thrust::identity<bool>{});
+                    cuda::std::identity{});
     return make_device_uvector(offsets_iterators, stream, rmm::mr::get_current_device_resource());
   }();
 

--- a/src/main/cpp/tests/hyper_log_log_plus_plus.cu
+++ b/src/main/cpp/tests/hyper_log_log_plus_plus.cu
@@ -102,7 +102,7 @@ std::unique_ptr<cudf::column> make_struct_column_from_scalars(
 
   // get column pointers from struct scalars
   auto col_ptrs   = get_column_ptrs_from_struct_scalars(scalars, num_longs_in_scalar);
-  auto d_col_ptrs = cudf::detail::make_device_uvector_sync(col_ptrs, stream, mr);
+  auto d_col_ptrs = cudf::detail::make_device_uvector(col_ptrs, stream, mr);
 
   // create output columns
   auto const results_iter = cudf::detail::make_counting_transform_iterator(0, [&](int i) {
@@ -120,7 +120,7 @@ std::unique_ptr<cudf::column> make_struct_column_from_scalars(
     });
   auto host_results_pointers =
     std::vector<int64_t*>(host_results_pointer_iter, host_results_pointer_iter + children.size());
-  auto d_output = cudf::detail::make_device_uvector_sync(host_results_pointers, stream, mr);
+  auto d_output = cudf::detail::make_device_uvector(host_results_pointers, stream, mr);
 
   // concatenate struct scalars into a struct column
   concat_struct_scalars_to_struct_column_kernel<<<1, 1, 0, stream.value()>>>(


### PR DESCRIPTION
This fixes a few things:
 * Fixes some compile warnings that are due to using deprecated functions.
 * Fixes compile errors that show up when upgrading to CUDA 12.8.