### PR TITLE
Update get_json_object parsing to deal with UCS2 surrogates

### DIFF
--- a/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GetJsonObjectTest.java
@@ -789,6 +789,19 @@ public class GetJsonObjectTest {
     }
   }
 
+  @Test
+  void getJsonObjectTest_testUCS2Surrogates() {
+    JSONUtils.PathInstructionJni[] query = new JSONUtils.PathInstructionJni[] {
+        namedPath("package_name")
+    };
+    try (ColumnVector input = ColumnVector.fromStrings(
+        "{'package_name': 'TEST1'}", "{'package_name': '\\uD83E\\uDD66'}");
+         ColumnVector expected = ColumnVector.fromStrings("TEST1", "\uD83E\uDD66");
+         ColumnVector output = JSONUtils.getJsonObject(input, query)) {
+      assertColumnsAreEqual(expected, output);
+    }
+  }
+
   /**
    * Test path: '$.store.book[*].reader[*].age'
    * When 'book' array size is one, then return one dimension array,


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/12857 but does not deal with invalid/dangling surrogates the same way as Spark does. Our code just falls back to doing what it did before. But Spark on the CPU does things a little differently. I am happy to file a follow on issue to try and make them all match.