### PR TITLE
more loggings in OOM state machine

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1674,7 +1674,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
 
       logger->info(
         "deadlock state is reached with all_task_ids: {} ({}), blocked_task_ids: {} ({}), "
-        "bufn_task_ids: {} ({}), threads: ({})",
+        "bufn_task_ids: {} ({}), threads: {} ({})",
         setToString(all_task_ids), all_task_ids.size(),
         setToString(blocked_task_ids), blocked_task_ids.size(),
         setToString(bufn_task_ids), bufn_task_ids.size(),

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1674,7 +1674,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
 
       logger->info(
         "deadlock state is reached with all_task_ids: {} ({}), blocked_task_ids: {} ({}), "
-        "bufn_task_ids: {} ({}), threads size: ({})",
+        "bufn_task_ids: {} ({}), threads: ({})",
         setToString(all_task_ids), all_task_ids.size(),
         setToString(blocked_task_ids), blocked_task_ids.size(),
         setToString(bufn_task_ids), bufn_task_ids.size(),

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1678,7 +1678,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
         setToString(all_task_ids), all_task_ids.size(),
         setToString(blocked_task_ids), blocked_task_ids.size(),
         setToString(bufn_task_ids), bufn_task_ids.size(),
-        setToString(threadsKeySet),threads.size());
+        setToString(threadsKeySet), threads.size());
     }
     return ret;
   }

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -397,9 +397,9 @@ class full_thread_state {
   std::string to_string() const
   {
     std::stringstream ss;
-    ss << "thread_id: " << thread_id << ", task_id: " << task_id
-       << ", state: " << as_str(state) << ", is_for_shuffle: " << is_for_shuffle
-       << ", pool_blocked: " << pool_blocked << ", is_cpu_alloc: " << is_cpu_alloc
+    ss << "thread_id: " << thread_id << ", task_id: " << task_id << ", state: " << as_str(state)
+       << ", is_for_shuffle: " << is_for_shuffle << ", pool_blocked: " << pool_blocked
+       << ", is_cpu_alloc: " << is_cpu_alloc
        << ", is_retry_alloc_before_bufn: " << is_retry_alloc_before_bufn;
     return ss.str();
   }
@@ -1564,7 +1564,8 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
 
   // Function to convert a set (ordered or unordered) to a concatenated string
   template <typename SetType>
-  std::string setToString(const SetType& set, const std::string& separator = ",") {
+  std::string setToString(const SetType& set, const std::string& separator = ",")
+  {
     // Use std::ostringstream for efficient string building.
     std::ostringstream oss;
 
@@ -1572,9 +1573,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
     // Iterate through the set.
     for (auto it = set.begin(); it != set.end(); ++it) {
       oss << *it;
-      if (std::next(it) != set.end()) {
-        oss << separator;
-      }
+      if (std::next(it) != set.end()) { oss << separator; }
     }
     oss << "}";
     return oss.str();
@@ -1666,31 +1665,34 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
     // Now if all of the tasks are blocked, then we need to break a deadlock
     bool ret = all_task_ids.size() == blocked_task_ids.size() && !all_task_ids.empty();
     if (ret) {
-
       std::set<long> threadsKeySet;
-      std::transform(threads.begin(), threads.end(),
+      std::transform(threads.begin(),
+                     threads.end(),
                      std::inserter(threadsKeySet, threadsKeySet.begin()),
                      [](const auto& pair) { return pair.first; });
 
       logger->info(
         "deadlock state is reached with all_task_ids: {} ({}), blocked_task_ids: {} ({}), "
         "bufn_task_ids: {} ({}), threads: {} ({})",
-        setToString(all_task_ids), all_task_ids.size(),
-        setToString(blocked_task_ids), blocked_task_ids.size(),
-        setToString(bufn_task_ids), bufn_task_ids.size(),
-        setToString(threadsKeySet), threads.size());
+        setToString(all_task_ids),
+        all_task_ids.size(),
+        setToString(blocked_task_ids),
+        blocked_task_ids.size(),
+        setToString(bufn_task_ids),
+        bufn_task_ids.size(),
+        setToString(threadsKeySet),
+        threads.size());
     }
     return ret;
   }
 
-  void log_all_threads_states() {
+  void log_all_threads_states()
+  {
     std::stringstream oss;
     oss << "States of all threads: ";
     for (auto it = threads.begin(); it != threads.end(); ++it) {
       oss << it->second.to_string();
-      if (std::next(it) != threads.end()) {
-        oss << ";";
-      }
+      if (std::next(it) != threads.end()) { oss << ";"; }
     }
     logger->info(oss.str());
   }
@@ -1739,7 +1741,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
             // allocation, instead of going to BUFN.
             thread->second.is_retry_alloc_before_bufn = true;
             logger->info("thread (id: {}) is_retry_alloc_before_bufn set to true",
-                          thread_id_to_bufn);
+                         thread_id_to_bufn);
             transition(thread->second, thread_state::THREAD_RUNNING);
           } else {
             log_all_threads_states();

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1670,7 +1670,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
     bool ret = all_task_ids.size() == blocked_task_ids.size() && !all_task_ids.empty();
     if (ret && is_log_enabled) {
       std::set<long> threads_key_set;
-      for (auto const &[k, v]: threads) {
+      for (auto const& [k, v] : threads) {
         threads_key_set.insert(k);
       }
       auto note = fmt::format(

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -21,6 +21,10 @@ import ai.rapids.cudf.NativeDepsLoader;
 import ai.rapids.cudf.RmmDeviceMemoryResource;
 import ai.rapids.cudf.RmmEventHandlerResourceAdaptor;
 import ai.rapids.cudf.RmmWrappingDeviceMemoryResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 
 /**
  * This is an internal class that provides an interface to a C++ spark_resource_adaptor class that
@@ -31,6 +35,7 @@ public class SparkResourceAdaptor
   static {
     NativeDepsLoader.loadNativeDeps();
   }
+  private static final Logger log = LoggerFactory.getLogger(SparkResourceAdaptor.class);
   /*
    * Please note that this class itself is not 100% thread safe. Most of the thread safety is handled
    * by RmmSpark, as no one else should interact with this class directly. There are a few functions
@@ -121,6 +126,9 @@ public class SparkResourceAdaptor
    * @param taskId the task ID this thread is associated with.
    */
   public void startDedicatedTaskThread(long threadId, long taskId) {
+    log.info("startDedicatedTaskThread: threadId: {}, task id: {}",
+        threadId, taskId
+    );
     startDedicatedTaskThread(getHandle(), threadId, taskId);
   }
 
@@ -152,6 +160,9 @@ public class SparkResourceAdaptor
    */
   public void poolThreadWorkingOnTasks(boolean isForShuffle, long threadId, long[] taskIds) {
     if (taskIds.length > 0) {
+      log.info("poolThreadWorkingOnTasks: threadId: {}, task id: {}",
+          threadId, Arrays.toString(taskIds)
+          );
       poolThreadWorkingOnTasks(getHandle(), isForShuffle, threadId, taskIds);
     }
   }

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -162,7 +162,7 @@ public class SparkResourceAdaptor
     if (taskIds.length > 0) {
       log.info("poolThreadWorkingOnTasks: threadId: {}, task id: {}",
           threadId, Arrays.toString(taskIds)
-          );
+      );
       poolThreadWorkingOnTasks(getHandle(), isForShuffle, threadId, taskIds);
     }
   }


### PR DESCRIPTION
add some loggings in OOM state machine so that it will become more friendly for troubleshooting GPU/CPU OOM because of state machine issues.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
