### PR TITLE
Expose the row index of one failed row when casting floats to decimals.

### DIFF
--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -117,14 +117,15 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_float
   try {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(j_input);
-    cudf::jni::native_jlongArray output(env, 2);
+    cudf::jni::native_jlongArray output(env, 3);
 
-    auto [casted_col, has_failure] = cudf::jni::floating_point_to_decimal(
+    auto [casted_col, has_failure, failure_row_id] = cudf::jni::floating_point_to_decimal(
       *input,
       cudf::data_type{static_cast<cudf::type_id>(output_type_id), static_cast<int>(decimal_scale)},
       precision);
     output[0] = cudf::jni::release_as_jlong(std::move(casted_col));
     output[1] = static_cast<jlong>(has_failure);
+    output[2] = static_cast<jlong>(failure_row_id);
     return output.get_jArray();
   }
   CATCH_STD(env, 0);

--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -117,15 +117,14 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_float
   try {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(j_input);
-    cudf::jni::native_jlongArray output(env, 3);
+    cudf::jni::native_jlongArray output(env, 2);
 
-    auto [casted_col, has_failure, failure_row_id] = cudf::jni::floating_point_to_decimal(
+    auto [casted_col, failure_row_id] = cudf::jni::floating_point_to_decimal(
       *input,
       cudf::data_type{static_cast<cudf::type_id>(output_type_id), static_cast<int>(decimal_scale)},
       precision);
     output[0] = cudf::jni::release_as_jlong(std::move(casted_col));
-    output[1] = static_cast<jlong>(has_failure);
-    output[2] = static_cast<jlong>(failure_row_id);
+    output[1] = static_cast<jlong>(failure_row_id);
     return output.get_jArray();
   }
   CATCH_STD(env, 0);

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -1311,6 +1311,7 @@ struct floating_point_to_decimal_fn {
   cudf::column_device_view input;
   int8_t* validity;
   bool* has_failure;
+  cudf::size_type* failure_row_id;
   int32_t decimal_places;
   DecimalRepType exclusive_bound;
 
@@ -1319,7 +1320,6 @@ struct floating_point_to_decimal_fn {
     auto const x = input.element<FloatType>(idx);
 
     if (input.is_null(idx) || !std::isfinite(x)) {
-      if (!std::isfinite(x)) { *has_failure = true; }
       validity[idx] = false;
       return DecimalRepType{0};
     }
@@ -1327,7 +1327,10 @@ struct floating_point_to_decimal_fn {
     auto const scaled_rounded = scaled_round<FloatType, DecimalRepType>(x, -decimal_places);
     auto const is_out_of_bound =
       -exclusive_bound >= scaled_rounded || scaled_rounded >= exclusive_bound;
-    if (is_out_of_bound) { *has_failure = true; }
+    if (is_out_of_bound) {
+      *has_failure    = true;
+      *failure_row_id = idx;
+    }
     validity[idx] = !is_out_of_bound;
 
     return is_out_of_bound ? DecimalRepType{0} : scaled_rounded;
@@ -1361,6 +1364,7 @@ struct floating_point_to_decimal_dispatcher {
                   cudf::mutable_column_view const& output,
                   int8_t* validity,
                   bool* has_failure,
+                  cudf::size_type* failure_row_id,
                   int32_t decimal_places,
                   int32_t precision,
                   rmm::cuda_stream_view stream) const
@@ -1371,17 +1375,18 @@ struct floating_point_to_decimal_dispatcher {
     auto const exclusive_bound = static_cast<DecimalRepType>(
       multiply_power10<DecimalRepType>(cuda::std::make_unsigned_t<DecimalRepType>{1}, precision));
 
-    thrust::tabulate(rmm::exec_policy_nosync(stream),
-                     output.begin<DecimalRepType>(),
-                     output.end<DecimalRepType>(),
-                     floating_point_to_decimal_fn<FloatType, DecimalRepType>{
-                       *d_input_ptr, validity, has_failure, decimal_places, exclusive_bound});
+    thrust::tabulate(
+      rmm::exec_policy_nosync(stream),
+      output.begin<DecimalRepType>(),
+      output.end<DecimalRepType>(),
+      floating_point_to_decimal_fn<FloatType, DecimalRepType>{
+        *d_input_ptr, validity, has_failure, failure_row_id, decimal_places, exclusive_bound});
   }
 };
 
 }  // namespace
 
-std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
+std::tuple<std::unique_ptr<cudf::column>, bool, cudf::size_type> floating_point_to_decimal(
   cudf::column_view const& input,
   cudf::data_type output_type,
   int32_t precision,
@@ -1396,6 +1401,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
 
   rmm::device_uvector<int8_t> validity(input.size(), stream, default_mr);
   rmm::device_scalar<bool> has_failure(false, stream, default_mr);
+  rmm::device_scalar<cudf::size_type> failure_row_id(-1, stream, default_mr);
 
   cudf::double_type_dispatcher(input.type(),
                                output_type,
@@ -1404,6 +1410,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
                                output->mutable_view(),
                                validity.begin(),
                                has_failure.data(),
+                               failure_row_id.data(),
                                decimal_places,
                                precision,
                                stream);
@@ -1412,7 +1419,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
     cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
   if (null_count > 0) { output->set_null_mask(std::move(null_mask), null_count); }
 
-  return {std::move(output), has_failure.value(stream)};
+  return {std::move(output), has_failure.value(stream), failure_row_id.value(stream)};
 }
 
 }  // namespace cudf::jni

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -74,7 +74,7 @@ std::unique_ptr<cudf::table> sub_decimal128(
  * @return A cudf column containing the cast result and a boolean value indicating whether the cast
            operation has failed for any input rows
  */
-std::tuple<std::unique_ptr<cudf::column>, bool, cudf::size_type> floating_point_to_decimal(
+std::pair<std::unique_ptr<cudf::column>, cudf::size_type> floating_point_to_decimal(
   cudf::column_view const& input,
   cudf::data_type output_type,
   int32_t precision,

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -74,7 +74,7 @@ std::unique_ptr<cudf::table> sub_decimal128(
  * @return A cudf column containing the cast result and a boolean value indicating whether the cast
            operation has failed for any input rows
  */
-std::pair<std::unique_ptr<cudf::column>, bool> floating_point_to_decimal(
+std::tuple<std::unique_ptr<cudf::column>, bool, cudf::size_type> floating_point_to_decimal(
   cudf::column_view const& input,
   cudf::data_type output_type,
   int32_t precision,

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -188,12 +188,10 @@ public class DecimalUtils {
    */
   public static class CastFloatToDecimalResult {
     public final ColumnVector result; // the cast result
-    public final boolean hasFailure; // whether the cast operation has failed for any input rows
-    public final long failureRowId; // the index of one faliure row, -1 means no failures.
+    public final long failureRowId; // the index of one faliure row, negative means no failures.
 
-    public CastFloatToDecimalResult(ColumnVector result, boolean hasFailure, long failureId) {
+    public CastFloatToDecimalResult(ColumnVector result, long failureId) {
       this.result = result;
-      this.hasFailure = hasFailure;
       this.failureRowId = failureId;
     }
   }
@@ -211,7 +209,7 @@ public class DecimalUtils {
     long[] result = floatingPointToDecimal(
         input.getNativeView(), outputType.getTypeId().getNativeId(), precision,
         outputType.getScale());
-    return new CastFloatToDecimalResult(new ColumnVector(result[0]), result[1] != 0, result[2]);
+    return new CastFloatToDecimalResult(new ColumnVector(result[0]), result[1]);
   }
 
   private static native long[] multiply128(long viewA, long viewB, int productScale, boolean interimCast);

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -189,10 +189,12 @@ public class DecimalUtils {
   public static class CastFloatToDecimalResult {
     public final ColumnVector result; // the cast result
     public final boolean hasFailure; // whether the cast operation has failed for any input rows
+    public final long failureRowId; // the index of one faliure row, -1 means no failures.
 
-    public CastFloatToDecimalResult(ColumnVector result, boolean hasFailure) {
+    public CastFloatToDecimalResult(ColumnVector result, boolean hasFailure, long failureId) {
       this.result = result;
       this.hasFailure = hasFailure;
+      this.failureRowId = failureId;
     }
   }
 
@@ -209,7 +211,7 @@ public class DecimalUtils {
     long[] result = floatingPointToDecimal(
         input.getNativeView(), outputType.getTypeId().getNativeId(), precision,
         outputType.getScale());
-    return new CastFloatToDecimalResult(new ColumnVector(result[0]), result[1] != 0);
+    return new CastFloatToDecimalResult(new ColumnVector(result[0]), result[1] != 0, result[2]);
   }
 
   private static native long[] multiply128(long viewA, long viewB, int productScale, boolean interimCast);

--- a/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/DecimalUtils.java
@@ -188,7 +188,7 @@ public class DecimalUtils {
    */
   public static class CastFloatToDecimalResult {
     public final ColumnVector result; // the cast result
-    public final long failureRowId; // the index of one faliure row, negative means no failures.
+    public final long failureRowId; // the index of one failure row, negative means no failures
 
     public CastFloatToDecimalResult(ColumnVector result, long failureId) {
       this.result = result;

--- a/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/DecimalUtilsTest.java
@@ -686,11 +686,11 @@ public class DecimalUtilsTest {
       DecimalUtils.CastFloatToDecimalResult output5 = DecimalUtils.floatingPointToDecimal(input5, DType.create(DType.DTypeEnum.DECIMAL64, -1), 4);
 
       try {
-        assert (!output1.hasFailure);
-        assert (!output2.hasFailure);
-        assert (!output3.hasFailure);
-        assert (output4.hasFailure);
-        assert (output5.hasFailure);
+        assert (output1.failureRowId < 0);
+        assert (output2.failureRowId < 0);
+        assert (output3.failureRowId < 0);
+        assert (output4.failureRowId >= 0);
+        assert (output5.failureRowId >= 0);
 
         assertColumnsAreEqual(expected1, output1.result);
         assertColumnsAreEqual(expected2, output2.result);


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/11550

This PR exposes the row index of one failed row when casting floats to decimals to replace the `has_failure`. This index will be used to get the row value which will be used to build the excepion message, to align with the behavior of Spark.

Spark will return nulls for NaN, Infinity and -Infinity even the ANSI mode is on, so this PR also changes the code to follow the logic.