### PR TITLE
Copy cudf floating point rounding code into spark-rapids-jni

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -243,6 +243,7 @@ add_library(
   src/parse_uri.cu
   src/regex_rewrite_utils.cu
   src/row_conversion.cu
+  src/round_float.cu
   src/shuffle_assemble.cu
   src/shuffle_split.cu
   src/substring_index.cu

--- a/src/main/cpp/src/ArithmeticJni.cpp
+++ b/src/main/cpp/src/ArithmeticJni.cpp
@@ -18,6 +18,7 @@
 #include "exception_with_row_index.hpp"
 #include "jni_utils.hpp"
 #include "multiply.hpp"
+#include "round_float.hpp"
 
 extern "C" {
 
@@ -59,4 +60,21 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_multiply(JNI
   // ExceptionWithRowIndex contains the row number that caused the exception
   CATCH_EXCEPTION_WITH_ROW_INDEX(env, 0);
 }
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_round(JNIEnv* env,
+                                                                          jclass,
+                                                                          jlong input_ptr,
+                                                                          jint decimal_places,
+                                                                          jint rounding_method)
+{
+  JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view* input     = reinterpret_cast<cudf::column_view*>(input_ptr);
+    cudf::rounding_method method = static_cast<cudf::rounding_method>(rounding_method);
+    return cudf::jni::release_as_jlong(spark_rapids_jni::round(*input, decimal_places, method));
+  }
+  CATCH_STD(env, 0);
+}
+
 }

