### PR TITLE
[auto-merge] bot-auto-merge-branch-25.10 to branch-25.12 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -130,7 +130,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "278d5596227df7ba91f59b056f1dfe34d6af68f7",
+      "git_tag" : "4cd5dbfb9c432a8291fb0b4e246f9f9fed26b915",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "25.10"


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-25.10` to create a PR keeping `branch-25.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.