### PR TITLE
Apply change to HostTableJni to remove confusion in cuDF builds

### DIFF
--- a/src/main/cpp/src/HostTableJni.cpp
+++ b/src/main/cpp/src/HostTableJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
-#include <iterator>
 #include <memory>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
There has been some confusion in cuDF ci (see https://github.com/rapidsai/cudf/pull/19045 for an example) on why their spark-rapids-jni build is failing. The changes stem from this PR https://github.com/rapidsai/cudf/pull/18983, which refactored headers/includes causing a .cpp file in spark-rapids-jni to fail.

Additionally, the build currently from cuDF is testing cuDF 25.08 vs spark-rapids-jni 25.06 (since we are "in between" versions right now). This is something we'll address in the future. 

This PR is an attempt to make the spark-rapids-jni build "green" even though it's not blocking cuDF, to hopefully reduce confusion overall.