### PR TITLE
Fix bug in casting string to timestamp: the isDST is wrong when using default timezone

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -276,6 +276,7 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStrings(JNIEnv* env,
                                                                    jclass,
                                                                    jlong input_column,
                                                                    int default_timezone_index,
+                                                                   bool is_default_timezone_dst,
                                                                    long default_epoch_day,
                                                                    jlong timezone_info_column)
 {
@@ -287,8 +288,12 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStrings(JNIEnv* env,
     auto const input_view =
       cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
     auto const* tz_info_view = reinterpret_cast<cudf::column_view const*>(timezone_info_column);
-    return cudf::jni::release_as_jlong(spark_rapids_jni::parse_timestamp_strings(
-      input_view, default_timezone_index, default_epoch_day, *tz_info_view));
+    return cudf::jni::release_as_jlong(
+      spark_rapids_jni::parse_timestamp_strings(input_view,
+                                                default_timezone_index,
+                                                is_default_timezone_dst,
+                                                default_epoch_day,
+                                                *tz_info_view));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -151,6 +151,7 @@ std::unique_ptr<cudf::column> long_to_binary_string(
  *
  * @param input The input String column contains timestamp strings
  * @param default_tz_index The default timezone index to `GpuTimeZoneDB` transition table.
+ * @param is_default_tz_dst If true, the default timezone is DST(Daylight Saving Time) timezone.
  * @param default_epoch_day Default epoch day to use if just time, e.g.:
  *   "T00:00:00Z" will use the default_epoch_day, e.g.: the result will be "2025-05-05T00:00:00Z"
  * @param tz_info Timezone info column: STRUCT<tz_name: string, index_to_transition_table: int,
@@ -162,6 +163,7 @@ std::unique_ptr<cudf::column> long_to_binary_string(
 std::unique_ptr<cudf::column> parse_timestamp_strings(
   cudf::strings_column_view const& input,
   cudf::size_type const default_tz_index,
+  bool const is_default_tz_dst,
   int64_t const default_epoch_day,
   cudf::column_view const& tz_info,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -642,6 +642,11 @@ public class GpuTimeZoneDB {
     }
   }
 
+  public static boolean isDST(String timezone) {
+    ZoneId zoneId = ZoneId.of(timezone, ZoneId.SHORT_IDS);
+    return !zoneId.getRules().getTransitionRules().isEmpty();
+  }
+
   private static native long convertTimestampColumnToUTC(long input, long transitions, int tzIndex);
 
   private static native long convertUTCTimestampColumnToTimeZone(long input, long transitions, int tzIndex);

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -498,7 +498,12 @@ public class CastStringsTest {
 
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
         ColumnVector tzInfo = getTimezoneInfoMock(); // mock timezone info
-        ColumnVector result = CastStrings.parseTimestampStrings(inputCv, 1, defaultEpochDay, tzInfo);
+        ColumnVector result = CastStrings.parseTimestampStrings(
+            inputCv,
+            1,
+            /* is default tz DST */ false,
+            defaultEpochDay,
+            tzInfo);
         ColumnVector expectedReturnType = ColumnVector
             .fromBoxedUnsignedBytes(expected_return_type.toArray(new Byte[0]));
         ColumnVector expectedUtcTs = ColumnVector.fromBoxedLongs(expected_utc_seconds.toArray(new Long[0]));
@@ -727,7 +732,12 @@ public class CastStringsTest {
 
     try (ColumnVector inputCv = ColumnVector.fromStrings(input.toArray(new String[0]));
         ColumnVector tzInfo = getTimezoneInfoMock(); // mock timezone info
-        ColumnVector result = CastStrings.parseTimestampStrings(inputCv, 1, defaultEpochDay, tzInfo);
+        ColumnVector result = CastStrings.parseTimestampStrings(
+            inputCv,
+            1,
+            /* is default tz DST */ false,
+            defaultEpochDay,
+            tzInfo);
         ColumnVector expectedReturnType = ColumnVector
             .fromBoxedUnsignedBytes(expected_return_type.toArray(new Byte[0]));
         ColumnVector expectedUtcTs = ColumnVector.fromBoxedLongs(expected_utc_seconds.toArray(new Long[0]));
@@ -996,4 +1006,43 @@ public class CastStringsTest {
       Assertions.assertNull(actual);
     }
   }
+
+  /**
+   * Test cast string to timestamp with non-UTC default timezone.
+   */
+  @Test
+  void castStringToTimestampUseNonUTCDefaultTimezone() {
+    GpuTimeZoneDB.cacheDatabase(2200);
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    // 1. test fallback to cpu: has year > 2200 and has DST
+    String ts1 = "6663-09-28T00:00:00";
+    // calculated from Spark:
+    // spark.conf.set("spark.sql.session.timeZone", "America/Los_Angeles")
+    // spark.createDataFrame([('6663-09-28T00:00:00',)], 'a string')
+    // .selectExpr("cast(cast(a as timestamp) as long) * 1000000L").show()
+    long micors1 = 148120124400000000L;
+    try (ColumnVector inputCv = ColumnVector.fromStrings(ts1);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv,
+            "America/Los_Angeles", // non-UTC default timezone
+            /* ansi */ false);
+        ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(micors1)) {
+      AssertUtils.assertColumnsAreEqual(expected, actual);
+    }
+
+    // 2. test run on GPU: has no year > 2200 although has DST
+    String ts2 = "2025-09-28T00:00:00";
+    // calculated from Spark: refer to the above code
+    long micors2 = 1759042800000000L;
+    try (ColumnVector inputCv = ColumnVector.fromStrings(ts2);
+        ColumnVector actual = CastStrings.toTimestamp(
+            inputCv,
+            "America/Los_Angeles", // non-UTC default timezone
+            /* ansi */ false);
+        ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(micors2)) {
+      AssertUtils.assertColumnsAreEqual(expected, actual);
+    }
+  }
+
 }


### PR DESCRIPTION
### bug
The isDST is wrong when using a DST timezone as default timezone, e.g.:  America/Los_Angeles
America/Los_Angeles is DST.

GpuTimeZoneDB.getIndexToTransitionTable("America/Los_Angeles") returns 150,
But the corresponding row inex for America/Los_Angeles in `GpuTimeZoneDB.timeZoneInfo` is 153.
Before this PR, the code use 150 instead of 153, refer to the code:
```cpp
      auto const is_DST_col = tz_info.child(2);
      if (is_DST_col.element<uint8_t>(default_tz_index)) {  // default_tz_index is index to transition table, not tz_info
        // update is DST
        is_DSTs[idx] = 1;
      }
```
Thus get wrong info.

### analysis
GpuTimeZoneDB has the following 3 fields:
- GpuTimeZoneDB.transitions
- GpuTimeZoneDB.zoneIdToTable saves the mappings: timezone -> index in transition table.
- GpuTimeZoneDB.timeZoneInfo saves  the info:  STRUCT<tz_name: string, index_to_transition_table: int, is_DST: int8>

The `transitions` only saves transitions for normalized timezone to save memory.
The zoneIdToTable and timeZoneInfo have more rows than transitions, not only  saves normalized but also non-normalized timezone.

E.g.:
After normalization for PST, it's `America/Los_Angeles`.
The `PST` and `America/Los_Angeles` can both appear in timestamp strings.
For the two timezones, there is only one transition info in `GpuTimeZoneDB.transitions`.

Before this PR, it assumes the rows are the same.

### fix
Pass in the isDST boolean for the default timezone.

Signed-off-by: Chong Gao <res_life@163.com>