### PR TITLE
Revert "scl default" changes made previously given CI failures

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -20,6 +20,11 @@
 
 set -e
 
+# Set this environment variable to ON to build the docker image for local development,
+# with gcc-toolset enabled by default.
+# This is necessary especially if the docker container is used for local development with an IDE.
+JNI_DOCKER_DEV_BUILD=${JNI_DOCKER_DEV_BUILD:-OFF}
+
 REPODIR_REL=$(git rev-parse --show-toplevel)
 REPODIR=$(realpath "$REPODIR_REL")
 GIT_COMMON_DIR_REL=$(git rev-parse --git-common-dir)
@@ -39,13 +44,20 @@ DOCKER_RUN_EXTRA_ARGS=${DOCKER_RUN_EXTRA_ARGS:-""}
 LOCAL_CCACHE_DIR=${LOCAL_CCACHE_DIR:-"$HOME/.ccache"}
 LOCAL_MAVEN_REPO=${LOCAL_MAVEN_REPO:-"$HOME/.m2/repository"}
 
-SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-devel-rockylinux8"
+if [ "$JNI_DOCKER_DEV_BUILD" == "ON" ]; then
+  echo "Building docker image for local development, gcc-toolset is enabled by default..."
+  SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-devel-rockylinux8"
+else
+  echo "Building docker image for production, gcc-toolset is NOT enabled by default..."
+  SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-rockylinux8"
+fi
 
 # ensure directories exist
 mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO"
 
 $DOCKER_CMD build $DOCKER_BUILD_EXTRA_ARGS -f $REPODIR/ci/Dockerfile \
   --build-arg CUDA_VERSION=$CUDA_VERSION \
+  --build-arg DEV_BUILD=$JNI_DOCKER_DEV_BUILD \
   -t $SPARK_IMAGE_NAME \
   $REPODIR/build
 

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -46,10 +46,10 @@ LOCAL_MAVEN_REPO=${LOCAL_MAVEN_REPO:-"$HOME/.m2/repository"}
 
 if [ "$JNI_DOCKER_DEV_BUILD" == "ON" ]; then
   echo "Building docker image for local development, gcc-toolset is enabled by default..."
-  SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-devel-rockylinux8"
+  JNI_DOCKER_IMAGE="spark-rapids-jni-build:${CUDA_VERSION}-devel-rockylinux8"
 else
   echo "Building docker image for production, gcc-toolset is NOT enabled by default..."
-  SPARK_IMAGE_NAME="spark-rapids-jni-build:${CUDA_VERSION}-rockylinux8"
+  JNI_DOCKER_IMAGE="spark-rapids-jni-build:${CUDA_VERSION}-rockylinux8"
 fi
 
 # ensure directories exist
@@ -58,7 +58,7 @@ mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO"
 $DOCKER_CMD build $DOCKER_BUILD_EXTRA_ARGS -f $REPODIR/ci/Dockerfile \
   --build-arg CUDA_VERSION=$CUDA_VERSION \
   --build-arg DEV_BUILD=$JNI_DOCKER_DEV_BUILD \
-  -t $SPARK_IMAGE_NAME \
+  -t $JNI_DOCKER_IMAGE \
   $REPODIR/build
 
 if [[ "$DOCKER_CMD" == "docker" ]]; then
@@ -114,5 +114,5 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -e VERBOSE \
   -e TZ=${TZ} \
   $DOCKER_OPTS \
