### PR TITLE
Add support for merging large table in kudo

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/ColumnViewInfo.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/ColumnViewInfo.java
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids.jni.kudo;
 import ai.rapids.cudf.*;
 
 import java.util.Optional;
-import java.util.OptionalLong;
 
 import static com.nvidia.spark.rapids.jni.Preconditions.ensureNonNegative;
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableMerger.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoTableMerger.java
@@ -49,7 +49,7 @@ class KudoTableMerger implements SimpleSchemaVisitor {
 
   private final KudoTable[] kudoTables;
   private final ColumnOffsetInfo[] columnOffsets;
-  private final long[] rowCounts;
+  private final int[] rowCounts;
   private final HostMemoryBuffer buffer;
   private final ColumnViewInfo[] colViewInfoList;
   private final long[] validityOffsets;
@@ -67,7 +67,7 @@ class KudoTableMerger implements SimpleSchemaVisitor {
 
   public KudoTableMerger(KudoTable[] tables, HostMemoryBuffer buffer,
                          ColumnOffsetInfo[] columnOffsets,
-                         long[] rowCounts) {
+                         int[] rowCounts) {
     this.kudoTables = requireNonNull(tables, "tables can't be null");
     requireNonNull(buffer, "buffer can't be null!");
     ensure(columnOffsets != null, "column offsets cannot be null");
@@ -108,9 +108,9 @@ class KudoTableMerger implements SimpleSchemaVisitor {
   public void preVisitStruct(Schema structType) {
     ColumnOffsetInfo offsetInfo = getCurColumnOffsets();
     long nullCount = deserializeValidityBuffer(offsetInfo);
-    long totalRowCount = rowCounts[curColIdx];
+    int totalRowCount = rowCounts[curColIdx];
     colViewInfoList[curColIdx] = new ColumnViewInfo(structType.getType(),
-        offsetInfo, toIntExact(nullCount), toIntExact(totalRowCount));
+        offsetInfo, toIntExact(nullCount), totalRowCount);
 
 
     for (int i=0; i<kudoTables.length; i++) {
@@ -131,11 +131,11 @@ class KudoTableMerger implements SimpleSchemaVisitor {
   public void preVisitList(Schema listType) {
     ColumnOffsetInfo offsetInfo = getCurColumnOffsets();
     long nullCount = deserializeValidityBuffer(offsetInfo);
-    long totalRowCount = rowCounts[curColIdx];
+    int totalRowCount = rowCounts[curColIdx];
     deserializeOffsetBuffer(offsetInfo);
 
     colViewInfoList[curColIdx] = new ColumnViewInfo(listType.getType(),
-        offsetInfo, toIntExact(nullCount), toIntExact(totalRowCount));
+        offsetInfo, toIntExact(nullCount), totalRowCount);
 
     for (int i=0; i<kudoTables.length; i++) {
       KudoTableHeader header = kudoTables[i].getHeader();
@@ -162,7 +162,7 @@ class KudoTableMerger implements SimpleSchemaVisitor {
   public void visit(Schema primitiveType) {
     ColumnOffsetInfo offsetInfo = getCurColumnOffsets();
     long nullCount = deserializeValidityBuffer(offsetInfo);
-    long totalRowCount = rowCounts[curColIdx];
+    int totalRowCount = rowCounts[curColIdx];
     if (primitiveType.getType().hasOffsets()) {
       deserializeOffsetBuffer(offsetInfo);
       deserializeDataBuffer(offsetInfo, OptionalInt.empty());
@@ -171,7 +171,7 @@ class KudoTableMerger implements SimpleSchemaVisitor {
     }
 
     colViewInfoList[curColIdx] = new ColumnViewInfo(primitiveType.getType(),
-        offsetInfo, toIntExact(nullCount), toIntExact(totalRowCount));
+        offsetInfo, toIntExact(nullCount), totalRowCount);
 
     if (primitiveType.getType().hasOffsets()) {
       for (int i=0; i<kudoTables.length; i++) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializerTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializerTest.java
@@ -694,9 +694,9 @@ public class KudoSerializerTest extends CudfTestBase {
 
   @Test
   public void testSerializeAndDeserializeLargeTable() {
-    try(Table t1 = buildLargeTestTable()) {
-      try (Table t2 = buildLargeTestTable()) {
-        try (Table expected = Table.concatenate(t1, t2)) {
+    try(Table t1 = buildLargeTestTable();
+        Table t2 = buildLargeTestTable();
+        Table expected = Table.concatenate(t1, t2)) {
           assertTrue(expected.getDeviceMemorySize() > Integer.MAX_VALUE,
               "Expected table size should exceed Integer.MAX_VALUE");
           final int sliceSize = 50000000;
@@ -714,8 +714,6 @@ public class KudoSerializerTest extends CudfTestBase {
           }
 
           checkMergeTable(expected, tableSlices);
-        }
-      }
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION

Closes #3592 

This pr changes `KudoSerializer` for following case:
1. Allowing merged table's device memory size to be larger than 2G, e.g. 
2. Add check for some possible overflow such as row count, null count, offset buffer.
3. Add tests for these cases.