### PR TITLE
Fix compiler warning on `arm64` platform

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -46,19 +46,15 @@ constexpr auto NUM_THREADS{256};
  */
 constexpr bool is_whitespace(char const chr)
 {
-  // Char can be signed or unsigned depending on the platform, so we need to check both ranges.
-  if constexpr (cuda::std::is_signed_v<char>) {
-    if (chr >= 0x0000 && chr <= 0x001F) { return true; }
-  } else {
-    if (chr <= 0x001F) { return true; }
-  }
-  switch (chr) {
-    case ' ':
-    case '\r':
-    case '\t':
-    case '\n': return true;
-    default: return false;
-  }
+  // Return true if:
+  // - Space (0x20, ' ')
+  // - Form feed (0x0c, '\f')
+  // - Line feed (0x0a, '\n')
+  // - Carriage return (0x0d, '\r')
+  // - Horizontal tab (0x09, '\t')
+  // - Vertical tab (0x0b, '\v')
+  auto const c = static_cast<unsigned char>(chr);
+  return c <= 0x001F || c == ' ';
 }
 
 template <typename T, std::enable_if_t<cuda::std::is_signed_v<T>>* = nullptr>

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -46,7 +46,7 @@ constexpr auto NUM_THREADS{256};
  */
 constexpr bool is_whitespace(char const chr)
 {
-  // Return true if:
+  // Whitespace characters include:
   // - Space (0x20, ' ')
   // - Form feed (0x0c, '\f')
   // - Line feed (0x0a, '\n')

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -45,7 +45,7 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  */
 constexpr bool is_whitespace(char const chr)
 {
-  // Return true if:
+  // Whitespace characters include:
   // - Space (0x20, ' ')
   // - Form feed (0x0c, '\f')
   // - Line feed (0x0a, '\n')

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -45,19 +45,15 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  */
 constexpr bool is_whitespace(char const chr)
 {
-  // Char can be signed or unsigned depending on the platform, so we need to check both ranges.
-  if constexpr (cuda::std::is_signed_v<char>) {
-    if (chr >= 0x0000 && chr <= 0x001F) { return true; }
-  } else {
-    if (chr <= 0x001F) { return true; }
-  }
-  switch (chr) {
-    case ' ':
-    case '\r':
-    case '\t':
-    case '\n': return true;
-    default: return false;
-  }
+  // Return true if:
+  // - Space (0x20, ' ')
+  // - Form feed (0x0c, '\f')
+  // - Line feed (0x0a, '\n')
+  // - Carriage return (0x0d, '\r')
+  // - Horizontal tab (0x09, '\t')
+  // - Vertical tab (0x0b, '\v')
+  auto const c = static_cast<unsigned char>(chr);
+  return c <= 0x001F || c == ' ';
 }
 
 template <typename T, size_type block_size>


### PR DESCRIPTION
This fixes the compiler warning when comparing an `unsigned char <= 0`. The warnings only show up when building on `arm64` platform. There was an attempt to fix it in https://github.com/NVIDIA/spark-rapids-jni/pull/3242 but that seems didn't work.