### PR TITLE
Hide non-public symbols by default

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -250,9 +250,11 @@ set_target_properties(
              # set target compile options
              CXX_STANDARD 17
              CXX_STANDARD_REQUIRED ON
+             CXX_VISIBILITY_PRESET hidden
              CXX_EXTENSIONS ON
              CUDA_STANDARD 17
              CUDA_STANDARD_REQUIRED ON
+             CUDA_VISIBILITY_PRESET hidden
              POSITION_INDEPENDENT_CODE ON
              INTERFACE_POSITION_INDEPENDENT_CODE ON
              CUDA_RUNTIME_LIBRARY Static
@@ -324,9 +326,11 @@ if(USE_GDS)
                # set target compile options
                CXX_STANDARD 17
                CXX_STANDARD_REQUIRED ON
+               CXX_VISIBILITY_PRESET hidden
                CXX_EXTENSIONS ON
                CUDA_STANDARD 17
                CUDA_STANDARD_REQUIRED ON
+               CUDA_VISIBILITY_PRESET hidden
                POSITION_INDEPENDENT_CODE ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON
                CUDA_RUNTIME_LIBRARY Static


### PR DESCRIPTION
This set `CXX_VISIBILITY_PRESET` and `CUDA_VISIBILITY_PRESET` to `hidden`, hiding non-public symbols by default to avoid non-API usage and potential conflicts with symbols from dependencies.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2151.