### PR TITLE
Update `pow_ten` function to properly handle unsupported exponents

### DIFF
--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -496,8 +496,7 @@ inline __device__ chunked256 pow_ten(int exp)
       return chunked256(0x161bcca7119915b5, 0x764b4abe8652979, 0x7775a5f171951000, 0x0);
     default:
       // This is not a supported value...
-      assert(0);
-      return chunked256();
+      CUDF_UNREACHABLE("exponent exceeds supported value");
   }
 }
 


### PR DESCRIPTION
This is a small PR to fix pow_ten function to properly handle unsupported exponents

The `pow_ten` function in `decimal_utils.cu` currently returns an uninitialized `chunked256()` object when an exponent outside the supported range (0-76) is passed. 
Replace the return statement with `CUDF_UNREACHABLE("exp exceeds supported value")` to properly indicate when an unsupported exponent is used. 