### PR TITLE
Change to use non-pvc workspace for premerge CI

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -139,7 +139,7 @@ pipeline {
                         ]
                     )
 
-                    stash(name: "source_tree", includes: "**")
+                    stash(name: "source_tree", includes: "**,.git/**", useDefaultExcludes: false)
 
                     container('cpu') {
                         // check if pre-merge dockerfile modified


### PR DESCRIPTION
Update Premerge CI to use non-pvc workspace to achieve better IO performance.