### PR TITLE
Add centralized priority for SparkResourceAdaptor with first gets highest priority

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -202,6 +202,7 @@ add_library(
   src/RowConversionJni.cpp
   src/SparkResourceAdaptorJni.cpp
   src/SubStringIndexJni.cpp
+  src/TaskPriorityJni.cpp
   src/ZOrderJni.cpp
   src/bloom_filter.cu
   src/case_when.cu

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -24,6 +24,7 @@
 #include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
+#include <task_priority.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -149,16 +150,16 @@ static auto make_logger(std::string const& filename)
  */
 class thread_priority {
  public:
-  thread_priority(long const tsk_id, long const t_id) : task_id(tsk_id), thread_id(t_id) {}
+  thread_priority(long const tsk_id, long const t_id) :
+  task_priority(spark_rapids_jni::get_task_priority(tsk_id)), 
+  thread_id(t_id) {}
 
   long get_thread_id() const { return thread_id; }
 
-  long get_task_id() const { return task_id; }
-
   bool operator<(const thread_priority& other) const
   {
-    long task_priority       = this->task_priority();
-    long other_task_priority = other.task_priority();
+    long task_priority       = this->task_priority;
+    long other_task_priority = other.task_priority;
     if (task_priority < other_task_priority) {
       return true;
     } else if (task_priority == other_task_priority) {
@@ -169,8 +170,8 @@ class thread_priority {
 
   bool operator>(const thread_priority& other) const
   {
-    long task_priority       = this->task_priority();
-    long other_task_priority = other.task_priority();
+    long task_priority       = this->task_priority;
+    long other_task_priority = other.task_priority;
     if (task_priority > other_task_priority) {
       return true;
     } else if (task_priority == other_task_priority) {
@@ -181,15 +182,13 @@ class thread_priority {
 
   void operator=(const thread_priority& other)
   {
-    task_id   = other.task_id;
+    task_priority = other.task_priority;
     thread_id = other.thread_id;
   }
 
  private:
-  long task_id;
+  long task_priority;
   long thread_id;
-
-  long task_priority() const { return std::numeric_limits<long>::max() - (task_id + 1); }
 };
 
 /**

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -150,9 +150,10 @@ static auto make_logger(std::string const& filename)
  */
 class thread_priority {
  public:
-  thread_priority(long const tsk_id, long const t_id) :
-  task_priority(spark_rapids_jni::get_task_priority(tsk_id)), 
-  thread_id(t_id) {}
+  thread_priority(long const tsk_id, long const t_id)
+    : task_priority(spark_rapids_jni::get_task_priority(tsk_id)), thread_id(t_id)
+  {
+  }
 
   long get_thread_id() const { return thread_id; }
 
@@ -183,7 +184,7 @@ class thread_priority {
   void operator=(const thread_priority& other)
   {
     task_priority = other.task_priority;
-    thread_id = other.thread_id;
+    thread_id     = other.thread_id;
   }
 
  private:

--- a/src/main/cpp/src/TaskPriorityJni.cpp
+++ b/src/main/cpp/src/TaskPriorityJni.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "jni_utils.hpp"
+#include "task_priority.hpp"
+
+namespace spark_rapids_jni {
+
+long get_task_priority(long attempt_id) {
+  return std::numeric_limits<long>::max() - (attempt_id + 1);
+}
+
+void task_done(long attempt_id) {
+  // noop for now will change soon
+}
+
+} // namespace spark_rapids_jni
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_TaskPriority_getTaskPriority(
+    JNIEnv* env, jclass, jlong task_attempt_id)
+{
+  return spark_rapids_jni::get_task_priority(task_attempt_id);
+}
+
+JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_TaskPriority_taskDone(
+  JNIEnv* env, jclass, jlong task_attempt_id)
+{
+  spark_rapids_jni::task_done(task_attempt_id);
+}
+
+}

--- a/src/main/cpp/src/task_priority.hpp
+++ b/src/main/cpp/src/task_priority.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace spark_rapids_jni {
+
+/**
+ * Get the priority for a task. Larger priorities mean the task
+ * should get priority access to resources compared to smaller
+ * priority numbers.
+ */
+long get_task_priority(long attempt_id);
+
+/**
+ * Inform the system that a particular task is finished.
+ */
+void task_done(long attempt_id);
+
+}  // namespace spark_rapids_jni

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkResourceAdaptor.java
@@ -182,6 +182,7 @@ public class SparkResourceAdaptor
    */
   public void taskDone(long taskId) {
     taskDone(getHandle(), taskId);
+    TaskPriority.taskDone(taskId);
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/TaskPriority.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/TaskPriority.java
@@ -24,13 +24,18 @@ import ai.rapids.cudf.NativeDepsLoader;
  * Get the priority for any task. If the priority for one task is larger than the priority for another task,
  * then it means that the task first task (larger number) should get access to resources before the task with
  * the lower priority value.
+ * This is currently tied into the SparkResourceAdaptor for task life cycle
  */
 public class TaskPriority {
   static {
     NativeDepsLoader.loadNativeDeps();
   }
 
+  /**
+   * Get the priority for a given task
+   * @param taskAttemptId the id of the task to get the priority for.
+   */
   public static native long getTaskPriority(long taskAttemptId);
 
-  public static native void taskDone(long taskAttemptId);
+  static native void taskDone(long taskAttemptId);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/TaskPriority.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/TaskPriority.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.NativeDepsLoader;
+
+/**
+ * Get the priority for any task. If the priority for one task is larger than the priority for another task,
+ * then it means that the task first task (larger number) should get access to resources before the task with
+ * the lower priority value.
+ */
+public class TaskPriority {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  public static native long getTaskPriority(long taskAttemptId);
+
+  public static native void taskDone(long taskAttemptId);
+}


### PR DESCRIPTION
This adds in an API for centralized task priority with a scheme where the first task to touch the priority system gets the highest priority. 