### PR TITLE
Add other spark platform type

### DIFF
--- a/src/main/cpp/src/version.hpp
+++ b/src/main/cpp/src/version.hpp
@@ -24,9 +24,10 @@ namespace spark_rapids_jni {
  * - VANILLA_SPARK: Represents the standard Apache Spark platform.
  * - DATABRICKS: Represents the Databricks platform.
  * - CLOUDERA: Represents the Cloudera platform.
+ * - UNKNOWN: Represents any other platform not specifically defined.
  * - NUM_PLATFORMS: Represents the total number of platforms defined.
  */
-enum class spark_platform_type { VANILLA_SPARK = 0, DATABRICKS, CLOUDERA, NUM_PLATFORMS };
+enum class spark_platform_type { VANILLA_SPARK = 0, DATABRICKS, CLOUDERA, UNKNOWN, NUM_PLATFORMS };
 
 class spark_system {
  public:

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkPlatformType.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkPlatformType.java
@@ -22,12 +22,16 @@ package com.nvidia.spark.rapids.jni;
  * The ordinal values are used to represent the platform in JNI calls.
  */
 public enum SparkPlatformType {
-  // ordinal 0 is vanilla Spark, JNI and kernel use 0 representing Spark
+  // ordinal 0 is vanilla Spark, Will translate to spark_platform_type::VANILLA_SPARK
   VANILLA_SPARK,
 
-  // ordinal 1 is Databricks, JNI and kernel use 1 representing Databricks
+  // ordinal 1 is Databricks, Will translate to spark_platform_type::DATABRICKS
   DATABRICKS,
 
-  // ordinal 2 is Cloudera, JNI and kernel use 2 representing Cloudera
-  CLOUDERA;
+  // ordinal 2 is Cloudera, Will translate to spark_platform_type::CLOUDERA
+  CLOUDERA,
+
+  // ordinal 3 is Unknown. Will translate to spark_platform_type::NUM_PLATFORMS
+  // Maybe customized Spark distributions.
+  UNKNOWN;
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/SparkPlatformType.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/SparkPlatformType.java
@@ -31,7 +31,7 @@ public enum SparkPlatformType {
   // ordinal 2 is Cloudera, Will translate to spark_platform_type::CLOUDERA
   CLOUDERA,
 
-  // ordinal 3 is Unknown. Will translate to spark_platform_type::NUM_PLATFORMS
+  // ordinal 3 is Unknown. Will translate to spark_platform_type::UNKNOWN
   // Maybe customized Spark distributions.
   UNKNOWN;
 }


### PR DESCRIPTION
Contributes to #3401 

Currently for casting string to timestamp, there are the scenarios:
- Is Spark 320
- is Spark 400+
- is Databrick 14.3+
- other

There is EMR customized Spark distribution, should have a UNKNOWN type to define.
Currently Spark-Rapids throws exception for EMR platfor, refer to [getVersionForJni code link](https://github.com/NVIDIA/spark-rapids/pull/12824/files#diff-286dc6154e5f4d6041551f62ae9ed2dd470e45d2923fb3bef01c9b964be58a77), after this JNI PR, Spark-Rapids will use UNKNOW platfor for EMR, and for the EMR distribution, the casting string to timestamp will use the default behavior.

Signed-off-by: Chong Gao <res_life@163.com>