### PR TITLE
Fix build due to removing of cudf's  `experimental::` row operators

### DIFF
--- a/src/main/cpp/src/hive_hash.cu
+++ b/src/main/cpp/src/hive_hash.cu
@@ -18,8 +18,8 @@
 #include "hash.hpp"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/row_operator/row_operators.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
-#include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -195,7 +195,7 @@ class hive_device_row_hasher {
    */
   class element_hasher_adapter {
    public:
-    using hash_functor_t = cudf::experimental::row::hash::element_hasher<hash_function, Nullate>;
+    using hash_functor_t = cudf::detail::row::hash::element_hasher<hash_function, Nullate>;
 
     __device__ element_hasher_adapter(Nullate check_nulls) noexcept
       : hash_functor{check_nulls, HIVE_INIT_HASH, HIVE_INIT_HASH}
@@ -390,9 +390,8 @@ class hive_device_row_hasher {
               // If the child is of primitive type, accumulate child hash into struct hash
               if (child_col.type().id() != cudf::type_id::LIST &&
                   child_col.type().id() != cudf::type_id::STRUCT) {
-                auto child_hash =
-                  cudf::type_dispatcher<cudf::experimental::dispatch_void_if_nested>(
-                    child_col.type(), this->hash_functor, child_col, 0);
+                auto child_hash = cudf::type_dispatcher<cudf::detail::dispatch_void_if_nested>(
+                  child_col.type(), this->hash_functor, child_col, 0);
                 top.update_cur_hash(child_hash);
               } else {
                 col_stack[stack_size++] = col_stack_frame(child_col);
@@ -412,7 +411,7 @@ class hive_device_row_hasher {
               thrust::counting_iterator(child_col.size()),
               HIVE_INIT_HASH,
               [child_col, hasher = this->hash_functor] __device__(auto hash, auto element_index) {
-                auto cur_hash = cudf::type_dispatcher<cudf::experimental::dispatch_void_if_nested>(
+                auto cur_hash = cudf::type_dispatcher<cudf::detail::dispatch_void_if_nested>(
                   child_col.type(), hasher, child_col, element_index);
                 return HIVE_HASH_FACTOR * hash + cur_hash;
               });

--- a/src/main/cpp/src/map_zip_with_utils.cu
+++ b/src/main/cpp/src/map_zip_with_utils.cu
@@ -19,11 +19,11 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/labeling/label_segments.cuh>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/row_operator/row_operators.cuh>
 #include <cudf/lists/count_elements.hpp>
 #include <cudf/lists/gather.hpp>
 #include <cudf/lists/set_operations.hpp>
 #include <cudf/reduction.hpp>
-#include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/span.hpp>
@@ -265,10 +265,10 @@ std::unique_ptr<column> indices_of(
   auto const values_tview = cudf::table_view{{all_values}};
   auto const has_nulls    = has_nested_nulls(values_tview) || has_nested_nulls(keys_tview);
   auto const comparator =
-    cudf::experimental::row::equality::two_table_comparator(values_tview, keys_tview, stream);
+    cudf::detail::row::equality::two_table_comparator(values_tview, keys_tview, stream);
   auto const d_comp    = comparator.equal_to<false>(cudf::nullate::DYNAMIC{has_nulls});
-  using lhs_index_type = cudf::experimental::row::lhs_index_type;
-  using rhs_index_type = cudf::experimental::row::rhs_index_type;
+  using lhs_index_type = cudf::detail::row::lhs_index_type;
+  using rhs_index_type = cudf::detail::row::rhs_index_type;
 
   // Perform the actual key-value comparisons
   // For each comparison: if key == value, return the value index; otherwise return Out of Bounds

--- a/src/main/cpp/src/murmur_hash.cu
+++ b/src/main/cpp/src/murmur_hash.cu
@@ -17,8 +17,8 @@
 #include "murmur_hash.cuh"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/row_operator/row_operators.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
-#include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -62,8 +62,8 @@ namespace {
  */
 template <template <typename> class hash_function, typename Nullate>
 class murmur_device_row_hasher {
-  friend class cudf::experimental::row::hash::row_hasher;  ///< Allow row_hasher to access private
-                                                           ///< members.
+  friend class cudf::detail::row::hash::row_hasher;  ///< Allow row_hasher to access private
+                                                     ///< members.
 
  public:
   /**
@@ -104,7 +104,7 @@ class murmur_device_row_hasher {
     {
     }
 
-    using hash_functor = cudf::experimental::row::hash::element_hasher<hash_fn, Nullate>;
+    using hash_functor = cudf::detail::row::hash::element_hasher<hash_fn, Nullate>;
 
     template <typename T, CUDF_ENABLE_IF(not cudf::is_nested<T>())>
     __device__ murmur_hash_value_type operator()(cudf::column_device_view const& col,
@@ -136,7 +136,7 @@ class murmur_device_row_hasher {
         _seed,
         [curr_col, nulls = this->_check_nulls] __device__(auto hash, auto element_index) {
           auto const hasher = hash_functor{nulls, hash, hash};
-          return cudf::type_dispatcher<cudf::experimental::dispatch_void_if_nested>(
+          return cudf::type_dispatcher<cudf::detail::dispatch_void_if_nested>(
             curr_col.type(), hasher, curr_col, element_index);
         });
     }
@@ -203,7 +203,7 @@ std::unique_ptr<cudf::column> murmur_hash3_32(cudf::table_view const& input,
   check_hash_compatibility(input);
 
   bool const nullable   = has_nested_nulls(input);
-  auto const row_hasher = cudf::experimental::row::hash::row_hasher(input, stream);
+  auto const row_hasher = cudf::detail::row::hash::row_hasher(input, stream);
   auto output_view      = output->mutable_view();
 
   // Compute the hash value for each row

--- a/src/main/cpp/src/xxhash64.cu
+++ b/src/main/cpp/src/xxhash64.cu
@@ -18,8 +18,8 @@
 #include "hash.hpp"
 
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/row_operator/row_operators.cuh>
 #include <cudf/detail/utilities/algorithm.cuh>
-#include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/table/table_device_view.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -493,7 +493,7 @@ class device_row_hasher {
             thrust::counting_iterator(curr_col.size()),
             ret,
             [curr_col, _check_nulls] __device__(auto hash, auto element_index) {
-              return cudf::type_dispatcher<cudf::experimental::dispatch_void_if_nested>(
+              return cudf::type_dispatcher<cudf::detail::dispatch_void_if_nested>(
                 curr_col.type(), element_hasher{_check_nulls, hash}, curr_col, element_index);
             });
           --stack_size;


### PR DESCRIPTION
The cudf's row operators are migrating out of the `experimental::` namespace in https://github.com/rapidsai/cudf/pull/20097. As such, we also need to adopt such changes.

Depends on: 
 * https://github.com/rapidsai/cudf/pull/20097