### PR TITLE
Bump org.apache.parquet:parquet-avro from 1.10.0 to 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,22 @@
       <version>${hilbert.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
This is to replace https://github.com/NVIDIA/spark-rapids-jni/pull/3214, because I can not update PR3214

Signed-off-by: Chong Gao <res_life@163.com>