### PR TITLE
Add deepwiki badge [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository contains native support code for the
 [RAPIDS Accelerator for Apache Spark](https://github.com/NVIDIA/spark-rapids).
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/spark-rapids-jni)
+
 ## Building From Source
 
 See the [build instructions in the contributing guide](CONTRIBUTING.md#building-from-source).


### PR DESCRIPTION
add deepwiki badge to enable weekly auto-refresh of https://deepwiki.com/NVIDIA/spark-rapids-jni

<img width="527" alt="image" src="https://github.com/user-attachments/assets/041dfdef-485a-4577-b410-e8fa2bbe9950" />
