### PR TITLE
Fix some nullptr dereference issues in profiler code

### DIFF
--- a/src/main/cpp/profiler/profiler_serializer.cpp
+++ b/src/main/cpp/profiler/profiler_serializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix #3754

Full story in the issue #3754.

We met a fatal error when profiling a query with spark-rapids's self-profiler:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f94c86b47fd, pid=1059639, tid=0x00007f91f7fff640
#
# JRE version: OpenJDK Runtime Environment (8.0_422-b05) (build 1.8.0_422-8u422-b05-1~22.04-b05)
# Java VM: OpenJDK 64-Bit Server VM (25.422-b05 mixed mode linux-amd64 compressed oops)
# Problematic frame:
# C  [libc.so.6+0x19d7fd]
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

---------------  T H R E A D  ---------------

Current thread (0x00007f91ec001000):  JavaThread "profiler writer" [_thread_in_native, id=1059804, stack(0x00007f91f7800000,0x00007f91f8000000)]

siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000000
```

It is because a nullptr dereference issue when process cupti activities.

In
```
auto name = fbb_.CreateSharedString(r->name);
```
If the `r->name` is `nullptr`, `nullptr` will be passed to a `strlen`, which will cause UB, thus resulting in a core dump. 

This PR fixes cases like that, and the fatal error disappears with this PR.

It's a team work with @GaryShen2008 and @binmahone, many thanks!



