### PR TITLE
[auto-merge] bot-auto-merge-branch-25.10 to branch-25.12 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -77,10 +77,10 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "1b70488a0ee6ed7590ca16618e8ee5d8e6605853",
+      "git_tag" : "d65e583806608a3bde785204fb99493a782bc0c4",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
-      "version" : "25.10"
+      "version" : "25.12"
     },
     "nanoarrow" : 
     {


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-25.10` to create a PR keeping `branch-25.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.