### PR TITLE
Support running build container in non-UTC timezone

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -25,6 +25,7 @@ REPODIR=$(realpath "$REPODIR_REL")
 GIT_COMMON_DIR_REL=$(git rev-parse --git-common-dir)
 GIT_COMMON_DIR=$(realpath "$GIT_COMMON_DIR_REL")
 WORKDIR=${WORKDIR:-$REPODIR}
+TZ=${TZ:-UTC}
 
 CUDA_VERSION=${CUDA_VERSION:-12.8.0}
 DOCKER_CMD=${DOCKER_CMD:-docker}
@@ -101,6 +102,7 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -e CUDA_VISIBLE_DEVICES \
   -e PARALLEL_LEVEL \
   -e VERBOSE \
+  -e TZ=${TZ} \
   $DOCKER_OPTS \
   $SPARK_IMAGE_NAME \
   bash -c "$RUN_CMD"


### PR DESCRIPTION
This adds the ability to optionally run the build container in non-UTC timezone. It is purely for convenience purpose when running the container for local development. In such situations, reading the build log showing time in local timezone would be much more helpful.

Usage:
```
# This can be added in `~/.bash_profile`.
export TZ=$(readlink /etc/localtime | sed 's#/var/db/timezone/zoneinfo/##')

<./build/run-in-docker> or <build command>
```

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2024.