### PR TITLE
Ansi multiply

### DIFF
--- a/src/main/cpp/src/multiply.cu
+++ b/src/main/cpp/src/multiply.cu
@@ -16,99 +16,314 @@
 
 #include "multiply.hpp"
 #include "row_error_utilities.hpp"
+#include "utilities.hpp"
 
-#include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/valid_if.cuh>
 
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/limits>
 #include <thrust/for_each.h>
 
 namespace spark_rapids_jni {
 
 namespace {
 
-// Functor to perform multiplication on two columns with overflow checks if ANSI mode is enabled.
+void check_multiply_inputs(cudf::data_type left_type,
+                           cudf::data_type right_type,
+                           cudf::size_type left_size,
+                           cudf::size_type right_size,
+                           bool is_ansi_mode,
+                           bool is_try_mode)
+{
+  CUDF_EXPECTS(left_type == right_type, "Input columns must have the same data type");
+  CUDF_EXPECTS(is_basic_spark_numeric(left_type), "Unsupported data type for multiplication.");
+  CUDF_EXPECTS(left_size == right_size, "Input columns must have the same size");
+  CUDF_EXPECTS(!(is_ansi_mode && is_try_mode),
+               "Cannot enable both ANSI mode and TRY mode at the same time");
+}
+
+/**
+ * @brief Multiply two int8_t or int16_t values with overflow check.
+ * Set `valid` to false if overflow occurs.
+ */
+template <typename T, CUDF_ENABLE_IF(std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t>)>
+__device__ void multiply(T x, T y, bool check_overflow, bool* valid, T* result)
+{
+  // when int8_t * int8_t or int16_t * int16_t, the result is promoted to int type.
+  int32_t r = x * y;
+  if (check_overflow &&
+      (r < cuda::std::numeric_limits<T>::min() || r > cuda::std::numeric_limits<T>::max())) {
+    *valid = false;  // overflow in ansi mode
+  } else {
+    *valid  = true;
+    *result = static_cast<T>(r);
+  }
+}
+
+/**
+ * @brief Multiply two int32_t values with overflow check.
+ * Set `valid` to false if overflow occurs.
+ */
+template <typename T, CUDF_ENABLE_IF(std::is_same_v<T, int32_t>)>
+__device__ void multiply(T x, T y, bool check_overflow, bool* valid, T* result)
+{
+  if (check_overflow) {
+    int64_t r = static_cast<int64_t>(x) * static_cast<int64_t>(y);
+    if (auto r_cast = static_cast<int>(r); static_cast<long>(r_cast) == r) {
+      *valid  = true;
+      *result = r_cast;
+    } else {
+      *valid = false;  // overflow in ansi mode
+    }
+  } else {
+    *valid  = true;
+    *result = x * y;
+  }
+}
+
+__device__ bool is_multiply_overflow(int64_t a, int64_t b)
+{
+  // constexpr int64_t INT64_MIN = (-9223372036854775807L - 1L); // -2^63
+  // constexpr int64_t INT64_MAX = 9223372036854775807L; // 2^63 - 1
+
+  if (a > 0 && b > 0 && a > 9223372036854775807L / b) return true;          // Positive overflow
+  if (a < 0 && b < 0 && a < 9223372036854775807L / b) return true;          // Negative overflow
+  if (a > 0 && b < 0 && b < (-9223372036854775807L - 1L) / a) return true;  // Mixed sign overflow
+  if (a < 0 && b > 0 && a < (-9223372036854775807L - 1L) / b) return true;  // Mixed sign overflow
+  return false;
+}
+
+/**
+ * @brief Multiply two int64_t values with overflow check.
+ * Set `valid` to false if overflow occurs.
+ */
+template <typename T, CUDF_ENABLE_IF(std::is_same_v<T, int64_t>)>
+__device__ void multiply(T x, T y, bool check_overflow, bool* valid, T* result)
+{
+  if (check_overflow && is_multiply_overflow(x, y)) {
+    *valid = false;  // overflow
+    return;
+  }
+
+  *valid  = true;
+  *result = x * y;
+}
+
+/**
+ * @brief Multiply two float values.
+ * `check_overflow` is ignored for float multiplication.
+ */
+template <typename T, CUDF_ENABLE_IF(std::is_same_v<T, float> || std::is_same_v<T, double>)>
+__device__ void multiply(T x, T y, bool check_overflow, bool* valid, T* result)
+{
+  *valid  = true;
+  *result = x * y;
+}
+
+/**
+ * @brief Functor to perform multiplication on two accessors,
+ * accessor is type of `column_accessor` or `numeric_scalar_accessor`
+ */
+template <typename T, typename LEFT_ACCESSOR, typename RIGHT_ACCESSOR>
 struct multiply_fn {
-  cudf::column_device_view left_cdv;
-  cudf::column_device_view right_cdv;
-  bool is_ansi_mode;
-  int* results;
+  LEFT_ACCESSOR left_accessor;
+  RIGHT_ACCESSOR right_accessor;
+  bool check_overflow;
+  T* results;
   bool* validity;
 
   __device__ void operator()(int row_idx) const
   {
-    if (left_cdv.is_null(row_idx) || right_cdv.is_null(row_idx)) {
+    if (left_accessor.is_null(row_idx) || right_accessor.is_null(row_idx)) {
       validity[row_idx] = false;
       return;
     }
 
-    if (is_ansi_mode) {
-      long a = left_cdv.element<int>(row_idx);
-      long b = right_cdv.element<int>(row_idx);
-      long r = a * b;
-      if (auto r_cast = static_cast<int>(r); static_cast<long>(r_cast) == r) {
-        validity[row_idx] = true;
-        results[row_idx]  = r_cast;
-      } else {
-        // Overflow detected
-        validity[row_idx] = false;
-      }
+    multiply<T>(left_accessor.element(row_idx),
+                right_accessor.element(row_idx),
+                check_overflow,
+                &validity[row_idx],
+                &results[row_idx]);
+  }
+};
+
+template <typename T, typename LEFT_ACCESSOR, typename RIGHT_ACCESSOR>
+std::unique_ptr<cudf::column> multiply(cudf::data_type type,
+                                       cudf::size_type num_rows,
+                                       LEFT_ACCESSOR const& left_accessor,
+                                       RIGHT_ACCESSOR const& right_accessor,
+                                       bool is_ansi_mode,
+                                       bool is_try_mode,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr)
+{
+  auto result =
+    cudf::make_numeric_column(type, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
+
+  // create a validity vector to track valid results
+  auto validity =
+    rmm::device_uvector<bool>(num_rows, stream, cudf::get_current_device_resource_ref());
+
+  // excute the multiplication
+  bool check_overflow = is_ansi_mode || is_try_mode;
+  thrust::for_each_n(
+    rmm::exec_policy_nosync(stream),
+    thrust::make_counting_iterator(0),
+    num_rows,
+    multiply_fn<T, LEFT_ACCESSOR, RIGHT_ACCESSOR>{left_accessor,
+                                                  right_accessor,
+                                                  check_overflow,
+                                                  result->mutable_view().begin<T>(),
+                                                  validity.data()});
+  // collect null mask and set
+  auto [null_mask, null_count] =
+    cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
+  if (null_count > 0) { result->set_null_mask(std::move(null_mask), null_count, stream); }
+
+  return result;
+}
+
+/**
+ * @brief Operator for multiply(cv, cv).
+ */
+struct dispatch_multiply {
+  // left operand can be either a column_view or a scalar
+  cudf::column_view const* left_cv;
+  cudf::scalar const* left_scalar;
+
+  // right operand can be either a column_view or a scalar
+  cudf::column_view const* right_cv;
+  cudf::scalar const* right_scalar;
+
+  template <typename T, CUDF_ENABLE_IF(is_basic_spark_numeric<T>())>
+  std::unique_ptr<cudf::column> operator()(cudf::data_type type,
+                                           cudf::size_type num_rows,
+                                           bool is_ansi_mode,
+                                           bool is_try_mode,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr) const
+  {
+    if (left_cv != nullptr && right_cv != nullptr) {
+      auto const left_cdv       = cudf::column_device_view::create(*left_cv, stream);
+      auto const left_accessor  = column_accessor<T>(*left_cdv);
+      auto const right_cdv      = cudf::column_device_view::create(*right_cv, stream);
+      auto const right_accessor = column_accessor<T>(*right_cdv);
+      return multiply<T, column_accessor<T>, column_accessor<T>>(
+        type, num_rows, left_accessor, right_accessor, is_ansi_mode, is_try_mode, stream, mr);
+    } else if (left_cv != nullptr && right_scalar != nullptr) {
+      auto const left_cdv      = cudf::column_device_view::create(*left_cv, stream);
+      auto const left_accessor = column_accessor<T>(*left_cdv);
+      auto const right_sdv     = cudf::get_scalar_device_view(
+        static_cast<cudf::scalar_type_t<T>&>(const_cast<cudf::scalar&>(*right_scalar)));
+      auto const right_accessor = numeric_scalar_accessor<T>(right_sdv);
+      return multiply<T, column_accessor<T>, numeric_scalar_accessor<T>>(
+        type, num_rows, left_accessor, right_accessor, is_ansi_mode, is_try_mode, stream, mr);
+    } else if (left_scalar != nullptr && right_cv != nullptr) {
+      auto const left_sdv = cudf::get_scalar_device_view(
+        static_cast<cudf::scalar_type_t<T>&>(const_cast<cudf::scalar&>(*left_scalar)));
+      auto const left_accessor  = numeric_scalar_accessor<T>(left_sdv);
+      auto const right_cdv      = cudf::column_device_view::create(*right_cv, stream);
+      auto const right_accessor = column_accessor<T>(*right_cdv);
+      return multiply<T, numeric_scalar_accessor<T>, column_accessor<T>>(
+        type, num_rows, left_accessor, right_accessor, is_ansi_mode, is_try_mode, stream, mr);
     } else {
-      validity[row_idx] = true;
-      results[row_idx]  = left_cdv.element<int>(row_idx) * right_cdv.element<int>(row_idx);
+      CUDF_FAIL("Unsupported combination of inputs for multiplication.");
     }
+  }
+
+  template <typename T, CUDF_ENABLE_IF(!is_basic_spark_numeric<T>())>
+  std::unique_ptr<cudf::column> operator()(cudf::data_type type,
+                                           cudf::size_type num_rows,
+                                           bool is_ansi_mode,
+                                           bool is_try_mode,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr) const
+  {
+    CUDF_FAIL("Unsupported type when multiply.");
   }
 };
 
 }  // anonymous namespace
 
-std::unique_ptr<cudf::column> multiply(cudf::column_view const& left_input,
-                                       cudf::column_view const& right_input,
+std::unique_ptr<cudf::column> multiply(cudf::column_view const& left_cv,
+                                       cudf::column_view const& right_cv,
                                        bool is_ansi_mode,
+                                       bool is_try_mode,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr)
 {
-  // Check input types
-  if (left_input.type() != cudf::data_type(cudf::type_id::INT32) ||
-      right_input.type() != cudf::data_type(cudf::type_id::INT32)) {
-    throw cudf::logic_error("Both inputs must be of type INT32");
-  }
-
-  // Check input sizes
-  if (left_input.size() != right_input.size()) {
-    throw cudf::logic_error("Input columns must have the same size");
-  }
-
-  auto result = cudf::make_numeric_column(cudf::data_type(cudf::type_id::INT32),
-                                          left_input.size(),
-                                          cudf::mask_state::UNALLOCATED,
-                                          stream,
-                                          mr);
-  auto validity =
-    rmm::device_uvector<bool>(left_input.size(), stream, cudf::get_current_device_resource_ref());
-  auto dcv_left  = cudf::column_device_view::create(left_input, stream);
-  auto dcv_right = cudf::column_device_view::create(right_input, stream);
-
-  thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
-    thrust::make_counting_iterator(0),
-    left_input.size(),
-    multiply_fn{
-      *dcv_left, *dcv_right, is_ansi_mode, result->mutable_view().data<int>(), validity.data()});
-
-  // make null mask and null count
-  auto [null_mask, null_count] =
-    cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
-  if (null_count > 0) { result->set_null_mask(std::move(null_mask), null_count, stream); }
-
+  check_multiply_inputs(
+    left_cv.type(), right_cv.type(), left_cv.size(), right_cv.size(), is_ansi_mode, is_try_mode);
+  auto result = cudf::type_dispatcher(left_cv.type(),
+                                      dispatch_multiply{&left_cv, nullptr, &right_cv, nullptr},
+                                      left_cv.type(),
+                                      left_cv.size(),
+                                      is_ansi_mode,
+                                      is_try_mode,
+                                      stream,
+                                      mr);
+  // check for overflow if ANSI mode is enabled
   if (is_ansi_mode) {
     // throw an error if any row has an overflow if ANSI mode is enabled
-    spark_rapids_jni::throw_row_error_if_any(left_input, right_input, result->view(), stream);
+    spark_rapids_jni::throw_row_error_if_any(left_cv, right_cv, result->view(), stream);
   }
+  return result;
+}
 
+std::unique_ptr<cudf::column> multiply(cudf::column_view const& left_cv,
+                                       cudf::scalar const& right_scalar,
+                                       bool is_ansi_mode,
+                                       bool is_try_mode,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr)
+{
+  check_multiply_inputs(
+    left_cv.type(), right_scalar.type(), left_cv.size(), left_cv.size(), is_ansi_mode, is_try_mode);
+  auto result = cudf::type_dispatcher(left_cv.type(),
+                                      dispatch_multiply{&left_cv, nullptr, nullptr, &right_scalar},
+                                      left_cv.type(),
+                                      left_cv.size(),
+                                      is_ansi_mode,
+                                      is_try_mode,
+                                      stream,
+                                      mr);
+  // check for overflow if ANSI mode is enabled
+  if (is_ansi_mode) {
+    // throw an error if any row has an overflow if ANSI mode is enabled
+    spark_rapids_jni::throw_row_error_if_any(left_cv, right_scalar, result->view(), stream);
+  }
+  return result;
+}
+
+std::unique_ptr<cudf::column> multiply(cudf::scalar const& left_scalar,
+                                       cudf::column_view const& right_cv,
+                                       bool is_ansi_mode,
+                                       bool is_try_mode,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr)
+{
+  check_multiply_inputs(left_scalar.type(),
+                        right_cv.type(),
+                        right_cv.size(),
+                        right_cv.size(),
+                        is_ansi_mode,
+                        is_try_mode);
+  auto result = cudf::type_dispatcher(left_scalar.type(),
+                                      dispatch_multiply{nullptr, &left_scalar, &right_cv, nullptr},
+                                      right_cv.type(),
+                                      right_cv.size(),
+                                      is_ansi_mode,
+                                      is_try_mode,
+                                      stream,
+                                      mr);
+  // check for overflow if ANSI mode is enabled
+  if (is_ansi_mode) {
+    // throw an error if any row has an overflow if ANSI mode is enabled
+    spark_rapids_jni::throw_row_error_if_any(left_scalar, right_cv, result->view(), stream);
+  }
   return result;
 }
 

--- a/src/main/cpp/src/multiply.cu
+++ b/src/main/cpp/src/multiply.cu
@@ -209,25 +209,23 @@ struct dispatch_multiply {
       auto const left_cdv  = cudf::column_device_view::create(*left_cv, stream);
       auto const right_cdv = cudf::column_device_view::create(*right_cv, stream);
       if (left_cv->has_nulls()) {
+        auto const left_accessor = cudf::detail::make_pair_iterator<T, true>(*left_cdv);
         if (right_cv->has_nulls()) {
-          auto const left_accessor  = cudf::detail::make_pair_iterator<T, true>(*left_cdv);
           auto const right_accessor = cudf::detail::make_pair_iterator<T, true>(*right_cdv);
           return multiply_impl<T, decltype(left_accessor), decltype(right_accessor)>(
             type, num_rows, left_accessor, right_accessor, check_overflow, stream, mr);
         } else {
-          auto const left_accessor  = cudf::detail::make_pair_iterator<T, true>(*left_cdv);
           auto const right_accessor = cudf::detail::make_pair_iterator<T, false>(*right_cdv);
           return multiply_impl<T, decltype(left_accessor), decltype(right_accessor)>(
             type, num_rows, left_accessor, right_accessor, check_overflow, stream, mr);
         }
       } else {
+        auto const left_accessor = cudf::detail::make_pair_iterator<T, false>(*left_cdv);
         if (right_cv->has_nulls()) {
-          auto const left_accessor  = cudf::detail::make_pair_iterator<T, false>(*left_cdv);
           auto const right_accessor = cudf::detail::make_pair_iterator<T, true>(*right_cdv);
           return multiply_impl<T, decltype(left_accessor), decltype(right_accessor)>(
             type, num_rows, left_accessor, right_accessor, check_overflow, stream, mr);
         } else {
-          auto const left_accessor  = cudf::detail::make_pair_iterator<T, false>(*left_cdv);
           auto const right_accessor = cudf::detail::make_pair_iterator<T, false>(*right_cdv);
           return multiply_impl<T, decltype(left_accessor), decltype(right_accessor)>(
             type, num_rows, left_accessor, right_accessor, check_overflow, stream, mr);

--- a/src/main/cpp/src/multiply.cu
+++ b/src/main/cpp/src/multiply.cu
@@ -86,13 +86,14 @@ __device__ void multiply(T x, T y, bool check_overflow, bool* valid, T* result)
 
 __device__ bool is_multiply_overflow(int64_t a, int64_t b)
 {
-  // constexpr int64_t INT64_MIN = (-9223372036854775807L - 1L); // -2^63
-  // constexpr int64_t INT64_MAX = 9223372036854775807L; // 2^63 - 1
+  constexpr auto int64_min = cuda::std::numeric_limits<int64_t>::min();
+  constexpr auto int64_max = cuda::std::numeric_limits<int64_t>::max();
 
-  if (a > 0 && b > 0 && a > 9223372036854775807L / b) return true;          // Positive overflow
-  if (a < 0 && b < 0 && a < 9223372036854775807L / b) return true;          // Negative overflow
-  if (a > 0 && b < 0 && b < (-9223372036854775807L - 1L) / a) return true;  // Mixed sign overflow
-  if (a < 0 && b > 0 && a < (-9223372036854775807L - 1L) / b) return true;  // Mixed sign overflow
+  if (a > 0 && b > 0 && a > int64_max / b) return true;  // Positive overflow
+  if (a < 0 && b < 0 && a < int64_max / b) return true;  // Negative overflow
+  if (a > 0 && b < 0 && b < int64_min / a) return true;  // Mixed sign overflow
+  if (a < 0 && b > 0 && a < int64_min / b) return true;  // Mixed sign overflow
+
   return false;
 }
 

--- a/src/main/cpp/src/multiply.cu
+++ b/src/main/cpp/src/multiply.cu
@@ -141,13 +141,8 @@ struct multiply_fn {
 
   __device__ void operator()(int row_idx) const
   {
-    auto const& left_pair   = left_accessor[row_idx];
-    auto const& right_pair  = right_accessor[row_idx];
-    auto const& left_value  = left_pair.first;
-    auto const& right_value = right_pair.first;
-    auto const& left_valid  = left_pair.second;
-    auto const& right_valid = right_pair.second;
-
+    auto const [left_value, left_valid]   = left_accessor[row_idx];
+    auto const [right_value, right_valid] = right_accessor[row_idx];
     if (!left_valid || !right_valid) {
       validity[row_idx] = false;
       return;

--- a/src/main/cpp/src/multiply.hpp
+++ b/src/main/cpp/src/multiply.hpp
@@ -16,30 +16,107 @@
 #pragma once
 
 #include <cudf/column/column_view.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
 namespace spark_rapids_jni {
 
 /**
- * @brief Multiply two columns with optional ANSI SQL mode.
- * Only supports 32-bit integer.
- * This function performs element-wise multiplication of two columns.
+ * @brief Multiply two columns with overflow check if ANSI mode is enabled.
+ * Only supports Spark data types: byte, short, integer, long, float32 and float64.
  * If `is_ansi_mode` is true, it checks for overflow and sets the validity accordingly.
  *
- * @param left_input The left input column view.
- * @param right_input The right input column view.
- * @param is_ansi_mode If true, enables ANSI SQL mode for overflow checking.
+ * E.g.:
+ * Integer.MAX_VALUE * 2 = -2 in regular mode
+ * Integer.MAX_VALUE * 2 = null in try mode
+ * Integer.MAX_VALUE * 2 = throws exception in ansi mode
+ *
+ * The left and right inputs MUST have the same data type, and have the same size.
+ * MUST not enable both ANSI mode and TRY mode at the same time.
+ *
+ * @throws spark_rapids_jni::exception_with_row_index exception if it's ansi mode and overflow
+ * occurs.
+ *
+ * @param left_input The left input.
+ * @param right_input The right input.
+ * @param is_ansi_mode If true, throws exception when overflow occurs.
+ * @param is_try_mode If true, set null when overflow occurs.
  * @param stream CUDA stream to use for the operation.
  * @param mr Memory resource to use for allocations.
  * @return A new column containing the results of the multiplication.
- * @throws spark_rapids_jni::exception_with_row_index exception if it's ansi mode and overflow
- * occurs.
  */
 std::unique_ptr<cudf::column> multiply(
   cudf::column_view const& left_input,
   cudf::column_view const& right_input,
   bool is_ansi_mode,
+  bool is_try_mode,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Multiply a column and a scalar with overflow check if ANSI mode is enabled.
+ * Only supports Spark data types: byte, short, integer, long, float32 and float64.
+ * If `is_ansi_mode` is true, it checks for overflow and sets the validity accordingly.
+ *
+ * E.g.:
+ * Integer.MAX_VALUE * 2 = -2 in regular mode
+ * Integer.MAX_VALUE * 2 = null in try mode
+ * Integer.MAX_VALUE * 2 = throws exception in ansi mode
+ *
+ * The left and right inputs MUST have the same data type, and have the same size.
+ * MUST not enable both ANSI mode and TRY mode at the same time.
+ * Input types MUST be: int8, int16, int32, int64, float32, or float64.
+ *
+ * @throws spark_rapids_jni::exception_with_row_index exception if it's ansi mode and overflow
+ * occurs.
+ *
+ * @param left_input The left input.
+ * @param right_input The right input.
+ * @param is_ansi_mode If true, throws exception when overflow occurs.
+ * @param is_try_mode If true, set null when overflow occurs.
+ * @param stream CUDA stream to use for the operation.
+ * @param mr Memory resource to use for allocations.
+ * @return A new column containing the results of the multiplication.
+ */
+std::unique_ptr<cudf::column> multiply(
+  cudf::column_view const& left_input,
+  cudf::scalar const& right_input,
+  bool is_ansi_mode,
+  bool is_try_mode,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Multiply a scalar and a column with overflow check if ANSI mode is enabled.
+ * Only supports Spark data types: byte, short, integer, long, float32 and float64.
+ * If `is_ansi_mode` is true, it checks for overflow and sets the validity accordingly.
+ *
+ * E.g.:
+ * Integer.MAX_VALUE * 2 = -2 in regular mode
+ * Integer.MAX_VALUE * 2 = null in try mode
+ * Integer.MAX_VALUE * 2 = throws exception in ansi mode
+ *
+ * The left and right inputs MUST have the same data type, and have the same size.
+ * MUST not enable both ANSI mode and TRY mode at the same time.
+ * Input types MUST be: int8, int16, int32, int64, float32, or float64.
+ *
+ * @throws spark_rapids_jni::exception_with_row_index exception if it's ansi mode and overflow
+ * occurs.
+ *
+ * @param left_input The left input.
+ * @param right_input The right input.
+ * @param is_ansi_mode If true, throws exception when overflow occurs.
+ * @param is_try_mode If true, set null when overflow occurs.
+ * @param stream CUDA stream to use for the operation.
+ * @param mr Memory resource to use for allocations.
+ * @return A new column containing the results of the multiplication.
+ */
+std::unique_ptr<cudf::column> multiply(
+  cudf::scalar const& left_input,
+  cudf::column_view const& right_input,
+  bool is_ansi_mode,
+  bool is_try_mode,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/src/main/cpp/src/row_error_utilities.hpp
+++ b/src/main/cpp/src/row_error_utilities.hpp
@@ -22,12 +22,12 @@
 namespace spark_rapids_jni {
 
 /**
- * @brief Throws an error with the row index if has any row is invalid for a unary operation.
+ * @brief Throws exception_with_row_index if has any row is invalid for a unary operation.
  * If the input is not null and the result is null, it means the row is invalid.
  *
  * @throws exception_with_row_index if any row is invalid.
  *
- * @param input The input column view.
+ * @param input The input.
  * @param result The result column view.
  */
 void throw_row_error_if_any(cudf::column_view const& input,
@@ -35,13 +35,13 @@ void throw_row_error_if_any(cudf::column_view const& input,
                             rmm::cuda_stream_view stream = cudf::get_default_stream());
 
 /**
- * @brief Throws an error with the row index if has any row is invalid for a binary operation.
- * If the inputs are not null and the result is null, it means the row is invalid.
+ * @brief Throws exception_with_row_index if has any row is invalid for a binary operation.
+ * If the input is not null and the result is null, it means the row is invalid.
  *
  * @throws exception_with_row_index if any row is invalid.
  *
- * @param input1 The first input column view.
- * @param input2 The second input column view.
+ * @param input1 The first input.
+ * @param input2 The second input.
  * @param result The result column view.
  */
 void throw_row_error_if_any(cudf::column_view const& input1,
@@ -50,14 +50,14 @@ void throw_row_error_if_any(cudf::column_view const& input1,
                             rmm::cuda_stream_view stream = cudf::get_default_stream());
 
 /**
- * @brief Throws an error with the row index if has any row is invalid for a ternary operation.
- * If the inputs are not null and the result is null, it means the row is invalid.
+ * @brief Throws exception_with_row_index if has any row is invalid for a ternary operation.
+ * If the input is not null and the result is null, it means the row is invalid.
  *
  * @throws exception_with_row_index if any row is invalid.
  *
- * @param input1 The first input column view.
- * @param input2 The second input column view.
- * @param input3 The third input column view.
+ * @param input1 The first input.
+ * @param input2 The second input.
+ * @param input3 The third input.
  * @param result The result column view.
  */
 void throw_row_error_if_any(cudf::column_view const& input1,
@@ -65,4 +65,35 @@ void throw_row_error_if_any(cudf::column_view const& input1,
                             cudf::column_view const& input3,
                             cudf::column_view const& result,
                             rmm::cuda_stream_view stream = cudf::get_default_stream());
+
+/**
+ * @brief Throws exception_with_row_index if has any row is invalid for a binary operation.
+ * If the input is not null and the result is null, it means the row is invalid.
+ *
+ * @throws exception_with_row_index if any row is invalid.
+ *
+ * @param input1 The first input.
+ * @param input2 The second input.
+ * @param result The result column view.
+ */
+void throw_row_error_if_any(cudf::column_view const& input1,
+                            cudf::scalar const& input2,
+                            cudf::column_view const& result,
+                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+
+/**
+ * @brief Throws exception_with_row_index if has any row is invalid for a binary operation.
+ * If the input is not null and the result is null, it means the row is invalid.
+ *
+ * @throws exception_with_row_index if any row is invalid.
+ *
+ * @param input1 The first input.
+ * @param input2 The second input.
+ * @param result The result column view.
+ */
+void throw_row_error_if_any(cudf::scalar const& input1,
+                            cudf::column_view const& input2,
+                            cudf::column_view const& result,
+                            rmm::cuda_stream_view stream = cudf::get_default_stream());
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/utilities.cu
+++ b/src/main/cpp/src/utilities.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/utilities.cu
+++ b/src/main/cpp/src/utilities.cu
@@ -28,6 +28,13 @@
 
 namespace spark_rapids_jni {
 
+bool is_basic_spark_numeric(cudf::data_type type)
+{
+  return type.id() == cudf::type_id::INT8 || type.id() == cudf::type_id::INT16 ||
+         type.id() == cudf::type_id::INT32 || type.id() == cudf::type_id::INT64 ||
+         type.id() == cudf::type_id::FLOAT32 || type.id() == cudf::type_id::FLOAT64;
+}
+
 std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
   rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -28,48 +28,6 @@
 
 namespace spark_rapids_jni {
 
-/**
- * @brief Element accessor from a column device view.
- * It has the same interfaces as the `numeric_scalar_accessor`.
- * This is used to access element from column and scalar with a unified model.
- */
-template <typename T>
-class column_accessor {
- public:
-  column_accessor(cudf::column_device_view cdv) : _cdv(cdv) {}
-
-  __device__ bool is_null(cudf::size_type row_index) const { return _cdv.is_null(row_index); }
-
-  __device__ T element(cudf::size_type row_index) const { return _cdv.element<T>(row_index); }
-
- private:
-  cudf::column_device_view _cdv;
-};
-
-/**
- * @brief Element accessor from a scalar. For any row index, return the same constant value.
- * It has the same interfaces as the `column_accessor`
- * This is used to access element from column and scalar with a unified model.
- */
-template <typename T>
-class numeric_scalar_accessor {
- public:
-  numeric_scalar_accessor(cudf::numeric_scalar_device_view<T> sdv) : _sdv(sdv) {}
-
-  /**
-   * @brief Ignore the row index when checking if the element is null.
-   */
-  __device__ bool is_null(cudf::size_type) const { return !_sdv.is_valid(); }
-
-  /**
-   * @brief Ignore the row index when accessing the element value.
-   */
-  __device__ T element(cudf::size_type) const { return _sdv.value(); }
-
- private:
-  cudf::numeric_scalar_device_view<T> _sdv;
-};
-
 template <typename T>
 constexpr inline bool is_basic_spark_numeric()
 {

--- a/src/main/cpp/tests/CMakeLists.txt
+++ b/src/main/cpp/tests/CMakeLists.txt
@@ -121,3 +121,6 @@ ConfigureTest(HLLPP
 
 ConfigureTest(CONV
     number_converter.cpp)
+
+ConfigureTest(MULTIPLY
+    multiply.cpp)

--- a/src/main/cpp/tests/multiply.cpp
+++ b/src/main/cpp/tests/multiply.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "multiply.hpp"
+
+#include "error.hpp"
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <tuple>
+#include <vector>
+
+struct MultiplyTests : public cudf::test::BaseFixture {};
+
+TEST_F(MultiplyTests, int8)
+{
+  // min(int8) = -128, max(int8) = 127
+  cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 127, 120}};
+  cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2, -2}};
+  cudf::test::fixed_width_column_wrapper<int8_t> expected{{1, 0, 0}, {1, 0, 0}};
+
+  auto result1 = spark_rapids_jni::multiply(input, input2, /*ansi*/ false, /*try*/ true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected);
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected error_at_row exception to be thrown";
+  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+    EXPECT_EQ(e.get_row_index(), 1);
+  }
+}
+
+TEST_F(MultiplyTests, int16)
+{
+  // min(int16) = -32768, max(int16) = 32767
+  cudf::test::fixed_width_column_wrapper<int16_t> input{{1, 2, 32767, -30000}};
+  cudf::test::fixed_width_column_wrapper<int16_t> input2{{1, 2, 2, 2}};
+  cudf::test::fixed_width_column_wrapper<int16_t> expected{{1, 4, 0, 0}, {1, 1, 0, 0}};
+
+  auto result1 = spark_rapids_jni::multiply(input, input2, /*ansi*/ false, /*try*/ true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected);
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected error_at_row exception to be thrown";
+  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+    EXPECT_EQ(e.get_row_index(), 2);
+  }
+}
+
+TEST_F(MultiplyTests, int32)
+{
+  // min(int32) = -2147483648, max(int32) = 2147483647
+  cudf::test::fixed_width_column_wrapper<int32_t> input{{0, 1, 2, 2147483647, 0, 5, 0, 2000000000},
+                                                        {0, 1, 1, 1, 0, 1, 0, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> input2{{5, 1, 2, 2, 4, 0, 0, -2},
+                                                         {1, 1, 1, 1, 1, 0, 0, 1}};
+  cudf::test::fixed_width_column_wrapper<int32_t> expected{{0, 1, 4, 0, 0, 0, 0, 0},
+                                                           {0, 1, 1, 0, 0, 0, 0, 0}};
+
+  auto result1 = spark_rapids_jni::multiply(input, input2, /*ansi*/ false, /*try*/ true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected);
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected error_at_row exception to be thrown";
+  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+    EXPECT_EQ(e.get_row_index(), 3);
+  }
+}
+
+TEST_F(MultiplyTests, int64)
+{
+  int64_t const min_int64 = -9223372036854775807LL - 1;  // -2^63
+  int64_t const max_int64 = 9223372036854775807LL;       // 2^63 - 1
+
+  // tuple format: (left, right, is_result_valid, expected_result)
+  std::vector<std::tuple<int64_t, int64_t, bool, int64_t>> cases = {
+    {1L, 1L, true, 1L},
+    {2L, 2L, true, 4L},
+    {min_int64, -1L, false, 0L},
+    {-1L, min_int64, false, 0L},
+    {max_int64 - 10L, 2L, false, 0L},
+    {max_int64 - 10L, -2L, false, 0L},
+    {min_int64 + 10L, 2L, false, 0L},
+    {min_int64 + 10L, -2L, false, 0L},
+    {-1L, 2L, true, -2L},
+    {-1L, 2L, true, -2L}};
+  std::vector<int64_t> left_longs;
+  std::vector<int64_t> right_longs;
+  std::vector<int64_t> expected_longs;
+  std::vector<bool> is_valid;
+  for (const auto& [left, right, is_valid_result, expected] : cases) {
+    left_longs.push_back(left);
+    right_longs.push_back(right);
+    expected_longs.push_back(expected);
+    is_valid.push_back(is_valid_result);
+  }
+
+  cudf::test::fixed_width_column_wrapper<int64_t> input1(left_longs.begin(), left_longs.end());
+  cudf::test::fixed_width_column_wrapper<int64_t> input2(right_longs.begin(), right_longs.end());
+  cudf::test::fixed_width_column_wrapper<int64_t> expected(
+    expected_longs.begin(), expected_longs.end(), is_valid.begin());
+
+  auto result = spark_rapids_jni::multiply(input1, input2, /*ansi*/ false, /*try*/ true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, expected);
+  try {
+    spark_rapids_jni::multiply(input1, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected error_at_row exception to be thrown";
+  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+    EXPECT_EQ(e.get_row_index(), 2);
+  }
+}
+
+TEST_F(MultiplyTests, float)
+{
+  cudf::test::fixed_width_column_wrapper<float> input{{1.0, 2.0}};
+  cudf::test::fixed_width_column_wrapper<float> input2{{1.0, 2.0}};
+  cudf::test::fixed_width_column_wrapper<float> expected{{1.0, 4.0}, {1, 1}};
+
+  auto result1 = spark_rapids_jni::multiply(input, input2, /*ansi*/ false, /*try*/ true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected);
+
+  auto result2 = spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result2, expected);
+}
+
+TEST_F(MultiplyTests, double)
+{
+  cudf::test::fixed_width_column_wrapper<double> input{{1.0, 2.0}};
+  cudf::test::fixed_width_column_wrapper<double> input2{{1.0, 2.0}};
+  cudf::test::fixed_width_column_wrapper<double> expected{{1.0, 4.0}, {1, 1}};
+
+  auto result1 = spark_rapids_jni::multiply(input, input2, /*ansi*/ false, /*try*/ true);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected);
+
+  auto result2 = spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result2, expected);
+}
+
+TEST_F(MultiplyTests, checkTypeEquals)
+{
+  cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 127}};
+  cudf::test::fixed_width_column_wrapper<int16_t> input2{{1, 2}};
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected logic_error";
+  } catch (const cudf::logic_error& e) {
+  }
+}
+
+TEST_F(MultiplyTests, checkRows)
+{
+  cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 2, 3}};
+  cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2}};
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected logic_error";
+  } catch (const cudf::logic_error& e) {
+  }
+}
+
+TEST_F(MultiplyTests, invalidType)
+{
+  cudf::test::fixed_width_column_wrapper<bool> input{{1, 0}};
+  cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2}};
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
+    FAIL() << "Expected logic_error";
+  } catch (const cudf::logic_error& e) {
+  }
+}
+
+TEST_F(MultiplyTests, invalidMode)
+{
+  cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 2}};
+  cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2}};
+
+  try {
+    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ true);
+    FAIL() << "Expected logic_error";
+  } catch (const cudf::logic_error& e) {
+  }
+}

