### PR TITLE
Fix bug: Using the default timezone is wrong if there is timezone in just time string

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -278,22 +278,27 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStrings(JNIEnv* env,
                                                                    int default_timezone_index,
                                                                    bool is_default_timezone_dst,
                                                                    long default_epoch_day,
-                                                                   jlong timezone_info_column)
+                                                                   jlong timezone_info_column,
+                                                                   jlong transitions_table)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, timezone_info_column, "timezone info column is null", 0);
+  JNI_NULL_CHECK(env, transitions_table, "transitions table is null", 0);
+
   try {
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
       cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
     auto const* tz_info_view = reinterpret_cast<cudf::column_view const*>(timezone_info_column);
+    auto const* transitions  = reinterpret_cast<cudf::table_view const*>(transitions_table);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::parse_timestamp_strings(input_view,
                                                 default_timezone_index,
                                                 is_default_timezone_dst,
                                                 default_epoch_day,
-                                                *tz_info_view));
+                                                *tz_info_view,
+                                                *transitions));
   }
   CATCH_STD(env, 0);
 }

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
 #include <rmm/resource_ref.hpp>
@@ -162,10 +163,11 @@ std::unique_ptr<cudf::column> long_to_binary_string(
  */
 std::unique_ptr<cudf::column> parse_timestamp_strings(
   cudf::strings_column_view const& input,
-  cudf::size_type const default_tz_index,
-  bool const is_default_tz_dst,
-  int64_t const default_epoch_day,
+  cudf::size_type default_tz_index,
+  bool is_default_tz_dst,
+  int64_t default_epoch_day,
   cudf::column_view const& tz_info,
+  cudf::table_view const& transitions,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -826,7 +826,10 @@ struct parse_timestamp_string_fn {
             transitions,
             tz_indices[idx],
             /* to_utc */ false);
-          int64_t rebased                    = *reinterpret_cast<int64_t*>(&rebased_seconds);
+
+          auto const rebased = static_cast<int64_t>(
+            cuda::std::chrono::duration_cast<cudf::duration_s>(rebased_seconds.time_since_epoch())
+              .count());
           int64_t rebased_days_of_local_date = rebased / (24L * 3600L);
 
           // Step 2: add date part to the seconds

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -32,6 +32,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+#include <chrono>
 #include <vector>
 
 /**
@@ -623,6 +624,8 @@ __device__ inline RESULT_TYPE to_long_check_max(ts_segments const& ts,
                                                 int64_t& seconds,
                                                 int32_t& microseconds)
 {
+  // if it's a just time timestamp string, then the `days` is 0, because
+  // default date in ts_segments is 1970-01-01
   int64_t const days = ts.to_epoch_day();
 
   // seconds part
@@ -700,8 +703,16 @@ struct parse_timestamp_string_fn {
   cudf::size_type default_tz_index;
   bool is_default_tz_dst;
   int64_t default_epoch_day;
+  // current seconds since epoch, used to calculate the date in just time string
+  int64_t current_seconds_since_epoch;
+
   // STRUCT<tz_name: string, index_to_transition_table: int, is_DST: int8>
   cudf::column_device_view tz_info;
+
+  // The list column of transitions to figure out the correct offset
+  // to adjust the timestamp. The type of the values in this column is
+  // LIST<STRUCT<utcInstant: int64, tzInstant: int64, utcOffset: int32>>.
+  cudf::detail::lists_column_device_view transitions;
 
   // parsed result types: not supported, invalid, success
   uint8_t* result_types;
@@ -748,19 +759,45 @@ struct parse_timestamp_string_fn {
       return;
     }
 
-    if (just_time == TS_TYPE::JUST_TIME) {
-      ts_seconds[idx] = seconds + (default_epoch_day * 24L * 3600L);
-    }
-
     // check the timezone, and get the timezone index
     if (tz.type == TZ_TYPE::NOT_SPECIFIED) {
       // use the default timezone index
       tz_types[idx]   = static_cast<uint8_t>(TZ_TYPE::OTHER_TZ);
       tz_indices[idx] = default_tz_index;
       is_DSTs[idx]    = is_default_tz_dst;
+      if (just_time == TS_TYPE::JUST_TIME) {
+        // use the default epoch days when the timezone is not specified
+        // the `default_epoch_day` is from Java code: LocalDate.now(default_time_zone).toEpochDay()
+        ts_seconds[idx] = seconds + (default_epoch_day * 24L * 3600L);
+        printf("rebased: 1 curr UTC seconds %ld, %ld, %ld\n",
+               seconds,
+               default_epoch_day,
+               ts_seconds[idx]);
+      }
     } else if (tz.type == TZ_TYPE::FIXED_TZ) {
-      // do nothing
+      if (just_time == TS_TYPE::JUST_TIME) {
+        // Step 1: Get the current date in the timezone
+        // in order to get the correct local date, rebase from utc timezone to local timezone
+        // e.g.: current UTC time is 2025-01-01T23:00:00, tz offsets is +01:00, then current date
+        // is: 2025-01-01T23:00:00 + 01:00 = 2025-01-02T00:00:00
+        auto rebased = current_seconds_since_epoch + tz.fixed_offset;
+        // This is to get the seconds for the date part with discarding the time part
+        auto rebased_days_of_local_date = rebased / (24L * 3600L);
+
+        printf("rebased: 2 curr UTC seconds %ld, %d, %ld\n",
+               current_seconds_since_epoch,
+               tz.fixed_offset,
+               rebased);
+
+        // Step 2: add date part to the seconds
+        ts_seconds[idx] = seconds + (rebased_days_of_local_date * 24L * 3600L);
+      }
     } else if (tz.type == TZ_TYPE::OTHER_TZ) {
+      /**
+       * If tz type is OTHER_TZ, binary search in the `tz_info` to get the timezone index and
+       * get if TZ is DST. If not found, set the result type to invalid.
+       * If the string is just time, use the current date in the timezone.
+       */
       auto const tz_col                  = tz_info.child(0);
       auto const index_in_transition_col = tz_info.child(1);
       auto const is_DST_col              = tz_info.child(2);
@@ -783,6 +820,27 @@ struct parse_timestamp_string_fn {
           // update is DST
           is_DSTs[idx] = 1;
         }
+
+        if (just_time == TS_TYPE::JUST_TIME) {
+          // get current date in the the timezone, equvalent to Java code: LocalDate.now(zoneId)
+          // E.g.:
+          //   LocalDate.now("America/Los_Angeles") = 2025-05-21,
+          //   at the same time:
+          //   LocalDate.now("Asia/Shanghai")       = 2025-05-22
+
+          // Step 1: rebase `current_seconds_since_epoch` from utc timezone to local timezone
+          // to get the current date
+          auto rebased_seconds = spark_rapids_jni::convert_timestamp<cudf::timestamp_s>(
+            cudf::timestamp_s{cudf::duration_s{current_seconds_since_epoch}},
+            transitions,
+            tz_indices[idx],
+            /* to_utc */ false);
+          int64_t rebased                    = *reinterpret_cast<int64_t*>(&rebased_seconds);
+          int64_t rebased_days_of_local_date = rebased / (24L * 3600L);
+
+          // Step 2: add date part to the seconds
+          ts_seconds[idx] = seconds + (rebased_days_of_local_date * 24L * 3600L);
+        }
       } else {
         // not found tz, update result_type to invalid
         result_types[idx] = static_cast<uint8_t>(RESULT_TYPE::INVALID);
@@ -802,10 +860,11 @@ struct parse_timestamp_string_fn {
  * Parse strings to an intermediate struct column with 7 sub-columns.
  */
 std::unique_ptr<cudf::column> parse_ts_strings(cudf::strings_column_view const& input,
-                                               cudf::size_type const default_tz_index,
-                                               bool const is_default_tz_dst,
-                                               int64_t const default_epoch_day,
+                                               cudf::size_type default_tz_index,
+                                               bool is_default_tz_dst,
+                                               int64_t default_epoch_day,
                                                cudf::column_view const& tz_info,
+                                               cudf::table_view const& transitions,
                                                rmm::cuda_stream_view stream,
                                                rmm::device_async_resource_ref mr)
 {
@@ -831,6 +890,15 @@ std::unique_ptr<cudf::column> parse_ts_strings(cudf::strings_column_view const& 
   auto parsed_tz_index_col = cudf::make_fixed_width_column(
     cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
 
+  // Get current seconds since epoch, used to calculate the date in just time string
+  auto duration = std::chrono::system_clock::now().time_since_epoch();
+  int64_t current_seconds_since_epoch =
+    std::chrono::duration_cast<std::chrono::seconds>(duration).count();
+
+  // get the fixed transitions
+  auto const ft_cdv_ptr        = cudf::column_device_view::create(transitions.column(0), stream);
+  auto const fixed_transitions = cudf::detail::lists_column_device_view{*ft_cdv_ptr};
+
   thrust::for_each_n(
     rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator(0),
@@ -839,7 +907,9 @@ std::unique_ptr<cudf::column> parse_ts_strings(cudf::strings_column_view const& 
                               default_tz_index,
                               is_default_tz_dst,
                               default_epoch_day,
+                              current_seconds_since_epoch,
                               *d_tz_info,
+                              fixed_transitions,
                               parsed_result_type_col->mutable_view().begin<uint8_t>(),
                               parsed_utc_seconds_col->mutable_view().begin<int64_t>(),
                               parsed_utc_microseconds_col->mutable_view().begin<int32_t>(),
@@ -1021,15 +1091,22 @@ std::unique_ptr<cudf::column> parse_to_date(cudf::strings_column_view const& inp
 }  // anonymous namespace
 
 std::unique_ptr<cudf::column> parse_timestamp_strings(cudf::strings_column_view const& input,
-                                                      cudf::size_type const default_tz_index,
-                                                      bool const is_default_tz_dst,
-                                                      int64_t const default_epoch_day,
+                                                      cudf::size_type default_tz_index,
+                                                      bool is_default_tz_dst,
+                                                      int64_t default_epoch_day,
                                                       cudf::column_view const& tz_info,
+                                                      cudf::table_view const& transitions,
                                                       rmm::cuda_stream_view stream,
                                                       rmm::device_async_resource_ref mr)
 {
-  return parse_ts_strings(
-    input, default_tz_index, is_default_tz_dst, default_epoch_day, tz_info, stream, mr);
+  return parse_ts_strings(input,
+                          default_tz_index,
+                          is_default_tz_dst,
+                          default_epoch_day,
+                          tz_info,
+                          transitions,
+                          stream,
+                          mr);
 }
 
 std::unique_ptr<cudf::column> parse_strings_to_date(cudf::strings_column_view const& input,

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -769,10 +769,6 @@ struct parse_timestamp_string_fn {
         // use the default epoch days when the timezone is not specified
         // the `default_epoch_day` is from Java code: LocalDate.now(default_time_zone).toEpochDay()
         ts_seconds[idx] = seconds + (default_epoch_day * 24L * 3600L);
-        printf("rebased: 1 curr UTC seconds %ld, %ld, %ld\n",
-               seconds,
-               default_epoch_day,
-               ts_seconds[idx]);
       }
     } else if (tz.type == TZ_TYPE::FIXED_TZ) {
       if (just_time == TS_TYPE::JUST_TIME) {
@@ -783,11 +779,6 @@ struct parse_timestamp_string_fn {
         auto rebased = current_seconds_since_epoch + tz.fixed_offset;
         // This is to get the seconds for the date part with discarding the time part
         auto rebased_days_of_local_date = rebased / (24L * 3600L);
-
-        printf("rebased: 2 curr UTC seconds %ld, %d, %ld\n",
-               current_seconds_since_epoch,
-               tz.fixed_offset,
-               rebased);
 
         // Step 2: add date part to the seconds
         ts_seconds[idx] = seconds + (rebased_days_of_local_date * 24L * 3600L);

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -70,26 +70,7 @@ struct convert_timestamp_tz_functor {
    */
   __device__ timestamp_type operator()(timestamp_type const& timestamp) const
   {
-    auto const utc_instants = transitions.child().child(0);
-    auto const tz_instants  = transitions.child().child(1);
-    auto const utc_offsets  = transitions.child().child(2);
-
-    auto const epoch_seconds = static_cast<int64_t>(
-      cuda::std::chrono::duration_cast<cudf::duration_s>(timestamp.time_since_epoch()).count());
-    auto const tz_transitions = cudf::list_device_view{transitions, tz_index};
-    auto const list_size      = tz_transitions.size();
-
-    auto const transition_times = cudf::device_span<int64_t const>(
-      (to_utc ? tz_instants : utc_instants).data<int64_t>() + tz_transitions.element_offset(0),
-      static_cast<size_t>(list_size));
-
-    auto const it = thrust::upper_bound(
-      thrust::seq, transition_times.begin(), transition_times.end(), epoch_seconds);
-    auto const idx         = static_cast<size_type>(thrust::distance(transition_times.begin(), it));
-    auto const list_offset = tz_transitions.element_offset(idx - 1);
-    auto const utc_offset  = cuda::std::chrono::duration_cast<duration_type>(
-      cudf::duration_s{static_cast<int64_t>(utc_offsets.element<int32_t>(list_offset))});
-    return to_utc ? timestamp - utc_offset : timestamp + utc_offset;
+    return spark_rapids_jni::convert_timestamp(timestamp, transitions, tz_index, to_utc);
   }
 };
 

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -68,6 +68,28 @@ std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
+ * @brief Convert input column timestamps in UTC to specified timezone
+ *
+ * The transition rules are in enclosed in a table, and the index corresponding to the
+ * specific timezone is given.
+ *
+ * This method is the inverse of convert_timestamp_to_utc.
+ *
+ * @param input the column of input timestamps in UTC
+ * @param transitions the table of transitions for all timezones
+ * @param tz_indices the indices of the timezones,
+ * each index is the row in `transitions` corresponding to the specific timezone
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned timestamp column's memory
+ */
+std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
+  cudf::column_view const& input,
+  cudf::table_view const& transitions,
+  cudf::column_view const& tz_indices,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
  * @brief Convert input column timestamps in multiple timezones to UTC.
  *
  * Note: The input timestamps are splited into seconds and microseconds columns to handle special

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -186,11 +186,12 @@ public class CastStrings {
   static ColumnVector parseTimestampStrings(
       ColumnView input, int defaultTimeZoneIndex,
       boolean isDefaultTimeZoneDST, long defaultEpochDay,
-      ColumnView timeZoneInfo) {
+      ColumnView timeZoneInfo,
+      Table transitions) {
 
     return new ColumnVector(parseTimestampStrings(
         input.getNativeView(), defaultTimeZoneIndex, isDefaultTimeZoneDST,
-        defaultEpochDay, timeZoneInfo.getNativeView()));
+        defaultEpochDay, timeZoneInfo.getNativeView(), transitions.getNativeView()));
   }
 
   private static ColumnVector convertToTimestamp(
@@ -281,8 +282,9 @@ public class CastStrings {
 
     // 2. parse to intermediate result
     try (ColumnVector tzInfo = GpuTimeZoneDB.getTimeZoneInfo();
+         Table transitions = GpuTimeZoneDB.getTransitions();
         ColumnVector parseResult = parseTimestampStrings(
-            input, defaultTimeZoneIndex, isDefaultTimeZoneDST, defaultEpochDay, tzInfo);
+            input, defaultTimeZoneIndex, isDefaultTimeZoneDST, defaultEpochDay, tzInfo, transitions);
         ColumnView invalid = parseResult.getChildColumnView(0);
         ColumnView tsSeconds = parseResult.getChildColumnView(1);
         ColumnView tsMicroseconds = parseResult.getChildColumnView(2);
@@ -351,7 +353,7 @@ public class CastStrings {
 
   private static native long parseTimestampStrings(
       long input, int defaultTimezoneIndex, boolean isDefaultTimeZoneDST,
-      long defaultEpochDay, long timeZoneInfo);
+      long defaultEpochDay, long timeZoneInfo, long transitions);
 
   private static native long parseDateStringsToDate(long input);
 


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids-jni/issues/3348

### bug
Refer to https://github.com/NVIDIA/spark-rapids-jni/issues/3348
Should not use the spark session timezone if there is timezone in the string for just time string.

### fix
- refactor timezones.cu to extract a rebase timezone method.
- If just time and has fixed tz,  rebase the current timestamp to the fixed tz, and get the current date to use.
- If just time and has specified tz,  rebase the current timestamp to the specified tz, and get the current date to use.

Signed-off-by: Chong Gao <res_life@163.com>