### PR TITLE
Rewrite JNI functions to use `JNI_TRY`/`JNI_CATCH`

### DIFF
--- a/src/main/cpp/src/Aggregation64Utils.cpp
+++ b/src/main/cpp/src/Aggregation64Utils.cpp
@@ -24,14 +24,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Aggregation64Utils_extr
   JNIEnv* env, jclass, jlong j_column_view, jint j_out_dtype, jint j_chunk_idx)
 {
   JNI_NULL_CHECK(env, j_column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cview = reinterpret_cast<cudf::column_view const*>(j_column_view);
     auto dtype = cudf::jni::make_data_type(j_out_dtype, 0);
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::extract_chunk32_from_64bit(*cview, dtype, j_chunk_idx));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -39,13 +40,14 @@ Java_com_nvidia_spark_rapids_jni_Aggregation64Utils_combineInt64SumChunks(
   JNIEnv* env, jclass, jlong j_table_view, jint j_dtype, jint j_scale)
 {
   JNI_NULL_CHECK(env, j_table_view, "table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto tview = reinterpret_cast<cudf::table_view const*>(j_table_view);
     std::unique_ptr<cudf::table> result =
       spark_rapids_jni::assemble64_from_sum(*tview, cudf::jni::make_data_type(j_dtype, j_scale));
     return cudf::jni::convert_table_for_return(env, result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/ArithmeticJni.cpp
+++ b/src/main/cpp/src/ArithmeticJni.cpp
@@ -33,7 +33,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_multiply(JNI
   JNI_NULL_CHECK(env, left, "left input is null", 0);
   JNI_NULL_CHECK(env, right, "right input is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     if (is_left_cv && is_right_cv) {

--- a/src/main/cpp/src/BloomFilterJni.cpp
+++ b/src/main/cpp/src/BloomFilterJni.cpp
@@ -25,14 +25,15 @@ extern "C" {
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_creategpu(
   JNIEnv* env, jclass, jint numHashes, jlong bloomFilterBits)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     int bloom_filter_longs = static_cast<int>((bloomFilterBits + 63) / 64);
     auto bloom_filter      = spark_rapids_jni::bloom_filter_create(numHashes, bloom_filter_longs);
     return reinterpret_cast<jlong>(bloom_filter.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_put(JNIEnv* env,
@@ -40,7 +41,8 @@ JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_put(JNIEnv* 
                                                                         jlong bloomFilter,
                                                                         jlong cv)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::column_view const& input_column = *reinterpret_cast<cudf::column_view const*>(cv);
@@ -48,14 +50,15 @@ JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_put(JNIEnv* 
                                        input_column);
     return 0;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_merge(JNIEnv* env,
                                                                            jclass,
                                                                            jlong bloomFilters)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::column_view const& input_bloom_filter =
@@ -63,7 +66,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_merge(JNIEn
     auto bloom_filter = spark_rapids_jni::bloom_filter_merge(input_bloom_filter);
     return reinterpret_cast<jlong>(bloom_filter.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_probe(JNIEnv* env,
@@ -71,20 +74,22 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_probe(JNIEn
                                                                            jlong bloomFilter,
                                                                            jlong cv)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::column_view const& input_column = *reinterpret_cast<cudf::column_view const*>(cv);
     return cudf::jni::release_as_jlong(spark_rapids_jni::bloom_filter_probe(
       input_column, *(reinterpret_cast<cudf::list_scalar*>(bloomFilter))));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_probebuffer(
   JNIEnv* env, jclass, jlong bloomFilter, jlong bloomFilterSize, jlong cv)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::column_view const& input_column = *reinterpret_cast<cudf::column_view const*>(cv);
@@ -92,6 +97,6 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_BloomFilter_probebuffer
     return cudf::jni::release_as_jlong(spark_rapids_jni::bloom_filter_probe(
       input_column, cudf::device_span<uint8_t const>{buf, static_cast<size_t>(bloomFilterSize)}));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/CaseWhenJni.cpp
+++ b/src/main/cpp/src/CaseWhenJni.cpp
@@ -23,13 +23,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CaseWhen_selectFirstTru
   JNIEnv* env, jclass, jlongArray bool_cols)
 {
   JNI_NULL_CHECK(env, bool_cols, "array of column handles is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::column_view> n_cudf_bool_columns(env, bool_cols);
     auto bool_column_views = n_cudf_bool_columns.get_dereferenced();
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::select_first_true_index(cudf::table_view(bool_column_views)));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -36,7 +36,8 @@
 constexpr char const* JNI_CAST_ERROR_CLASS = "com/nvidia/spark/rapids/jni/CastException";
 
 #define CATCH_CAST_EXCEPTION(env, ret_val)                                                \
-  catch (const spark_rapids_jni::cast_error& e)                                           \
+  JNI_CATCH_FIRST(env, ret_val)                                                           \
+  catch (spark_rapids_jni::cast_error const& e)                                           \
   {                                                                                       \
     if (env->ExceptionOccurred()) { return ret_val; }                                     \
     jclass ex_class = env->FindClass(JNI_CAST_ERROR_CLASS);                               \
@@ -54,7 +55,8 @@ constexpr char const* JNI_CAST_ERROR_CLASS = "com/nvidia/spark/rapids/jni/CastEx
     }                                                                                     \
     return ret_val;                                                                       \
   }                                                                                       \
-  JNI_CATCH(env, 0);
+  CATCH_SPECIAL_EXCEPTION(env, ret_val)                                                   \
+  CATCH_STD_EXCEPTION(env, ret_val)
 
 extern "C" {
 

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -54,7 +54,7 @@ constexpr char const* JNI_CAST_ERROR_CLASS = "com/nvidia/spark/rapids/jni/CastEx
     }                                                                                     \
     return ret_val;                                                                       \
   }                                                                                       \
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 
 extern "C" {
 
@@ -63,7 +63,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toInteger(
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
@@ -84,7 +85,8 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_toDecimal(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
@@ -99,7 +101,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toFloat(
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::strings_column_view scv{*reinterpret_cast<cudf::column_view const*>(input_column)};
@@ -115,7 +118,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloat(J
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
@@ -130,7 +134,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloatWi
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
@@ -146,7 +151,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromDecimal
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
@@ -161,7 +167,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromLongToB
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
@@ -176,7 +183,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersW
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   using namespace cudf;
-  try {
+  JNI_TRY
+  {
     if (base != 10 && base != 16) {
       auto const error_msg = "Bases supported 10, 16; Actual: " + std::to_string(base);
       throw spark_rapids_jni::cast_error(0, error_msg);
@@ -246,7 +254,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   using namespace cudf;
-  try {
+  JNI_TRY
+  {
     jni::auto_set_device(env);
     auto input_view{*reinterpret_cast<column_view const*>(input_column)};
     auto result = [&] {
@@ -290,7 +299,8 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStringsToIntermediate
   JNI_NULL_CHECK(env, timezone_info_column, "timezone info column is null", 0);
   JNI_NULL_CHECK(env, transitions_table, "transitions table is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
@@ -308,20 +318,21 @@ Java_com_nvidia_spark_rapids_jni_CastStrings_parseTimestampStringsToIntermediate
                                                 *transitions,
                                                 spark_system));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_parseDateStringsToDate(
   JNIEnv* env, jclass, jlong input_column)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const input_view =
       cudf::strings_column_view(*reinterpret_cast<cudf::column_view const*>(input_column));
     return cudf::jni::release_as_jlong(spark_rapids_jni::parse_strings_to_date(input_view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/DateTimeUtilsJni.cpp
+++ b/src/main/cpp/src/DateTimeUtilsJni.cpp
@@ -24,13 +24,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_rebaseGre
 {
   JNI_NULL_CHECK(env, input, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::rebase_gregorian_to_julian(*input_cv);
     return reinterpret_cast<jlong>(output.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_rebaseJulianToGregorian(
@@ -38,13 +39,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_rebaseJul
 {
   JNI_NULL_CHECK(env, input, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(input);
     auto output         = spark_rapids_jni::rebase_julian_to_gregorian(*input_cv);
     return reinterpret_cast<jlong>(output.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateWithColumnFormat(
@@ -53,14 +55,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateW
   JNI_NULL_CHECK(env, datetime, "input datetime is null", 0);
   JNI_NULL_CHECK(env, format, "input format is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const datetime_cv = reinterpret_cast<cudf::column_view const*>(datetime);
     auto const format_cv   = reinterpret_cast<cudf::column_view const*>(format);
     return reinterpret_cast<jlong>(spark_rapids_jni::truncate(*datetime_cv, *format_cv).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateWithScalarFormat(
@@ -68,7 +71,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateW
 {
   JNI_NULL_CHECK(env, datetime, "input datetime is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const datetime_cv = reinterpret_cast<cudf::column_view const*>(datetime);
@@ -76,7 +80,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_DateTimeUtils_truncateW
     auto const format      = std::string(format_jstr.get(), format_jstr.size_bytes());
     return reinterpret_cast<jlong>(spark_rapids_jni::truncate(*datetime_cv, format).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/DecimalUtilsJni.cpp
+++ b/src/main/cpp/src/DecimalUtilsJni.cpp
@@ -29,7 +29,8 @@ Java_com_nvidia_spark_rapids_jni_DecimalUtils_multiply128(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
     auto view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
@@ -37,7 +38,7 @@ Java_com_nvidia_spark_rapids_jni_DecimalUtils_multiply128(JNIEnv* env,
     return cudf::jni::convert_table_for_return(
       env, cudf::jni::multiply_decimal128(*view_a, *view_b, scale, cast_interim_result));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divide128(
@@ -45,7 +46,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divid
 {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto view_a          = reinterpret_cast<cudf::column_view const*>(j_view_a);
     auto view_b          = reinterpret_cast<cudf::column_view const*>(j_view_b);
@@ -59,7 +61,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_divid
         env, cudf::jni::divide_decimal128(*view_a, *view_b, scale));
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_remainder128(
@@ -67,7 +69,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_remai
 {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
     auto view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
@@ -75,7 +78,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_remai
     return cudf::jni::convert_table_for_return(
       env, cudf::jni::remainder_decimal128(*view_a, *view_b, scale));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_add128(
@@ -83,7 +86,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_add12
 {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
     auto const view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
@@ -91,7 +95,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_add12
     return cudf::jni::convert_table_for_return(env,
                                                cudf::jni::add_decimal128(*view_a, *view_b, scale));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_subtract128(
@@ -99,7 +103,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_subtr
 {
   JNI_NULL_CHECK(env, j_view_a, "column is null", 0);
   JNI_NULL_CHECK(env, j_view_b, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const view_a = reinterpret_cast<cudf::column_view const*>(j_view_a);
     auto const view_b = reinterpret_cast<cudf::column_view const*>(j_view_b);
@@ -107,14 +112,15 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_subtr
     return cudf::jni::convert_table_for_return(env,
                                                cudf::jni::sub_decimal128(*view_a, *view_b, scale));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_floatingPointToDecimal(
   JNIEnv* env, jclass, jlong j_input, jint output_type_id, jint precision, jint decimal_scale)
 {
   JNI_NULL_CHECK(env, j_input, "j_input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(j_input);
     cudf::jni::native_jlongArray output(env, 2);
@@ -127,7 +133,7 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_DecimalUtils_float
     output[1] = static_cast<jlong>(failure_row_id);
     return output.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -23,7 +23,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTi
 {
   JNI_NULL_CHECK(env, input_handle, "column is null", 0);
   JNI_NULL_CHECK(env, transitions_handle, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input       = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const transitions = reinterpret_cast<cudf::table_view const*>(transitions_handle);
@@ -31,7 +32,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTi
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::convert_timestamp_to_utc(*input, *transitions, index).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -40,7 +41,8 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertUTCTimestampColumnToTimeZo
 {
   JNI_NULL_CHECK(env, input_handle, "column is null", 0);
   JNI_NULL_CHECK(env, transitions_handle, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input       = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const transitions = reinterpret_cast<cudf::table_view const*>(transitions_handle);
@@ -48,7 +50,7 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertUTCTimestampColumnToTimeZo
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::convert_utc_timestamp_to_timezone(*input, *transitions, index).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -71,7 +73,8 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTimestampColumnToUTCWithTz
   JNI_NULL_CHECK(env, transitions_handle, "transitions column is null", 0);
   JNI_NULL_CHECK(env, tz_indices_handle, "tz indices column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_seconds = reinterpret_cast<cudf::column_view const*>(input_seconds_handle);
     auto const input_microseconds =
@@ -91,6 +94,6 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTimestampColumnToUTCWithTz
                                                                               *tz_indices)
                                      .release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/HashJni.cpp
+++ b/src/main/cpp/src/HashJni.cpp
@@ -31,14 +31,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_murmurHash32(
 {
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto column_views =
       cudf::jni::native_jpointerArray<cudf::column_view>{env, column_handles}.get_dereferenced();
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::murmur_hash3_32(cudf::table_view{column_views}, seed));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_xxhash64(JNIEnv* env,
@@ -48,14 +49,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_xxhash64(JNIEnv* e
 {
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto column_views =
       cudf::jni::native_jpointerArray<cudf::column_view>{env, column_handles}.get_dereferenced();
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::xxhash64(cudf::table_view{column_views}, seed));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_hiveHash(JNIEnv* env,
@@ -64,12 +66,13 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Hash_hiveHash(JNIEnv* e
 {
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto column_views =
       cudf::jni::native_jpointerArray<cudf::column_view>{env, column_handles}.get_dereferenced();
     return cudf::jni::release_as_jlong(spark_rapids_jni::hive_hash(cudf::table_view{column_views}));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/HistogramJni.cpp
+++ b/src/main/cpp/src/HistogramJni.cpp
@@ -25,7 +25,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_createHistogr
   JNI_NULL_CHECK(env, values_handle, "values_handle is null", 0);
   JNI_NULL_CHECK(env, frequencies_handle, "frequencies_handle is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const values      = reinterpret_cast<cudf::column_view const*>(values_handle);
@@ -34,7 +35,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_createHistogr
       spark_rapids_jni::create_histogram_if_valid(*values, *frequencies, output_as_lists)
         .release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_percentileFromHistogram(
@@ -43,7 +44,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_percentileFro
   JNI_NULL_CHECK(env, input_handle, "input_handle is null", 0);
   JNI_NULL_CHECK(env, jpercentages, "jpercentages is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const input       = reinterpret_cast<cudf::column_view const*>(input_handle);
@@ -54,7 +56,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Histogram_percentileFro
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::percentile_from_histogram(*input, percentages, output_as_lists).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/HostTableJni.cpp
+++ b/src/main/cpp/src/HostTableJni.cpp
@@ -179,20 +179,22 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_bufferSize(JN
                                                                               jlong jstream)
 {
   JNI_NULL_CHECK(env, table_handle, "table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto t      = reinterpret_cast<cudf::table_view const*>(table_handle);
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     return static_cast<jlong>(host_buffer_size(*t, stream));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_copyFromTableAsync(
   JNIEnv* env, jclass, jlong table_handle, jlong host_address, jlong host_size, jlong jstream)
 {
   JNI_NULL_CHECK(env, table_handle, "table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto table           = reinterpret_cast<cudf::table_view const*>(table_handle);
     auto buffer          = reinterpret_cast<uint8_t*>(host_address);
@@ -201,7 +203,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_copyFromTable
     auto host_table_view = to_host_table_async(*table, buffer, buffer_size, stream);
     return reinterpret_cast<jlong>(host_table_view.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_toDeviceColumnViews(
@@ -210,7 +212,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_toDevice
   JNI_NULL_CHECK(env, table_handle, "table is null", nullptr);
   JNI_ARG_CHECK(
     env, host_to_dev_offset % sizeof(cudf::bitmask_type) == 0, "invalid offset", nullptr);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto host_table = reinterpret_cast<spark_rapids_jni::host_table_view const*>(table_handle);
     auto column_view_ptrs = to_device_column_views(*host_table, host_to_dev_offset);
@@ -222,17 +225,15 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_toDevice
       [](std::unique_ptr<cudf::column_view>& p) { return cudf::jni::release_as_jlong(p); });
     return handles.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_freeDeviceColumnView(
   JNIEnv* env, jclass, jlong dev_column_view_handle)
 {
   JNI_NULL_CHECK(env, dev_column_view_handle, "view is null", );
-  try {
-    delete reinterpret_cast<cudf::column_view*>(dev_column_view_handle);
-  }
-  CATCH_STD(env, );
+  JNI_TRY { delete reinterpret_cast<cudf::column_view*>(dev_column_view_handle); }
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_freeHostTable(JNIEnv* env,
@@ -240,10 +241,8 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_HostTable_freeHostTable(
                                                                                 jlong table_handle)
 {
   JNI_NULL_CHECK(env, table_handle, "table is null", );
-  try {
-    delete reinterpret_cast<host_table_view*>(table_handle);
-  }
-  CATCH_STD(env, );
+  JNI_TRY { delete reinterpret_cast<host_table_view*>(table_handle); }
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/HyperLogLogPlusPlusHostUDFJni.cpp
+++ b/src/main/cpp/src/HyperLogLogPlusPlusHostUDFJni.cpp
@@ -26,7 +26,8 @@ Java_com_nvidia_spark_rapids_jni_HyperLogLogPlusPlusHostUDF_createHLLPPHostUDF(J
                                                                                jint agg_type,
                                                                                int precision)
 {
-  try {
+  JNI_TRY
+  {
     auto udf_ptr = [&] {
       // The value of agg_type must be sync with
       // `HyperLogLogPlusPlusHostUDF.java#AggregationType`.
@@ -42,7 +43,7 @@ Java_com_nvidia_spark_rapids_jni_HyperLogLogPlusPlusHostUDF_createHLLPPHostUDF(J
 
     return reinterpret_cast<jlong>(udf_ptr);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -50,13 +51,14 @@ Java_com_nvidia_spark_rapids_jni_HyperLogLogPlusPlusHostUDF_estimateDistinctValu
   JNIEnv* env, jclass, jlong sketches, jint precision)
 {
   JNI_NULL_CHECK(env, sketches, "Sketch column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const sketch_view = reinterpret_cast<cudf::column_view const*>(sketches);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::estimate_from_hll_sketches(*sketch_view, precision).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -29,11 +29,12 @@ extern "C" {
 JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_getMaxJSONPathDepth(JNIEnv* env,
                                                                                       jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     return spark_rapids_jni::MAX_JSON_PATH_DEPTH;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -48,7 +49,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(JNIEnv* env,
   JNI_NULL_CHECK(env, j_type_nums, "j_type_nums is null", 0);
   JNI_NULL_CHECK(env, j_names, "j_names is null", 0);
   JNI_NULL_CHECK(env, j_indexes, "j_indexes is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const n_column_view      = reinterpret_cast<cudf::column_view const*>(input_column);
     auto const n_strings_col_view = cudf::strings_column_view{*n_column_view};
@@ -75,7 +77,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(JNIEnv* env,
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::get_json_object(n_strings_col_view, instructions));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -97,7 +99,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
 
   using path_type = std::vector<std::tuple<path_instruction_type, std::string, int32_t>>;
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const path_offsets = cudf::jni::native_jintArray(env, j_path_offsets).to_vector();
@@ -140,7 +143,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
     });
     return out_handles.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_extractRawMapFromJsonString(
@@ -154,7 +157,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_extractRawMap
 {
   JNI_NULL_CHECK(env, j_input, "j_input is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
     return cudf::jni::ptr_as_jlong(
@@ -165,7 +169,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_extractRawMap
                                              allow_unquoted_control)
         .release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -190,7 +194,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_fromJSONToStructs(JNIEnv* env,
   JNI_NULL_CHECK(env, j_scales, "j_scales is null", 0);
   JNI_NULL_CHECK(env, j_precisions, "j_precisions is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const input_cv     = reinterpret_cast<cudf::column_view const*>(j_input);
@@ -220,7 +225,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_fromJSONToStructs(JNIEnv* env,
                                              is_us_locale)
         .release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -240,7 +245,8 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_convertFromStrings(JNIEnv* env,
   JNI_NULL_CHECK(env, j_scales, "j_scales is null", 0);
   JNI_NULL_CHECK(env, j_precisions, "j_precisions is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const input_cv     = reinterpret_cast<cudf::column_view const*>(j_input);
@@ -264,7 +270,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_convertFromStrings(JNIEnv* env,
                                              is_us_locale)
         .release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_removeQuotes(
@@ -272,14 +278,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_JSONUtils_removeQuotes(
 {
   JNI_NULL_CHECK(env, j_input, "j_input is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(j_input);
     return cudf::jni::ptr_as_jlong(
       spark_rapids_jni::remove_quotes(cudf::strings_column_view{*input_cv}, nullify_if_not_quoted)
         .release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/KudoGpuSerializerJni.cpp
+++ b/src/main/cpp/src/KudoGpuSerializerJni.cpp
@@ -25,7 +25,8 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_splitAndSerializeToDevic
 {
   JNI_NULL_CHECK(env, j_table_view, "table is null", NULL);
   JNI_NULL_CHECK(env, j_splits, "splits is null", NULL);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto table = reinterpret_cast<cudf::table_view const*>(j_table_view);
@@ -59,7 +60,7 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_splitAndSerializeToDevic
 
     return result.get_jArray();
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -80,7 +81,8 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_assembleFromDeviceRawNat
   JNI_NULL_CHECK(env, flat_type_ids, "type_ids is null", NULL);
   JNI_NULL_CHECK(env, flat_scale, "scale is null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::device_span<uint8_t const> partitions(reinterpret_cast<uint8_t*>(part_addr), part_len);
@@ -111,6 +113,6 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_assembleFromDeviceRawNat
                        cudf::get_default_stream(),
                        cudf::get_current_device_resource()));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 }

--- a/src/main/cpp/src/ListSliceJni.cpp
+++ b/src/main/cpp/src/ListSliceJni.cpp
@@ -23,7 +23,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
   JNIEnv* env, jclass, jlong input_column, jint start, jint length, jboolean check_start_length)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     // The following constructor expects that the type of the input_column is LIST.
@@ -32,7 +33,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start, length, check_start_length));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceIntCol(
@@ -40,7 +41,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, length, "length column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     // The following constructor expects that the type of the input_column is LIST.
@@ -50,7 +52,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start, length_cv, check_start_length));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceColInt(
@@ -58,7 +60,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, start, "start column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     // The following constructor expects that the type of the input_column is LIST.
@@ -68,7 +71,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start_cv, length, check_start_length));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listSliceColCol(
@@ -77,7 +80,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, start, "start column is null", 0);
   JNI_NULL_CHECK(env, length, "length column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     // The following constructor expects that the type of the input_column is LIST.
@@ -88,7 +92,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuListSliceUtils_listS
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::list_slice(lcv, start_cv, length_cv, check_start_length));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/src/main/cpp/src/MapJni.cpp
+++ b/src/main/cpp/src/MapJni.cpp
@@ -27,13 +27,13 @@ JNIEXPORT jlong Java_com_nvidia_spark_rapids_jni_Map_sort(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, map_haldle, "column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto sort_order = is_descending ? cudf::order::DESCENDING : cudf::order::ASCENDING;
     cudf::column_view const& map_view = *reinterpret_cast<cudf::column_view const*>(map_haldle);
     return cudf::jni::release_as_jlong(spark_rapids_jni::sort_map_column(map_view, sort_order));
   }
-
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/MapZipWithUtilsJNI.cpp
+++ b/src/main/cpp/src/MapZipWithUtilsJNI.cpp
@@ -23,12 +23,13 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuMapZipWithUtils_mapZ
 {
   JNI_NULL_CHECK(env, input_column1, "input column1 is null", 0);
   JNI_NULL_CHECK(env, input_column2, "input column2 is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::lists_column_view col1{*reinterpret_cast<cudf::column_view const*>(input_column1)};
     cudf::lists_column_view col2{*reinterpret_cast<cudf::column_view const*>(input_column2)};
     return cudf::jni::release_as_jlong(spark_rapids_jni::map_zip(col1, col2));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -724,7 +724,8 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
                                                              jboolean ignore_case)
 {
   CUDF_FUNC_RANGE();
-  try {
+  JNI_TRY
+  {
     auto meta    = std::make_unique<parquet::format::FileMetaData>();
     uint32_t len = static_cast<uint32_t>(buffer_length);
     // We don't support encrypted parquet...
@@ -771,25 +772,27 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
 
     return cudf::jni::release_as_jlong(meta);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_close(JNIEnv* env,
                                                                             jclass,
                                                                             jlong handle)
 {
-  try {
+  JNI_TRY
+  {
     parquet::format::FileMetaData* ptr = reinterpret_cast<parquet::format::FileMetaData*>(handle);
     delete ptr;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumRows(JNIEnv* env,
                                                                                   jclass,
                                                                                   jlong handle)
 {
-  try {
+  JNI_TRY
+  {
     parquet::format::FileMetaData* ptr = reinterpret_cast<parquet::format::FileMetaData*>(handle);
     long ret                           = 0;
     for (auto it = ptr->row_groups.begin(); it != ptr->row_groups.end(); ++it) {
@@ -797,14 +800,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumRow
     }
     return ret;
   }
-  CATCH_STD(env, -1);
+  JNI_CATCH(env, -1);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumColumns(JNIEnv* env,
                                                                                      jclass,
                                                                                      jlong handle)
 {
-  try {
+  JNI_TRY
+  {
     parquet::format::FileMetaData* ptr = reinterpret_cast<parquet::format::FileMetaData*>(handle);
     int ret                            = 0;
     if (ptr->schema.size() > 0) {
@@ -812,14 +816,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumCol
     }
     return ret;
   }
-  CATCH_STD(env, -1);
+  JNI_CATCH(env, -1);
 }
 
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_serializeThriftFile(
   JNIEnv* env, jclass, jlong handle, jobject host_memory_allocator)
 {
   CUDF_FUNC_RANGE();
-  try {
+  JNI_TRY
+  {
     parquet::format::FileMetaData* meta = reinterpret_cast<parquet::format::FileMetaData*>(handle);
     std::shared_ptr<apache::thrift::transport::TMemoryBuffer> transportOut(
       new apache::thrift::transport::TMemoryBuffer());
@@ -850,6 +855,6 @@ JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_seriali
     after[7]       = '1';
     return ret;
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 }

--- a/src/main/cpp/src/NumberConverterJni.cpp
+++ b/src/main/cpp/src/NumberConverterJni.cpp
@@ -35,7 +35,8 @@ Java_com_nvidia_spark_rapids_jni_NumberConverter_convert(JNIEnv* env,
   if (is_from_cv) { JNI_NULL_CHECK(env, from_base, "from_base column handle is null", 0); }
   if (is_to_cv) { JNI_NULL_CHECK(env, to_base, "to_base column handle is null", 0); }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_variant     = is_input_cv
                                      ? variant_t{*reinterpret_cast<cudf::column_view*>(input)}
@@ -49,7 +50,7 @@ Java_com_nvidia_spark_rapids_jni_NumberConverter_convert(JNIEnv* env,
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::convert(input_variant, from_base_variant, to_base_variant));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jboolean JNICALL
@@ -66,7 +67,8 @@ Java_com_nvidia_spark_rapids_jni_NumberConverter_isConvertOverflow(JNIEnv* env,
   if (is_from_cv) { JNI_NULL_CHECK(env, from_base, "from_base column handle is null", 0); }
   if (is_to_cv) { JNI_NULL_CHECK(env, to_base, "to_base column handle is null", 0); }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_variant     = is_input_cv
                                      ? variant_t{*reinterpret_cast<cudf::column_view*>(input)}
@@ -79,6 +81,6 @@ Java_com_nvidia_spark_rapids_jni_NumberConverter_isConvertOverflow(JNIEnv* env,
                                      : variant_t{static_cast<int>(to_base)};
     return spark_rapids_jni::is_convert_overflow(input_variant, from_base_variant, to_base_variant);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/ParseURIJni.cpp
+++ b/src/main/cpp/src/ParseURIJni.cpp
@@ -28,7 +28,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseProtocol(
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
@@ -44,7 +45,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseHost(JNIE
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
@@ -60,7 +62,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQuery(JNI
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(
@@ -75,7 +78,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, query, "query is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     cudf::jni::native_jstring native_query(env, query);
@@ -93,7 +97,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parseQueryWith
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, query_column, "query column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     auto const query = reinterpret_cast<cudf::column_view const*>(query_column);
@@ -110,7 +115,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParseURI_parsePath(JNIE
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(input_column);
     return cudf::jni::ptr_as_jlong(

--- a/src/main/cpp/src/RegexRewriteUtilsJni.cpp
+++ b/src/main/cpp/src/RegexRewriteUtilsJni.cpp
@@ -27,7 +27,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_RegexRewriteUtils_liter
   JNI_NULL_CHECK(env, input, "input column is null", 0);
   JNI_NULL_CHECK(env, target, "target is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(input);
@@ -36,6 +37,6 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_RegexRewriteUtils_liter
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::literal_range_pattern(scv, *ss_scalar, d, start, end));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/RowConversionJni.cpp
+++ b/src/main/cpp/src/RowConversionJni.cpp
@@ -27,7 +27,8 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRowsFixedWidthOptimized(
 {
   JNI_NULL_CHECK(env, input_table, "input table is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view const* n_input_table = reinterpret_cast<cudf::table_view const*>(input_table);
     std::vector<std::unique_ptr<cudf::column>> cols =
@@ -39,7 +40,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRowsFixedWidthOptimized(
     });
     return outcol_handles.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -47,7 +48,8 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRows(JNIEnv* env, jclass
 {
   JNI_NULL_CHECK(env, input_table, "input table is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view const* n_input_table = reinterpret_cast<cudf::table_view const*>(input_table);
     std::vector<std::unique_ptr<cudf::column>> cols =
@@ -59,7 +61,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertToRows(JNIEnv* env, jclass
     });
     return outcol_handles.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -69,7 +71,8 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRowsFixedWidthOptimize
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, types, "types is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::lists_column_view const list_input{*reinterpret_cast<cudf::column_view*>(input_column)};
     cudf::jni::native_jintArray n_types(env, types);
@@ -88,7 +91,7 @@ Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRowsFixedWidthOptimize
       spark_rapids_jni::convert_from_rows_fixed_width_optimized(list_input, types_vec);
     return cudf::jni::convert_table_for_return(env, result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_convertFromRows(
@@ -97,7 +100,8 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_conv
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
   JNI_NULL_CHECK(env, types, "types is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::lists_column_view const list_input{*reinterpret_cast<cudf::column_view*>(input_column)};
     cudf::jni::native_jintArray n_types(env, types);
@@ -116,6 +120,6 @@ JNIEXPORT jlongArray JNICALL Java_com_nvidia_spark_rapids_jni_RowConversion_conv
       spark_rapids_jni::convert_from_rows(list_input, types_vec);
     return cudf::jni::convert_table_for_return(env, result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -2252,7 +2252,7 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_for
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->force_retry_oom(thread_id, num_ooms, oom_filter, skip_count);
   }
-  JNI_CATCH(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceSplitAndRetryOOM(

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -2076,17 +2076,16 @@ extern "C" {
 JNIEXPORT jlong JNICALL
 Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getCurrentThreadId(JNIEnv* env, jclass)
 {
-  try {
-    return static_cast<jlong>(pthread_self());
-  }
-  CATCH_STD(env, 0)
+  JNI_TRY { return static_cast<jlong>(pthread_self()); }
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_createNewAdaptor(
   JNIEnv* env, jclass, jlong child, jstring log_loc)
 {
   JNI_NULL_CHECK(env, child, "child is null", 0);
-  try {
+  JNI_TRY
+  {
     auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
     cudf::jni::native_jstring nlogloc(env, log_loc);
     std::shared_ptr<spdlog::logger> logger;
@@ -2109,18 +2108,19 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_cr
     auto ret = new spark_resource_adaptor(env, wrapped, logger, is_log_enabled);
     return cudf::jni::ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL
 Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_releaseAdaptor(JNIEnv* env, jclass, jlong ptr)
 {
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->all_done();
     delete mr;
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
@@ -2128,22 +2128,24 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_startDedicatedTaskThread(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id, jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->start_dedicated_task_thread(thread_id, task_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_isThreadWorkingOnTaskAsPoolThread(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->is_working_on_task_as_pool_thread(thread_id);
   }
-  CATCH_STD(env, false)
+  JNI_CATCH(env, false);
 }
 
 JNIEXPORT void JNICALL
@@ -2152,13 +2154,14 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_poolThreadWorkingOnTasks(
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
   JNI_NULL_CHECK(env, task_ids, "task_ids is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::native_jlongArray jtask_ids(env, task_ids);
     std::unordered_set<long> task_set(jtask_ids.begin(), jtask_ids.end());
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->pool_thread_working_on_tasks(is_for_shuffle, thread_id, task_set);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
@@ -2167,13 +2170,14 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_poolThreadFinishedForTasks
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
   JNI_NULL_CHECK(env, task_ids, "task_ids is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::native_jlongArray jtask_ids(env, task_ids);
     std::unordered_set<long> task_set(jtask_ids.begin(), jtask_ids.end());
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->pool_thread_finished_for_tasks(thread_id, task_set);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
@@ -2181,11 +2185,12 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_removeThreadAssociation(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id, jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->remove_thread_association(thread_id, task_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_taskDone(JNIEnv* env,
@@ -2194,99 +2199,108 @@ JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_tas
                                                                                       jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->task_done(task_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_submittingToPool(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->submitting_to_pool(thread_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_waitingOnPool(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->waiting_on_pool(thread_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_doneWaitingOnPool(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->done_waiting_on_pool(thread_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceRetryOOM(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id, jint num_ooms, jint oom_filter, jint skip_count)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->force_retry_oom(thread_id, num_ooms, oom_filter, skip_count);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceSplitAndRetryOOM(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id, jint num_ooms, jint oom_filter, jint skip_count)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->force_split_and_retry_oom(thread_id, num_ooms, oom_filter, skip_count);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_forceCudfException(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id, jint num_times)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->force_cudf_exception(thread_id, num_times);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_blockThreadUntilReady(
   JNIEnv* env, jclass, jlong ptr)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->block_thread_until_ready();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jint JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getStateOf(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_thread_state_as_int(thread_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL
@@ -2296,11 +2310,12 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetRetryThrowInter
                                                                                     jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_and_reset_num_retry(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL
@@ -2308,11 +2323,12 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetSplitRetryThrow
   JNIEnv* env, jclass, jlong ptr, jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_and_reset_num_split_retry(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -2322,11 +2338,12 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetBlockTimeIntern
                                                                                    jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_and_reset_block_time(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -2334,11 +2351,12 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetComputeTimeLost
   JNIEnv* env, jclass, jlong ptr, jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_and_reset_lost_time(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -2346,22 +2364,24 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getAndResetGpuMaxMemoryAll
   JNIEnv* env, jclass, jlong ptr, jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_and_reset_gpu_max_memory_allocated(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getMaxGpuTaskMemory(
   JNIEnv* env, jclass, jlong ptr, jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_max_gpu_task_memory(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -2371,55 +2391,60 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_getTotalBlockedOrLostTime(
                                                                                 jlong task_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->get_total_blocked_or_lost(task_id);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_startRetryBlock(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->start_retry_block(thread_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_endRetryBlock(
   JNIEnv* env, jclass, jlong ptr, jlong thread_id)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->end_retry_block(thread_id);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_checkAndBreakDeadlocks(
   JNIEnv* env, jclass, jlong ptr)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->check_and_break_deadlocks();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_preCpuAlloc(
   JNIEnv* env, jclass, jlong ptr, jlong amount, jboolean blocking)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->cpu_prealloc(amount, blocking);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL
@@ -2432,54 +2457,59 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_postCpuAllocSuccess(JNIEnv
                                                                           jboolean was_recursive)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->cpu_postalloc_success(reinterpret_cast<void*>(addr), amount, blocking, was_recursive);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_postCpuAllocFailed(
   JNIEnv* env, jclass, jlong ptr, jboolean was_oom, jboolean blocking, jboolean was_recursive)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", 0);
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     return mr->cpu_postalloc_failed(was_oom, blocking, was_recursive);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_cpuDeallocate(
   JNIEnv* env, jclass, jlong ptr, jlong addr, jlong amount)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->cpu_dealloc(reinterpret_cast<void*>(addr), amount);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_spillRangeStart(
   JNIEnv* env, jclass, jlong ptr)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->spill_range_start();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
 Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_spillRangeDone(JNIEnv* env, jclass, jlong ptr)
 {
   JNI_NULL_CHECK(env, ptr, "resource_adaptor is null", );
-  try {
+  JNI_TRY
+  {
     auto mr = reinterpret_cast<spark_resource_adaptor*>(ptr);
     mr->spill_range_done();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, );
 }
 }

--- a/src/main/cpp/src/StringUtilsJni.cpp
+++ b/src/main/cpp/src/StringUtilsJni.cpp
@@ -24,10 +24,11 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_StringUtils_randomUUIDs
                                                                                  jint row_count,
                                                                                  jlong seed)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     return cudf::jni::release_as_jlong(spark_rapids_jni::random_uuids(row_count, seed));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/SubStringIndexJni.cpp
+++ b/src/main/cpp/src/SubStringIndexJni.cpp
@@ -24,7 +24,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuSubstringIndexUtils_
 {
   JNI_NULL_CHECK(env, strings_handle, "strings column handle is null", 0);
   JNI_NULL_CHECK(env, delimiter, "delimiter scalar handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input               = reinterpret_cast<cudf::column_view const*>(strings_handle);
     auto const strings_column      = cudf::strings_column_view{*input};
@@ -32,6 +33,6 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuSubstringIndexUtils_
     return cudf::jni::release_as_jlong(
       spark_rapids_jni::substring_index(strings_column, *ss_scalar, count));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }  // extern "C"

--- a/src/main/cpp/src/ZOrderJni.cpp
+++ b/src/main/cpp/src/ZOrderJni.cpp
@@ -25,14 +25,15 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ZOrder_interleaveBits(
 {
   JNI_NULL_CHECK(env, input_columns, "input is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::column_view> n_input_columns(env, input_columns);
     cudf::table_view tbl(n_input_columns.get_dereferenced());
 
     return cudf::jni::ptr_as_jlong(spark_rapids_jni::interleave_bits(tbl).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ZOrder_hilbertIndex(
@@ -40,13 +41,14 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ZOrder_hilbertIndex(
 {
   JNI_NULL_CHECK(env, input_columns, "input is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::column_view> n_input_columns(env, input_columns);
     cudf::table_view tbl(n_input_columns.get_dereferenced());
 
     return cudf::jni::ptr_as_jlong(spark_rapids_jni::hilbert_index(num_bits, tbl).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/src/main/cpp/src/exception_with_row_index.hpp
+++ b/src/main/cpp/src/exception_with_row_index.hpp
@@ -53,6 +53,7 @@ class exception_with_row_index : public std::runtime_error {
 // This macro is used in JNI functions to throw an ExceptionWithRowIndex if error occurs
 // ExceptionWithRowIndex contains the row number that caused the exception
 #define CATCH_EXCEPTION_WITH_ROW_INDEX(env, ret_val)                                        \
+  JNI_CATCH_FIRST(env, ret_val)                                                             \
   catch (spark_rapids_jni::exception_with_row_index const& e)                               \
   {                                                                                         \
     if (env->ExceptionOccurred()) { return ret_val; }                                       \
@@ -67,5 +68,6 @@ class exception_with_row_index : public std::runtime_error {
     }                                                                                       \
     return ret_val;                                                                         \
   }                                                                                         \
-  JNI_CATCH(env, 0);
+  CATCH_SPECIAL_EXCEPTION(env, ret_val)                                                     \
+  CATCH_STD_EXCEPTION(env, ret_val)
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/exception_with_row_index.hpp
+++ b/src/main/cpp/src/exception_with_row_index.hpp
@@ -67,5 +67,5 @@ class exception_with_row_index : public std::runtime_error {
     }                                                                                       \
     return ret_val;                                                                         \
   }                                                                                         \
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }  // namespace spark_rapids_jni


### PR DESCRIPTION
This rewrites all JNI functions, replacing try/CATCH_STD with JNI_TRY/JNI_CATCH macros. By doing so, when needed (such as for debugging) we can insert more code in between the try/catch that can affect the entire JNI build.