### PR TITLE
Use a common object library to avoid repeated compilation when building C++ tests

### DIFF
--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -17,6 +17,20 @@
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
 
+# We need to include the source code defined in cudftestutil_impl, but it is an interface library
+# that does not compile, we need to define an object library for the compilation. By doing so, we
+# only compile such source files once instead of doing so for every test executable.
+add_library(spark_rapids_jni_test_common OBJECT)
+
+target_compile_options(spark_rapids_jni_test_common
+                PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CUDF_CXX_FLAGS}>"
+                        "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
+target_link_libraries(
+    spark_rapids_jni_test_common
+    PUBLIC cudf::cudftestutil GTest::gmock GTest::gmock_main GTest::gtest GTest::gtest_main
+    PRIVATE cudf::cudftestutil_impl
+  )
+
 function(ConfigureTest CMAKE_TEST_NAME)
     add_executable(${CMAKE_TEST_NAME} ${ARGN})
     target_compile_options(${CMAKE_TEST_NAME}
@@ -29,10 +43,18 @@ function(ConfigureTest CMAKE_TEST_NAME)
         ${CMAKE_TEST_NAME}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/gtests>"
                    INSTALL_RPATH "\$ORIGIN/../../../lib"
+                   CXX_STANDARD 17
+                   CXX_STANDARD_REQUIRED ON
+                   # For std:: support of __int128_t. Can be removed once using cuda::std
+                   CXX_EXTENSIONS ON
+                   CUDA_STANDARD 17
+                   CUDA_STANDARD_REQUIRED ON
     )
-    target_link_libraries(${CMAKE_TEST_NAME} GTest::gtest_main GTest::gmock_main cudf::cudf
-                                             cudf::cudftestutil cudf::cudftestutil_impl
-                                             spark_rapids_jni)
+    target_compile_definitions(
+        ${CMAKE_TEST_NAME} PRIVATE THRUST_FORCE_32_BIT_OFFSET_TYPE=1 CCCL_AVOID_SORT_UNROLL=1
+    )
+    target_link_libraries(${CMAKE_TEST_NAME} PRIVATE spark_rapids_jni_test_common
+                                                     spark_rapids_jni)
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
     install(
         TARGETS ${CMAKE_TEST_NAME}


### PR DESCRIPTION
Currently, building each test executable involves compiling all the source files from `cudf::cudftestutil_impl`. That is because `cudf::cudftestutil_impl` is just an interface library that does not compile but just provides a list of source files. This  PR adds an object library that compiles these source files, allowing them to be compiled just once instead of compiled for every build of a test executable.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/2506.

---
### Example of compiling `column_utilities.cu` from `cudf::cudftestutil_impl`:
#### Before:
```
cat build.ninja | grep column_utilities.cu.o: | wc -l
17
```
That means the file is compiled 17 times.

#### After:
```
cat build.ninja | grep column_utilities.cu.o: | wc -l
1
```