### PR TITLE
Use the acutal digits count for the overflow check when casting strings to decimals

### DIFF
--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -537,7 +537,8 @@ CUDF_KERNEL void string_to_decimal_kernel(T* out,
       significant_digits_before_decimal_in_string + zeros_to_decimal + rounding_digits;
 
     // too many digits required to store decimal
-    if (max_digits_before_decimal < significant_digits_before_decimal) { valid = false; }
+    auto const leading_zeros = total_digits - num_precise_digits;
+    if (max_digits_before_decimal < decimal_location - leading_zeros) { valid = false; }
 
     // at this point we have the precise digits we need, but we might need trailing zeros on this
     // value both before and after the decimal


### PR DESCRIPTION
This is a fix to the issue https://github.com/NVIDIA/spark-rapids/issues/10908.

`significant_digits_before_decimal` is the digits count of the stored value, not the actual value. When the scale is negative, the stored digits count is not equal to that of the actual digits. For example, the digits `123456` with DecimalType(4, -2) has `1235` as the stored digits, but the acutal digits are  `123500`.

The overflow check should use the actual digits count instead, which can represented as `decimal_location - leading_zeros`.

Tests will be added in the relevent Plugin PR.
 