--- a/src/main/cpp/tests/multiply.cpp
+++ b/src/main/cpp/tests/multiply.cpp
@@ -72,6 +72,9 @@ TEST_F(MultiplyTests, int32)
   cudf::test::fixed_width_column_wrapper<int32_t> expected{{0, 1, 4, 0, 0, 0, 0, 0},
                                                            {0, 1, 1, 0, 0, 0, 0, 0}};
 
+  // 0, 1, 1, 1, 0, 1, 0, 1
+  // 1, 1, 1, 1, 1, 0, 0, 1
+  // 0, 1, 1, 0, 0, 0, 0, 0
   auto result1 = spark_rapids_jni::multiply(input, input2, /*ansi*/ false, /*try*/ true);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected);
 

--- a/src/main/cpp/tests/multiply.cpp
+++ b/src/main/cpp/tests/multiply.cpp
@@ -157,11 +157,8 @@ TEST_F(MultiplyTests, checkTypeEquals)
   cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 127}};
   cudf::test::fixed_width_column_wrapper<int16_t> input2{{1, 2}};
 
-  try {
-    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
-    FAIL() << "Expected logic_error";
-  } catch (const cudf::logic_error& e) {
-  }
+  EXPECT_THROW(spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false),
+               cudf::logic_error);
 }
 
 TEST_F(MultiplyTests, checkRows)
