### PR TITLE
Disable libprofiler.so build for cuda13 given libcupti_static issues

### DIFF
--- a/build/build-in-docker
+++ b/build/build-in-docker
@@ -30,6 +30,7 @@ export CMAKE_GENERATOR=${CMAKE_GENERATOR:-"Ninja"}
 export CUDA_VERSION=${CUDA_VERSION:-12.9.1}
 CUDA_CLASSIFIER=cuda${CUDA_VERSION%%.*}
 BUILD_FAULTINJ=${BUILD_FAULTINJ:-ON}
+BUILD_PROFILER=${BUILD_PROFILER:-ON}
 
 if (( $# == 0 )); then
   echo "Usage: $0 <Maven build arguments>"
@@ -39,12 +40,22 @@ fi
 # Set env for arm64 build, The possible values of 'uname -m' : [x86_64/i386/aarch64/mips/...]
 if [ "$(uname -m)" == "aarch64" ]; then
   USE_GDS="OFF" # The GDS cuFiles RDMA libraries are not included in the arm64 CUDA toolkit.
-  BUILD_FAULTINJ="OFF" # libcupti_static.a linked by cufaultinj, does not exist in the arm64 CUDA toolkit.
+  # libcupti_static.a linked by cufaultinj and the profiler, does not exist in the arm64 CUDA toolkit.
+  BUILD_FAULTINJ="OFF"
+  BUILD_PROFILER="OFF"
+fi
+
+# disable the profiler and cufaultinj, since there are issues linking
+# against libcupti_static.a in CUDA 13
+if [ "$CUDA_CLASSIFIER" == "cuda13" ]; then
+  BUILD_FAULTINJ="OFF"
+  BUILD_PROFILER="OFF"
 fi
 
 $SCRIPTDIR/run-in-docker mvn \
     -Dmaven.repo.local=$LOCAL_MAVEN_REPO \
     -DUSE_GDS=$USE_GDS \
     -DBUILD_FAULTINJ=${BUILD_FAULTINJ} \
+    -DBUILD_PROFILER=${BUILD_PROFILER} \
     -Dcuda.version=$CUDA_CLASSIFIER \
     "$@"

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -55,7 +55,11 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
-  -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -DBUILD_PROFILER=${BUILD_PROFILER} -Dcuda.version=$CUDA_VER \
+  -DBUILD_TESTS=ON \
+  -DBUILD_BENCHMARKS=ON \
+  -DBUILD_FAULTINJ=${BUILD_FAULTINJ} \
+  -DBUILD_PROFILER=${BUILD_PROFILER} \
+  -Dcuda.version=$CUDA_VER \
   -DUSE_SANITIZER=${USE_SANITIZER}
 
 build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -28,6 +28,7 @@ PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 USE_GDS=${USE_GDS:-ON}
 USE_SANITIZER=${USE_SANITIZER:-ON}
 BUILD_FAULTINJ=${BUILD_FAULTINJ:-ON}
+BUILD_PROFILER=${BUILD_PROFILER:-ON}
 ARM64=${ARM64:-false}
 artifact_suffix="${CUDA_VER}"
 
@@ -36,8 +37,17 @@ if [ "${ARM64}" == "true" ]; then
   profiles="${profiles},arm64"
   USE_GDS="OFF"
   USE_SANITIZER="ON"
+  # libcupti_static.a linked by cufaultinj and the profiler, does not exist in the arm64 CUDA toolkit
   BUILD_FAULTINJ="OFF"
+  BUILD_PROFILER="OFF"
   artifact_suffix="${artifact_suffix}-arm64"
+fi
+
+# disable the profiler and cufaultinj, since there are issues linking
+# against libcupti_static.a in CUDA 13
+if [ "${CUDA_VER}" == "cuda13" ]; then
+  BUILD_FAULTINJ="OFF"
+  BUILD_PROFILER="OFF"
 fi
 
 ${MVN} clean package ${MVN_MIRROR}  \
@@ -45,7 +55,7 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
-  -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -Dcuda.version=$CUDA_VER \
+  -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON -DBUILD_FAULTINJ=${BUILD_FAULTINJ} -DBUILD_PROFILER=${BUILD_PROFILER} -Dcuda.version=$CUDA_VER \
   -DUSE_SANITIZER=${USE_SANITIZER}
 
 build_name=$(${MVN} help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)


### PR DESCRIPTION
Temporary workaround for https://github.com/NVIDIA/spark-rapids-jni/issues/3627

This disables the profiler and cufaultinj for cuda13 in build-in-docker and also in the ci nightlies. We are doing this to get the cuda13 build going, and once we resolve the libcupti_static issues we'll bring them back.

Note that this will break a plugin that tries to use the profiler for cuda13. A subsequent change in the plugin will be raised that will make the profiler fallback gracefully, and warn the user on the driver about the issue (since libprofiler won't be around to link it).