### PR TITLE
Fix bug in cast string to timestamp: just time string without leading 'T' is also valid

### DIFF
--- a/src/main/cpp/src/cast_string_to_timestamp.cu
+++ b/src/main/cpp/src/cast_string_to_timestamp.cu
@@ -659,7 +659,7 @@ __device__ RESULT_TYPE parse_timestamp_string(unsigned char const* const ptr,
   bool negative_year_sign = false;
 
   if (ptr[pos] == 'T' || (end_pos - pos > 1 && ptr[pos + 1] == ':') ||
-      (end_pos - pos > 2 && ptr[pos + 2] == ':')) {
+      (end_pos - pos > 2 && (ptr[pos + 1] == ':' || ptr[pos + 2] == ':'))) {
     // first char is T, means only have time part
     // or the second or third char is ':', e.g.: 12:00:00 or 1:00:00
     just_time = TS_TYPE::JUST_TIME;

--- a/src/main/cpp/src/cast_string_to_timestamp.cu
+++ b/src/main/cpp/src/cast_string_to_timestamp.cu
@@ -655,27 +655,29 @@ __device__ RESULT_TYPE parse_timestamp_string(unsigned char const* const ptr,
 
   if (eof(pos, end_pos)) { return RESULT_TYPE::INVALID; }
 
-  // parse sign
-  bool negative_year_sign    = false;
-  unsigned char const sign_c = ptr[pos];
-  if ('-' == sign_c || '+' == sign_c) {
-    pos++;
-    if ('-' == sign_c) { negative_year_sign = true; }
-  }
-
-  if (eof(pos, end_pos)) { return RESULT_TYPE::INVALID; }
-
   ts_segments ts;
+  bool negative_year_sign = false;
 
-  if (ptr[pos] == 'T') {
-    // after parse sign, first char is T, means only have time part
+  if (ptr[pos] == 'T' || (end_pos - pos > 1 && ptr[pos + 1] == ':') ||
+      (end_pos - pos > 2 && ptr[pos + 2] == ':')) {
+    // first char is T, means only have time part
+    // or the second or third char is ':', e.g.: 12:00:00 or 1:00:00
     just_time = TS_TYPE::JUST_TIME;
-    pos++;
+
+    if (ptr[pos] == 'T') { pos++; }
 
     // parse from time
     if (!parse_from_time(ptr, pos, end_pos, ts, tz)) { return RESULT_TYPE::INVALID; }
   } else {
     just_time = TS_TYPE::NOT_JUST_TIME;
+
+    // parse sign
+    unsigned char const sign_c = ptr[pos];
+    if ('-' == sign_c || '+' == sign_c) {
+      pos++;
+      if ('-' == sign_c) { negative_year_sign = true; }
+    }
+
     // parse from date
     if (!parse_from_date(ptr, pos, end_pos, ts, tz)) { return RESULT_TYPE::INVALID; }
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -442,7 +442,7 @@ public class CastStringsTest {
     long defaultEpochDay = 1;
     long secondsOfEpochDay = defaultEpochDay * 24 * 60 * 60;
     List<List<Object>> list = new ArrayList<>();
-    // Row is: input, return type, UTC ts, just time, tz type, offset, is DST, tz
+    // Row is: input, return type, UTC seconds, UTC microseconds, tz type, offset, is DST, tz
     // index
     // Intermediate result:
     // - Return type: 0 success, 1 invalid, 2 unsupported
@@ -452,6 +452,8 @@ public class CastStringsTest {
     // - TZ offset: record offset in seconds when tz type is fixed
     // - TZ is DST: 0 no, 1 yes
     // - TZ index: 0 CTT, 1 JST, 2 PST
+
+    // valid time
     list.add(Arrays.asList("T00", 0, 0L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("T1:2", 0, 3720L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("T01:2", 0, 3720L + secondsOfEpochDay, 0, 2, 0, 0, 1));
@@ -462,7 +464,11 @@ public class CastStringsTest {
     list.add(Arrays.asList("T01:02:03 UTC", 0, 3723L + secondsOfEpochDay, 0, 1, 0, 0, -1));
     list.add(Arrays.asList(" \r\n\tT23:17:50 \r\n\t", 0, 83870L + secondsOfEpochDay, 0, 2, 0, 0, 1));
 
-    // // invalid time
+    // valid time: begin with not T
+    list.add(Arrays.asList("01:2:3", 0, 3723L + secondsOfEpochDay, 0, 2, 0, 0, 1));
+    list.add(Arrays.asList("1:2:3", 0, 3723L + secondsOfEpochDay, 0, 2, 0, 0, 1));
+
+    // invalid time
     list.add(Arrays.asList("Tx", 1, 0L, 0, 0, 0, 0, -1));
     list.add(Arrays.asList("T00x", 1, 0L, 0, 0, 0, 0, -1));
     list.add(Arrays.asList("T00:", 1, 0L, 0, 0, 0, 0, -1));
@@ -475,6 +481,12 @@ public class CastStringsTest {
     list.add(Arrays.asList("T123", 1, 0L, 0, 0, 0, 0, -1));
     list.add(Arrays.asList("T12345", 1, 0L, 0, 0, 0, 0, -1));
     list.add(Arrays.asList("T00:02:003", 1, 0L, 0, 0, 0, 0, -1));
+
+    // invalid time: time leading by sign
+    list.add(Arrays.asList("+00:00:00", 1, 0L, 0, 0, 0, 0, -1));
+    list.add(Arrays.asList("-00:00:00", 1, 0L, 0, 0, 0, 0, -1));
+    list.add(Arrays.asList("+T00:00:00", 1, 0L, 0, 0, 0, 0, -1));
+    list.add(Arrays.asList("-T00:00:00", 1, 0L, 0, 0, 0, 0, -1));
 
     List<String> input = new ArrayList<>(list.size());
     List<Byte> expected_return_type = new ArrayList<>(list.size());

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -465,7 +465,7 @@ public class CastStringsTest {
     list.add(Arrays.asList(" \r\n\tT23:17:50 \r\n\t", 0, 83870L + secondsOfEpochDay, 0, 2, 0, 0, 1));
 
     // valid time: begin with not T
-    list.add(Arrays.asList("1:", 0, 3600L + secondsOfEpochDay, 0, 2, 0, 0, 1));
+    list.add(Arrays.asList("01:2", 0, 3720L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("1:2", 0, 3720L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("01:2:3", 0, 3723L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("1:2:3", 0, 3723L + secondsOfEpochDay, 0, 2, 0, 0, 1));

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -465,6 +465,8 @@ public class CastStringsTest {
     list.add(Arrays.asList(" \r\n\tT23:17:50 \r\n\t", 0, 83870L + secondsOfEpochDay, 0, 2, 0, 0, 1));
 
     // valid time: begin with not T
+    list.add(Arrays.asList("1:", 0, 3600L + secondsOfEpochDay, 0, 2, 0, 0, 1));
+    list.add(Arrays.asList("1:2", 0, 3720L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("01:2:3", 0, 3723L + secondsOfEpochDay, 0, 2, 0, 0, 1));
     list.add(Arrays.asList("1:2:3", 0, 3723L + secondsOfEpochDay, 0, 2, 0, 0, 1));
 


### PR DESCRIPTION
## bug
"01:2:3" and "1:2:3" are also valid just time strings besides "T01:2:3" and "T1:2:3"
Before this PR, the code only handled 'T' leading strings.

## fix
Check if 'T' is leadning, and if the 2nd or the 3rd character is ':', if it is, then try parsing time.
Note: sing '+' and '-' should not be leading just time, e.g. the following is invalid:
"+T01:2:3"
"-1:2:3"

Signed-off-by: Chong Gao <res_life@163.com>