@@ -169,11 +166,8 @@ TEST_F(MultiplyTests, checkRows)
   cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 2, 3}};
   cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2}};
 
-  try {
-    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
-    FAIL() << "Expected logic_error";
-  } catch (const cudf::logic_error& e) {
-  }
+  EXPECT_THROW(spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false),
+               cudf::logic_error);
 }
 
 TEST_F(MultiplyTests, invalidType)
@@ -181,11 +175,8 @@ TEST_F(MultiplyTests, invalidType)
   cudf::test::fixed_width_column_wrapper<bool> input{{1, 0}};
   cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2}};
 
-  try {
-    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
-    FAIL() << "Expected logic_error";
-  } catch (const cudf::logic_error& e) {
-  }
+  EXPECT_THROW(spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false),
+               cudf::logic_error);
 }
 
 TEST_F(MultiplyTests, invalidMode)
@@ -193,9 +184,6 @@ TEST_F(MultiplyTests, invalidMode)
   cudf::test::fixed_width_column_wrapper<int8_t> input{{1, 2}};
   cudf::test::fixed_width_column_wrapper<int8_t> input2{{1, 2}};
 
-  try {
-    spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ true);
-    FAIL() << "Expected logic_error";
-  } catch (const cudf::logic_error& e) {
-  }
+  EXPECT_THROW(spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ true),
+               cudf::logic_error);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
@@ -17,37 +17,8 @@ package com.nvidia.spark.rapids.jni;
 
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.Scalar;
-import ai.rapids.cudf.DType;
 
 public class Arithmetic {
-
-  private static void checkMultiply(DType leftType, DType rightType, 
-      long leftRowCount, long rightRowCount, boolean isAnsiMode, boolean isTryMode) {
-    
-    if (!(leftType.getTypeId() == DType.DTypeEnum.INT8 ||
-          leftType.getTypeId() == DType.DTypeEnum.INT16 ||
-          leftType.getTypeId() == DType.DTypeEnum.INT32 ||
-          leftType.getTypeId() == DType.DTypeEnum.INT64 ||
-          leftType.getTypeId() == DType.DTypeEnum.FLOAT32 ||
-          leftType.getTypeId() == DType.DTypeEnum.FLOAT64)) {
-      throw new IllegalArgumentException("Multiplication types must be signed integral or float, " +
-          "but get type: " + leftType);
-    }
-
-    if (leftType != rightType) {
-      throw new IllegalArgumentException("Column types do not match: " + leftType
-          + " vs " + rightType);
-    }
-
-    if (leftRowCount != rightRowCount) {
-      throw new IllegalArgumentException("Row counts do not match: " + leftRowCount
-          + " vs " + rightRowCount);
-    }
-
-    if (isAnsiMode && isTryMode) {
-      throw new IllegalArgumentException("isAnsiMode and isTryMode cannot both be true");
-    }
-  }
 
   /**
    * Computes multiplication on two ColumnVectors.
@@ -72,9 +43,6 @@ public class Arithmetic {
    */
   public static ColumnVector multiply(ColumnVector left, ColumnVector right, boolean isAnsiMode,
       boolean isTryMode) {
-    checkMultiply(left.getType(), right.getType(), left.getRowCount(),
-        right.getRowCount(), isAnsiMode, isTryMode);
-
     return new ColumnVector(multiply(
         left.getNativeView(), true, right.getNativeView(), true, isAnsiMode,
         isTryMode));
@@ -103,8 +71,6 @@ public class Arithmetic {
    */
   public static ColumnVector multiply(ColumnVector left, Scalar right, boolean isAnsiMode,
       boolean isTryMode) {
-    checkMultiply(left.getType(), right.getType(), left.getRowCount(),
-        left.getRowCount(), isAnsiMode, isTryMode);
     return new ColumnVector(multiply(
         left.getNativeView(), true, right.getScalarHandle(), false, isAnsiMode,
         isTryMode));
@@ -133,8 +99,6 @@ public class Arithmetic {
    */
   public static ColumnVector multiply(Scalar left, ColumnVector right, boolean isAnsiMode,
       boolean isTryMode) {
-    checkMultiply(left.getType(), right.getType(), right.getRowCount(),
-        right.getRowCount(), isAnsiMode, isTryMode);
     return new ColumnVector(multiply(
         left.getScalarHandle(), false, right.getNativeView(), true, isAnsiMode,
         isTryMode));

--- a/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
@@ -16,39 +16,130 @@
 package com.nvidia.spark.rapids.jni;
 
 import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.Scalar;
+import ai.rapids.cudf.DType;
 
 public class Arithmetic {
 
+  private static void checkMultiply(DType leftType, DType rightType, 
+      long leftRowCount, long rightRowCount, boolean isAnsiMode, boolean isTryMode) {
+    
+    if (!(leftType.getTypeId() == DType.DTypeEnum.INT8 ||
+          leftType.getTypeId() == DType.DTypeEnum.INT16 ||
+          leftType.getTypeId() == DType.DTypeEnum.INT32 ||
+          leftType.getTypeId() == DType.DTypeEnum.INT64 ||
+          leftType.getTypeId() == DType.DTypeEnum.FLOAT32 ||
+          leftType.getTypeId() == DType.DTypeEnum.FLOAT64)) {
+      throw new IllegalArgumentException("Multiplication types must be signed integral or float, " +
+          "but get type: " + leftType);
+    }
+
+    if (leftType != rightType) {
+      throw new IllegalArgumentException("Column types do not match: " + leftType
+          + " vs " + rightType);
+    }
+
+    if (leftRowCount != rightRowCount) {
+      throw new IllegalArgumentException("Row counts do not match: " + leftRowCount
+          + " vs " + rightRowCount);
+    }
+
+    if (isAnsiMode && isTryMode) {
+      throw new IllegalArgumentException("isAnsiMode and isTryMode cannot both be true");
+    }
+  }
+
   /**
-   * Computes the element-wise multiplication of two ColumnVectors.
+   * Computes multiplication on two ColumnVectors.
    * If the types of the two vectors do not match, an IllegalArgumentException is
-   * thrown. If the row counts of the two vectors do not match, an
-   * IllegalArgumentException is thrown. If the operation results in an overflow
+   * thrown. If the row counts of the two inputs do not match, an
+   * IllegalArgumentException is thrown. If there is any overflow
    * in ANSI mode, an ExceptionWithRowIndex is thrown.
-   *
-   * @param left       left column vector
-   * @param right      right column vector
+   * Only supports Spark data types: byte, short, integer, long, float32 and float64.
+   * 
+   * E.g.:
+   * Integer.MAX_VALUE * 2 = -2 in regular mode, the result is wrong(overflow occurs).
+   * Integer.MAX_VALUE * 2 = null in try mode
+   * Integer.MAX_VALUE * 2 = throws exception in ansi mode
+   * 
+   * @param left       left input
+   * @param right      right input
    * @param isAnsiMode is ANSI mode enabled
-   *                   (if true, overflow will throw an ExceptionWithRowIndex)
-   *                   (if false, overflow will result in wrong values, e.g.
-   *                   Integer.MAX_VALUE * 2 = -2)
-   * @return a new ColumnVector containing the result of multiplying the two input
-   *         vectors
-   * @throws ExceptionWithRowIndex if an overflow occurs in ANSI mode
+   * @param isTryMode  if true, set null when overflow occurs
+   * @return a new ColumnVector containing the result of multiplying
+   *
+   * @throws ExceptionWithRowIndex if has any overflow in ANSI mode
    */
-  public static ColumnVector multiply(ColumnVector left, ColumnVector right, boolean isAnsiMode) {
-    if (left.getType() != right.getType()) {
-      throw new IllegalArgumentException("Column types do not match: " + left.getType()
-          + " vs " + right.getType());
-    }
-    if (left.getRowCount() != right.getRowCount()) {
-      throw new IllegalArgumentException("Row counts do not match: " + left.getRowCount()
-          + " vs " + right.getRowCount());
-    }
+  public static ColumnVector multiply(ColumnVector left, ColumnVector right, boolean isAnsiMode,
+      boolean isTryMode) {
+    checkMultiply(left.getType(), right.getType(), left.getRowCount(),
+        right.getRowCount(), isAnsiMode, isTryMode);
+
     return new ColumnVector(multiply(
-        left.getNativeView(), true, right.getNativeView(), true, isAnsiMode));
+        left.getNativeView(), true, right.getNativeView(), true, isAnsiMode,
+        isTryMode));
+  }
+
+  /**
+   * Computes multiplication on two ColumnVectors.
+   * If the types of the two vectors do not match, an IllegalArgumentException is
+   * thrown. If the row counts of the two inputs do not match, an
+   * IllegalArgumentException is thrown. If there is any overflow
+   * in ANSI mode, an ExceptionWithRowIndex is thrown.
+   * Only supports Spark data types: byte, short, integer, long, float32 and float64.
+   * 
+   * E.g.:
+   * Integer.MAX_VALUE * 2 = -2 in regular mode, the result is wrong(overflow occurs).
+   * Integer.MAX_VALUE * 2 = null in try mode
+   * Integer.MAX_VALUE * 2 = throws exception in ansi mode
+   * 
+   * @param left       left input
+   * @param right      right input
+   * @param isAnsiMode is ANSI mode enabled
+   * @param isTryMode  if true, set null when overflow occurs
+   * @return a new ColumnVector containing the result of multiplying
+   *
+   * @throws ExceptionWithRowIndex if has any overflow in ANSI mode
+   */
+  public static ColumnVector multiply(ColumnVector left, Scalar right, boolean isAnsiMode,
+      boolean isTryMode) {
+    checkMultiply(left.getType(), right.getType(), left.getRowCount(),
+        left.getRowCount(), isAnsiMode, isTryMode);
+    return new ColumnVector(multiply(
+        left.getNativeView(), true, right.getScalarHandle(), false, isAnsiMode,
+        isTryMode));
+  }
+
+  /**
+   * Computes multiplication on two ColumnVectors.
+   * If the types of the two vectors do not match, an IllegalArgumentException is
+   * thrown. If the row counts of the two inputs do not match, an
+   * IllegalArgumentException is thrown. If there is any overflow
+   * in ANSI mode, an ExceptionWithRowIndex is thrown.
+   * Only supports Spark data types: byte, short, integer, long, float32 and float64.
+   * 
+   * E.g.:
+   * Integer.MAX_VALUE * 2 = -2 in regular mode, the result is wrong(overflow occurs).
+   * Integer.MAX_VALUE * 2 = null in try mode
+   * Integer.MAX_VALUE * 2 = throws exception in ansi mode
+   * 
+   * @param left       left input
+   * @param right      right input
+   * @param isAnsiMode is ANSI mode enabled
+   * @param isTryMode  if true, set null when overflow occurs
+   * @return a new ColumnVector containing the result of multiplying
+   *
+   * @throws ExceptionWithRowIndex if has any overflow in ANSI mode
+   */
+  public static ColumnVector multiply(Scalar left, ColumnVector right, boolean isAnsiMode,
+      boolean isTryMode) {
+    checkMultiply(left.getType(), right.getType(), right.getRowCount(),
+        right.getRowCount(), isAnsiMode, isTryMode);
+    return new ColumnVector(multiply(
+        left.getScalarHandle(), false, right.getNativeView(), true, isAnsiMode,
+        isTryMode));
   }
 
   private static native long multiply(long leftHandle, boolean isLeftCv, long rightHandle,
-      boolean isRightCv, boolean isAnsiMode);
+      boolean isRightCv, boolean isAnsiMode, boolean isTryMode);
 }


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/13054

## Requirements
#### byte/short check:
```scala
  private def checkOverflow(res: Int, x: Byte, y: Byte, op: String, hint: String): Unit = {
    if (res > Byte.MaxValue || res < Byte.MinValue) {
      throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(x, op, y, hint)
    }
  }

  override def plus(x: Byte, y: Byte): Byte = {
    val tmp = x + y
    checkOverflow(tmp, x, y, "+", "try_add")
    tmp.toByte
  }
```
#### int/long check
```scala
    case _: IntegerType if failOnError =>
      MathUtils.multiplyExact(
        input1.asInstanceOf[Int],
        input2.asInstanceOf[Int],
        getContextOrNull())
    case _: LongType if failOnError =>
      MathUtils.multiplyExact(
        input1.asInstanceOf[Long],
        input2.asInstanceOf[Long],
        getContextOrNull())
```
For more details: 
Refer to [link](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala)

Refer to [link](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala#L558)

## changes
Add ANSI multiplication for types: int8, int16, int32, int64, float, double.
Multipy scalar/column in a unified way.
Use the approach in https://github.com/NVIDIA/spark-rapids-jni/pull/3504 to check nulls info.

Signed-off-by: Chong Gao <res_life@163.com>