### PR TITLE
Fix compile warnings when comparing unsigned char to zero

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -46,7 +46,12 @@ constexpr auto NUM_THREADS{256};
  */
 constexpr bool is_whitespace(char const chr)
 {
-  if (chr >= 0x0000 && chr <= 0x001F) { return true; }
+  // Char can be signed or unsigned depending on the platform, so we need to check both ranges.
+  if constexpr (cuda::std::is_signed_v<char>) {
+    if (chr >= 0x0000 && chr <= 0x001F) { return true; }
+  } else {
+    if (chr <= 0x001F) { return true; }
+  }
   switch (chr) {
     case ' ':
     case '\r':

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -45,7 +45,12 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  */
 constexpr bool is_whitespace(char const chr)
 {
-  if (chr >= 0x0000 && chr <= 0x001F) { return true; }
+  // Char can be signed or unsigned depending on the platform, so we need to check both ranges.
+  if constexpr (cuda::std::is_signed_v<char>) {
+    if (chr >= 0x0000 && chr <= 0x001F) { return true; }
+  } else {
+    if (chr <= 0x001F) { return true; }
+  }
   switch (chr) {
     case ' ':
     case '\r':


### PR DESCRIPTION
This fixes the (potential) warnings when comparing unsigned char to zero. Most of the times, the warnings do not show up because `char` is a signed type on `x86` platform but it can be unsigned on `arm64` platform (`char` can be signed or unsigned, it is not specified by C++ standard).

Fixes https://github.com/NVIDIA/spark-rapids-jni/issues/3227.