### PR TITLE
Adopt to changes in cudf JNI exception handling

### DIFF
--- a/src/main/cpp/src/HostTableJni.cpp
+++ b/src/main/cpp/src/HostTableJni.cpp
@@ -26,8 +26,8 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
-#include <iterator>
 #include <memory>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -61,7 +61,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(JNIEnv* env,
     int size             = type_nums.size();
     if (names.size() != size || indexes.size() != static_cast<std::size_t>(size) ||
         type_nums.size() != static_cast<std::size_t>(size)) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "wrong number of entries passed in", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "wrong number of entries passed in", 0);
     }
 
     for (int i = 0; i < size; i++) {
@@ -111,7 +112,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
     if (num_entries < 0 || names.size() != num_entries ||
         indexes.size() != static_cast<std::size_t>(num_entries) ||
         type_nums.size() != static_cast<std::size_t>(num_entries)) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "wrong number of entries passed in", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "wrong number of entries passed in", 0);
     }
 
     for (std::size_t i = 0; i < num_paths; ++i) {

--- a/src/main/cpp/src/RowConversionJni.cpp
+++ b/src/main/cpp/src/RowConversionJni.cpp
@@ -75,7 +75,8 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRowsFixedWidthOptimize
     cudf::jni::native_jintArray n_types(env, types);
     cudf::jni::native_jintArray n_scale(env, scale);
     if (n_types.size() != n_scale.size()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match size", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match size", NULL);
     }
     std::vector<cudf::data_type> types_vec;
     std::transform(n_types.begin(),
@@ -102,7 +103,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_conv
     cudf::jni::native_jintArray n_types(env, types);
     cudf::jni::native_jintArray n_scale(env, scale);
     if (n_types.size() != n_scale.size()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match size", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match size", NULL);
     }
     std::vector<cudf::data_type> types_vec;
     std::transform(n_types.begin(),

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -1119,7 +1119,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
     // overhead
     if (state.num_times_retried + 1 > 500) {
       state.record_failed_retry_time();
-      throw_java_exception(cudf::jni::OOM_CLASS, "GPU OutOfMemory: retry limit exceeded");
+      throw_java_exception(cudf::jni::OOM_ERROR_CLASS, "GPU OutOfMemory: retry limit exceeded");
     }
     state.num_times_retried++;
   }
@@ -1414,7 +1414,7 @@ class spark_resource_adaptor final : public rmm::mr::device_memory_resource {
         log_status(
           "INJECTED_CUDF_EXCEPTION", thread_id, thread->second.task_id, thread->second.state);
         thread->second.record_failed_retry_time();
-        throw_java_exception(cudf::jni::CUDF_ERROR_CLASS, "injected CudfException");
+        throw_java_exception(cudf::jni::CUDF_EXCEPTION_CLASS, "injected CudfException");
       }
 
       if (thread->second.split_and_retry_oom.matches(is_for_cpu)) {


### PR DESCRIPTION
The exception handling in cudf jni is changed to prepare for support capturing native stacktrace when exception being thrown. That is breaking changes and this PR fixes it.

No new feature/implementation is added.

Depends on:
 * https://github.com/rapidsai/cudf/pull/18983