-  $SPARK_IMAGE_NAME \
+  $JNI_DOCKER_IMAGE \
   scl enable gcc-toolset-11 "$RUN_CMD"

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,8 +88,6 @@ for (( i=0; i<${#RW_SRC[@]}; i++)); do
   MNT_ARGS+=(--mount type=bind,src=${RW_SRC[$i]},dst=${RW_SRC[$i]})
 done
 
-
-# Running `bash` should already have gcc-toolset enabled when the container initialized.
 $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --rm \
   ${MNT_ARGS[@]} \
   --workdir "$WORKDIR" \
@@ -105,4 +103,4 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -e TZ=${TZ} \
   $DOCKER_OPTS \
   $SPARK_IMAGE_NAME \
-  bash -c "$RUN_CMD"
+  scl enable gcc-toolset-11 "$RUN_CMD"

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -23,6 +23,7 @@
 ARG CUDA_VERSION=12.8.0
 ARG OS_RELEASE=8
 ARG TARGETPLATFORM=linux/amd64
+
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
@@ -43,17 +44,14 @@ RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSI
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 
-# 3.22.3: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
-ARG CMAKE_VERSION=3.30.4
-# default x86_64 from x86 build, aarch64 cmake for arm build
-ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    tar zxf cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    rm cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz
-ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
+
+# Make version-less alias for external reference such as when cmake is called by an IDE outside of the container
+RUN ln -s /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin/cmake /usr/local/bin/cmake
 
 # ccache for interactive builds
-ARG CCACHE_VERSION=4.6
 RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
    tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
    rm ccache-${CCACHE_VERSION}.tar.gz && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -23,7 +23,6 @@
 ARG CUDA_VERSION=12.8.0
 ARG OS_RELEASE=8
 ARG TARGETPLATFORM=linux/amd64
-
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
@@ -41,24 +40,20 @@ ARG CMAKE_ARCH=x86_64
 RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSION} python39 zlib-devel maven tar wget patch ninja-build git && \
   alternatives --set python /usr/bin/python3 && \
   python -m pip install requests 'urllib3<2.0'
-
-# Enable the toolset by default for bash shell
-RUN echo "source scl_source enable gcc-toolset-${TOOLSET_VERSION}" >> /etc/bashrc
-
-# Execute every time a new non-interactive bash shell is started to enable gcc-toolset
-ENV BASH_ENV=/etc/bashrc
-
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 
+# 3.22.3: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
+ARG CMAKE_VERSION=3.30.4
+# default x86_64 from x86 build, aarch64 cmake for arm build
+ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    tar zxf cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
    rm cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz
-
-# Make version-less alias for external reference such as when cmake is called by an IDE outside of the container
-RUN ln -s /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin/cmake /usr/local/bin/cmake
+ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
 
 # ccache for interactive builds
+ARG CCACHE_VERSION=4.6
 RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
    tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
    rm ccache-${CCACHE_VERSION}.tar.gz && \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -28,7 +28,10 @@ ARG TARGETPLATFORM=linux/amd64
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
 
-### Software versions for development
+# If DEV_BUILD is ON, the gcc-toolset will be enabled by default for bash shell
+ARG DEV_BUILD=OFF
+
+# Dependency versions
 ARG TOOLSET_VERSION=11
 ARG CMAKE_VERSION=3.30.4
 ARG CCACHE_VERSION=4.11.2
@@ -41,6 +44,15 @@ ARG CMAKE_ARCH=x86_64
 RUN dnf --enablerepo=powertools install -y scl-utils gcc-toolset-${TOOLSET_VERSION} python39 zlib-devel maven tar wget patch ninja-build git && \
   alternatives --set python /usr/bin/python3 && \
   python -m pip install requests 'urllib3<2.0'
+
+# Enable the gcc-toolset by default for bash shell if DEV_BUILD is ON
+RUN if [ "$DEV_BUILD" = "ON" ]; then \
+        echo "source scl_source enable gcc-toolset-${TOOLSET_VERSION}" >> /etc/bashrc; \
+    fi
+
+# Execute every time a new non-interactive bash shell is started
+ENV BASH_ENV=/etc/bashrc
+
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir -m 777 /usr/local/rapids /rapids
 

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         timeout(time: 3, unit: 'HOURS') { // step only timeout for test run
                             common.resolveIncompatibleDriverIssue(this)
                             try {
-                                sh 'ci/premerge-build.sh'
+                                sh 'scl enable gcc-toolset-11 "ci/premerge-build.sh"'
                                 sh 'bash ci/fuzz-test.sh'
                             } finally {
                                 common.syncDir(this, "${CUSTOM_WORKSPACE}", "${PVC_WORKSPACE}", false, ['.m2/'])

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -17,7 +17,8 @@
 
 # NOTE:
 #     this script is for jenkins only, and should not be used for local development
-#     run with ci/Dockerfile in jenkins: `ci/submodule-sync.sh`
+#     run with ci/Dockerfile in jenkins:
+#         scl enable gcc-toolset-11 ci/submodule-sync.sh
 
 set -ex
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids-jni/issues/3299

The issue here looks to be that we are enabling a devtoolset from within a shell that already has devtoolset enabled. TableTest, in particularly, will shell out (invoking bash, see https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java#L852), and this is the stack where we hang. 

It looks that enabling toolsets should be done once, and this nested case may be error prone. I have reverted the change locally and cannot reproduce the hang anymore. I believe this to be the root cause of our hangs in CI.