--- a/src/main/cpp/src/ArithmeticJni.cpp
+++ b/src/main/cpp/src/ArithmeticJni.cpp
@@ -61,11 +61,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_multiply(JNI
   CATCH_EXCEPTION_WITH_ROW_INDEX(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_round(JNIEnv* env,
-                                                                          jclass,
-                                                                          jlong input_ptr,
-                                                                          jint decimal_places,
-                                                                          jint rounding_method)
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_round(
+  JNIEnv* env, jclass, jlong input_ptr, jint decimal_places, jint rounding_method)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
   try {
@@ -76,5 +73,4 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_Arithmetic_round(JNIEnv
   }
   CATCH_STD(env, 0);
 }
-
 }

--- a/src/main/cpp/src/round_float.cu
+++ b/src/main/cpp/src/round_float.cu
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "round_float.hpp"
+
+#include <cuda/std/type_traits>
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/transform.h>
+
+#include <cmath>
+#include <type_traits>
+
+namespace spark_rapids_jni {
+
+
+inline float __device__ generic_round(float f) { return roundf(f); }
+inline double __device__ generic_round(double d) { return ::round(d); }
+
+inline float __device__ generic_round_half_even(float f) { return rintf(f); }
+inline double __device__ generic_round_half_even(double d) { return rint(d); }
+
+inline __device__ float generic_modf(float a, float* b) { return modff(a, b); }
+inline __device__ double generic_modf(double a, double* b) { return modf(a, b); }
+
+
+template <typename T>
+struct half_up_zero {
+  T n;  // unused in the decimal_places = 0 case
+  __device__ T operator()(T e)
+  {
+    return generic_round(e);
+  }
+};
+
+template <typename T>
+struct half_up_positive {
+  T n;
+  __device__ T operator()(T e)
+  {
+    T integer_part;
+    T const fractional_part = generic_modf(e, &integer_part);
+    return integer_part + generic_round(fractional_part * n) / n;
+  }
+};
+
+template <typename T>
+struct half_up_negative {
+  T n;
+  __device__ T operator()(T e)
+  {
+    return generic_round(e / n) * n;
+  }
+};
+
+template <typename T>
+struct half_even_zero {
+  T n;  // unused in the decimal_places = 0 case
+  __device__ T operator()(T e)
+  {
+    return generic_round_half_even(e);
+  }
+};
+
+template <typename T>
+struct half_even_positive {
+  T n;
+  __device__ T operator()(T e)
+  {
+    T integer_part;
+    T const fractional_part = generic_modf(e, &integer_part);
+    return integer_part + generic_round_half_even(fractional_part * n) / n;
+  }
+};
+
+template <typename T>
+struct half_even_negative {
+  T n;
+  __device__ T operator()(T e)
+  {
+    return generic_round_half_even(e / n) * n;
+  }
+};
+
+template <typename T, template <typename> typename RoundFunctor>
+std::unique_ptr<cudf::column> round_with(cudf::column_view const& input,
+                                         int32_t decimal_places,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
+    requires(std::is_floating_point_v<T>)
+{
+  using Functor = RoundFunctor<T>;
+
+  auto result = cudf::make_fixed_width_column(input.type(),
+                                              input.size(),
+                                              cudf::detail::copy_bitmask(input, stream, mr),
+                                              input.null_count(),
+                                              stream,
+                                              mr);
+
+  auto out_view = result->mutable_view();
+  T const n     = std::pow(10, std::abs(decimal_places));
+
+  thrust::transform(
+    rmm::exec_policy(stream), input.begin<T>(), input.end<T>(), out_view.begin<T>(), Functor{n});
+
+  result->set_null_count(input.null_count());
+
+  return result;
+}
+
+struct round_type_dispatcher {
+  template <typename T, typename... Args>
+  std::unique_ptr<cudf::column> operator()(Args&&...)
+    requires(!std::is_floating_point_v<T>)
+  {
+    CUDF_FAIL("Type not supported for spark_rapids_jni::round");
+  }
+  
+  template <typename T>
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const& input,
+                                           int32_t decimal_places,
+                                           cudf::rounding_method method,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr)
+    requires(std::is_floating_point_v<T>)
+  {
+    // clang-format off
+    switch (method) {
+      case cudf::rounding_method::HALF_UP:
+        if      (decimal_places == 0) return round_with<T, half_up_zero      >(input, decimal_places, stream, mr);
+        else if (decimal_places >  0) return round_with<T, half_up_positive  >(input, decimal_places, stream, mr);
+        else                          return round_with<T, half_up_negative  >(input, decimal_places, stream, mr);
+      case cudf::rounding_method::HALF_EVEN:
+        if      (decimal_places == 0) return round_with<T, half_even_zero    >(input, decimal_places, stream, mr);
+        else if (decimal_places >  0) return round_with<T, half_even_positive>(input, decimal_places, stream, mr);
+        else                          return round_with<T, half_even_negative>(input, decimal_places, stream, mr);
+      default: CUDF_FAIL("Undefined rounding method");
+    }
+    // clang-format on
+  }
+};
+
+std::unique_ptr<cudf::column> round(cudf::column_view const& input,
+                                    int32_t decimal_places,
+                                    cudf::rounding_method method,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  CUDF_EXPECTS(cudf::is_numeric(input.type()) || cudf::is_fixed_point(input.type()),
+               "Only integral/floating point/fixed point currently supported.");
+
+  if(!cudf::is_floating_point(input.type())) {
+    return cudf::round_decimal(input, decimal_places, method, stream, mr);
+  }
+  if (input.is_empty()) {
+    return cudf::empty_like(input);
+  }
+
+  return cudf::type_dispatcher(
+    input.type(), round_type_dispatcher{}, input, decimal_places, method, stream, mr);
+}
+
+} // namespace spark_rapids_jni

--- a/src/main/cpp/src/round_float.hpp
+++ b/src/main/cpp/src/round_float.hpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #pragma once
 
 #include <cudf/column/column.hpp>
@@ -59,11 +59,11 @@ namespace spark_rapids_jni {
  *
  * @return Column with each of the values rounded
  */
- std::unique_ptr<cudf::column> round(
-    cudf::column_view const& input,
-    int32_t decimal_places            = 0,
-    cudf::rounding_method method      = cudf::rounding_method::HALF_UP,
-    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-  
- } // namespace spark_rapids_jni
+std::unique_ptr<cudf::column> round(
+  cudf::column_view const& input,
+  int32_t decimal_places            = 0,
+  cudf::rounding_method method      = cudf::rounding_method::HALF_UP,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/round_float.hpp
+++ b/src/main/cpp/src/round_float.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/round.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+namespace spark_rapids_jni {
+
+/**
+ * @brief Rounds all the values in a column to the specified number of decimal places.
+ *
+ * `cudf::round` currently supports HALF_UP and HALF_EVEN rounding for integer, floating point and
+ * `decimal32` and `decimal64` numbers. For `decimal32` and `decimal64` numbers, negated
+ * `numeric::scale` is equivalent to `decimal_places`.
+ *
+ * Example:
+ * ```
+ * cudf::column_view a; // contains { 1.729, 17.29, 172.9, 1729 };
+ *
+ * auto result1 = round(a);     // { 2,   17,   173,   1729 }
+ * auto result2 = round(a, 1);  // { 1.7, 17.3, 172.9, 1729 }
+ * auto result3 = round(a, -1); // { 0,   20,   170,   1730 }
+ *
+ * cudf::column_view b; // contains { 1.5, 2.5, 1.35, 1.45, 15, 25 };
+ *
+ * auto result4 = round(b,  0, cudf::rounding_method::HALF_EVEN); // { 2,   2,   1,   1,   15, 25};
+ * auto result5 = round(b,  1, cudf::rounding_method::HALF_EVEN); // { 1.5, 2.5, 1.4, 1.4, 15, 25};
+ * auto result6 = round(b, -1, cudf::rounding_method::HALF_EVEN); // { 0,   0,   0,   0,   20, 20};
+ * ```
+ *
+ * @param input          Column of values to be rounded
+ * @param decimal_places Number of decimal places to round to (default 0). If negative, this
+ * specifies the number of positions to the left of the decimal point.
+ * @param method         Rounding method
+ * @param stream         CUDA stream used for device memory operations and kernel launches
+ * @param mr             Device memory resource used to allocate the returned column's device memory
+ *
+ * @return Column with each of the values rounded
+ */
+ std::unique_ptr<cudf::column> round(
+    cudf::column_view const& input,
+    int32_t decimal_places            = 0,
+    cudf::rounding_method method      = cudf::rounding_method::HALF_UP,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+  
+ } // namespace spark_rapids_jni

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -1412,6 +1412,8 @@ __global__ void copy_validity(cudf::device_span<assemble_batch> batches)
     remaining_rows -= rows_in_batch;
   } while (remaining_words > 0);
 
+  __syncthreads();
+
   // final trailing bits, if any
   if (threadIdx.x == 0 && dst_word_index == last_word_index) {
     valid_count += store_word(dst_word_index, prev_word[0]);

--- a/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids.jni;
 
 import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.ColumnView;
 import ai.rapids.cudf.Scalar;
 
 public class Arithmetic {
@@ -104,6 +105,58 @@ public class Arithmetic {
         isTryMode));
   }
 
+  /**
+   * Rounds all the values in a column to the specified number of decimal places.
+   *
+   * @param input         Column of values to be rounded
+   * @param decimalPlaces Number of decimal places to round to. If negative, this
+   *                      specifies the number of positions to the left of the decimal point.
+   * @param mode          Rounding method(either HALF_UP or HALF_EVEN)
+   * @return a new ColumnVector with rounded values.
+   */
+  public static ColumnVector round(ColumnView input, int decimalPlaces, RoundMode mode) {
+    return new ColumnVector(round(input.getNativeView(), decimalPlaces, mode.nativeId));
+  }
+
+  /**
+   * Rounds all the values in a column with decimal places = 0. Default number of decimal places
+   * to round to is 0.
+   *
+   * @param input Column of values to be rounded
+   * @param round Rounding method(either HALF_UP or HALF_EVEN)
+   * @return a new ColumnVector with rounded values.
+   */
+  public static ColumnVector round(ColumnView input, RoundMode round) {
+    return round(input, 0, round);
+  }
+
+  /**
+   * Rounds all the values in a column to the specified number of decimal places with HALF_UP
+   * (default) as Rounding method.
+   *
+   * @param input         Column of values to be rounded
+   * @param decimalPlaces Number of decimal places to round to. If negative, this
+   *                      specifies the number of positions to the left of the decimal point.
+   * @return a new ColumnVector with rounded values.
+   */
+  public static ColumnVector round(ColumnView input, int decimalPlaces) {
+    return round(input, decimalPlaces, RoundMode.HALF_UP);
+  }
+
+  /**
+   * Rounds all the values in a column with these default values:
+   * decimalPlaces = 0
+   * Rounding method = RoundMode.HALF_UP
+   *
+   * @param input Column of values to be rounded
+   * @return a new ColumnVector with rounded values.
+   */
+  public static ColumnVector round(ColumnView input) {
+    return round(input, 0, RoundMode.HALF_UP);
+  }
+
   private static native long multiply(long leftHandle, boolean isLeftCv, long rightHandle,
       boolean isRightCv, boolean isAnsiMode, boolean isTryMode);
+
+  private static native long round(long nativeHandle, int decimalPlaces, int roundingMethod);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/RoundMode.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RoundMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/RoundMode.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RoundMode.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.jni;
+
+/**
+ * Rounding modes supported in round method.
+ * HALF_UP : Rounding mode to round towards "nearest neighbor". If both neighbors are
+ * equidistant, then round up.
+ * HALF_EVEN : Rounding mode to round towards the "nearest neighbor". If both neighbors are
+ * equidistant, round towards the even neighbor.
+ */
+public enum RoundMode {
+  HALF_UP(0),
+  HALF_EVEN(1);
+  final int nativeId;
+
+  RoundMode(int nativeId) { this.nativeId = nativeId; }
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/ArithmeticTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ArithmeticTest.java
@@ -16,12 +16,17 @@
 
 package com.nvidia.spark.rapids.jni;
 
-import ai.rapids.cudf.*;
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.ColumnView;
+import ai.rapids.cudf.Scalar;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.nvidia.spark.rapids.jni.RoundMode;
+
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+import java.math.BigInteger;
 
 public class ArithmeticTest {
 
@@ -101,6 +106,126 @@ public class ArithmeticTest {
       Assertions.fail("Expected ExceptionWithRowIndex due to overflow");
     } catch (ExceptionWithRowIndex e) {
       Assertions.assertEquals(2, e.getRowIndex());
+    }
+  }
+
+  @Test
+  void roundFloatsHalfUp() {
+    try (ColumnVector v = ColumnVector.fromBoxedFloats(1.234f, 25.66f, null, 154.9f, 2346f);
+         ColumnVector result1 = Arithmetic.round(v, 0, RoundMode.HALF_UP);
+         ColumnVector result2 = Arithmetic.round(v, 1, RoundMode.HALF_UP);
+         ColumnVector result3 = Arithmetic.round(v, -1, RoundMode.HALF_UP);
+         ColumnVector expected1 = ColumnVector.fromBoxedFloats(1f, 26f, null, 155f, 2346f);
+         ColumnVector expected2 = ColumnVector.fromBoxedFloats(1.2f, 25.7f, null, 154.9f, 2346f);
+         ColumnVector expected3 = ColumnVector.fromBoxedFloats(0f, 30f, null, 150f, 2350f)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+      assertColumnsAreEqual(expected3, result3);
+    }
+  }
+
+  @Test
+  void roundFloatsHalfEven() {
+    try (ColumnVector v = ColumnVector.fromBoxedFloats(1.5f, 2.5f, 1.35f, null, 1.25f, 15f, 25f);
+         ColumnVector result1 = Arithmetic.round(v, RoundMode.HALF_EVEN);
+         ColumnVector result2 = Arithmetic.round(v, 1, RoundMode.HALF_EVEN);
+         ColumnVector result3 = Arithmetic.round(v, -1, RoundMode.HALF_EVEN);
+         ColumnVector expected1 = ColumnVector.fromBoxedFloats(2f, 2f, 1f, null, 1f, 15f, 25f);
+         ColumnVector expected2 = ColumnVector.fromBoxedFloats(1.5f, 2.5f, 1.4f, null, 1.2f, 15f, 25f);
+         ColumnVector expected3 = ColumnVector.fromBoxedFloats(0f, 0f, 0f, null, 0f, 20f, 20f)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+      assertColumnsAreEqual(expected3, result3);
+    }
+  }
+
+  @Test
+  void roundIntsHalfUp() {
+    try (ColumnVector v = ColumnVector.fromBoxedInts(12, 135, 160, -1454, null, -1500, -140, -150);
+         ColumnVector result1 = Arithmetic.round(v, 2, RoundMode.HALF_UP);
+         ColumnVector result2 = Arithmetic.round(v, -2, RoundMode.HALF_UP);
+         ColumnVector expected1 = ColumnVector.fromBoxedInts(12, 135, 160, -1454, null, -1500, -140, -150);
+         ColumnVector expected2 = ColumnVector.fromBoxedInts(0, 100, 200, -1500, null, -1500, -100, -200)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+    }
+  }
+
+  @Test
+  void roundIntsHalfEven() {
+    try (ColumnVector v = ColumnVector.fromBoxedInts(12, 24, 135, 160, null, 1450, 1550, -1650);
+         ColumnVector result1 = Arithmetic.round(v, 2, RoundMode.HALF_EVEN);
+         ColumnVector result2 = Arithmetic.round(v, -2, RoundMode.HALF_EVEN);
+         ColumnVector expected1 = ColumnVector.fromBoxedInts(12, 24, 135, 160, null, 1450, 1550, -1650);
+         ColumnVector expected2 = ColumnVector.fromBoxedInts(0, 0, 100, 200, null, 1400, 1600, -1600)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+    }
+  }
+
+  @Test
+  void roundDecimal() {
+    final int dec32Scale1 = -2;
+    final int resultScale1 = -3;
+
+    final int[] DECIMAL32_1 = new int[]{14, 15, 16, 24, 25, 26} ;
+    final int[] expectedHalfUp = new int[]{1, 2, 2, 2, 3, 3};
+    final int[] expectedHalfEven = new int[]{1, 2, 2, 2, 2, 3};
+    try (ColumnVector v = ColumnVector.decimalFromInts(-dec32Scale1, DECIMAL32_1);
+         ColumnVector roundHalfUp = Arithmetic.round(v, -3, RoundMode.HALF_UP);
+         ColumnVector roundHalfEven = Arithmetic.round(v, -3, RoundMode.HALF_EVEN);
+         ColumnVector answerHalfUp = ColumnVector.decimalFromInts(-resultScale1, expectedHalfUp);
+         ColumnVector answerHalfEven = ColumnVector.decimalFromInts(-resultScale1, expectedHalfEven)) {
+      assertColumnsAreEqual(answerHalfUp, roundHalfUp);
+      assertColumnsAreEqual(answerHalfEven, roundHalfEven);
+    }
+  }
+
+  @Test
+  void roundDefault() {
+    try (ColumnVector v = ColumnVector.fromBoxedFloats(1.234f, 25.66f, null, 154.9f, 2346f);
+         ColumnVector result = Arithmetic.round(v);
+         ColumnVector expected = ColumnVector.fromBoxedFloats(1f, 26f, null, 155f, 2346f)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void roundWithDecimalPlaces() {
+    try (ColumnVector v = ColumnVector.fromBoxedFloats(1.234f, 25.66f, null, 154.9f, 2346f);
+         ColumnVector result = Arithmetic.round(v, 2);
+         ColumnVector expected = ColumnVector.fromBoxedFloats(1.23f, 25.66f, null, 154.9f, 2346f)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void roundDoublesHalfUp() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.234, 25.66, null, 154.9, 2346.0);
+         ColumnVector result1 = Arithmetic.round(v, 0, RoundMode.HALF_UP);
+         ColumnVector result2 = Arithmetic.round(v, 1, RoundMode.HALF_UP);
+         ColumnVector result3 = Arithmetic.round(v, -1, RoundMode.HALF_UP);
+         ColumnVector expected1 = ColumnVector.fromBoxedDoubles(1.0, 26.0, null, 155.0, 2346.0);
+         ColumnVector expected2 = ColumnVector.fromBoxedDoubles(1.2, 25.7, null, 154.9, 2346.0);
+         ColumnVector expected3 = ColumnVector.fromBoxedDoubles(0.0, 30.0, null, 150.0, 2350.0)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+      assertColumnsAreEqual(expected3, result3);
+    }
+  }
+
+  @Test
+  void roundDoublesHalfEven() {
+    try (ColumnVector v = ColumnVector.fromBoxedDoubles(1.5, 2.5, 1.35, null, 1.25, 15.0, 25.0);
+         ColumnVector result1 = Arithmetic.round(v, RoundMode.HALF_EVEN);
+         ColumnVector result2 = Arithmetic.round(v, 1, RoundMode.HALF_EVEN);
+         ColumnVector result3 = Arithmetic.round(v, -1, RoundMode.HALF_EVEN);
+         ColumnVector expected1 = ColumnVector.fromBoxedDoubles(2.0, 2.0, 1.0, null, 1.0, 15.0, 25.0);
+         ColumnVector expected2 = ColumnVector.fromBoxedDoubles(1.5, 2.5, 1.4, null, 1.2, 15.0, 25.0);
+         ColumnVector expected3 = ColumnVector.fromBoxedDoubles(0.0, 0.0, 0.0, null, 0.0, 20.0, 20.0)) {
+      assertColumnsAreEqual(expected1, result1);
+      assertColumnsAreEqual(expected2, result2);
+      assertColumnsAreEqual(expected3, result3);
     }
   }
 }


### PR DESCRIPTION
Copy/paste deprecated cudf floating point rounding code into spark-rapids-jni. The new rounding code here is identical to the [cudf code](https://github.com/rapidsai/cudf/blob/branch-25.12/cpp/src/round/round.cu) for floating, and redirects non-floating-point to the existing cudf round_decimal() methods.  Unit tests already exist and the tests pass.  

This implements a new API (Arithmetic.round) to call the copied rounding code, as the old [ColumnView round() methods](https://github.com/rapidsai/cudf/blob/08d02989ebe498a7d643bc49be26a2b5d762236b/java/src/main/java/ai/rapids/cudf/ColumnView.java#L1116) are defined in cudf java code and thus don't know about and can't call the new code.  

This is for [issue 3585](https://github.com/NVIDIA/spark-rapids-jni/issues/3585), as this code will be removed from cudf so we need it here. [This PR](https://github.com/NVIDIA/spark-rapids/pull/13497) has been submitted for spark-rapids that changes that code to use this new API.  [This PR](https://github.com/rapidsai/cudf/pull/20110) in cudf removes the old ColumnView rounding code. 