### PR TITLE
Fix kudo serializer test where table is too large.

### DIFF
--- a/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializerTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/kudo/KudoSerializerTest.java
@@ -816,7 +816,7 @@ public class KudoSerializerTest extends CudfTestBase {
     List<ColumnVector> allCols = new ArrayList<>();
     List<ColumnVector> tableCols = new ArrayList<>();
 
-    final int nonNullCount = Integer.MAX_VALUE / 512 - 21; // to avoid OOM
+    final int nonNullCount = Integer.MAX_VALUE / 128 - 21; // to avoid OOM
     final int nullCount = 11; // to add nulls
     final int totalCount = nonNullCount + nullCount;
 


### PR DESCRIPTION
Closes #3759 

Reduce the allocation size in kudo test so that it works on devices with smaller memories.