### PR TITLE
[auto-merge] bot-auto-merge-branch-25.10 to branch-25.12 [skip ci] [bot]

### DIFF
--- a/src/main/cpp/profiler/profiler_serializer.cpp
+++ b/src/main/cpp/profiler/profiler_serializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -367,7 +367,9 @@ void profiler_serializer::process_api_activity(CUpti_ActivityAPI const* r)
 
 void profiler_serializer::process_device_activity(CUpti_ActivityDevice4 const* r)
 {
-  auto name = fbb_.CreateSharedString(r->name);
+  auto has_name = r->name != nullptr;
+  flatbuffers::Offset<flatbuffers::String> name;
+  if (has_name) { name = fbb_.CreateSharedString(r->name); }
   DeviceActivityBuilder dab(fbb_);
   dab.add_global_memory_bandwidth(r->globalMemoryBandwidth);
   dab.add_global_memory_size(r->globalMemorySize);
@@ -411,7 +413,9 @@ void profiler_serializer::process_kernel(CUpti_ActivityKernel8 const* r)
     // Ignore records with invalid timestamps
     return;
   }
-  auto name = fbb_.CreateSharedString(r->name);
+  auto has_name = r->name != nullptr;
+  flatbuffers::Offset<flatbuffers::String> name;
+  if (has_name) { name = fbb_.CreateSharedString(r->name); }
   KernelActivityBuilder kab(fbb_);
   kab.add_requested(r->cacheConfig.config.requested);
   kab.add_executed(r->cacheConfig.config.executed);
@@ -467,7 +471,7 @@ void profiler_serializer::process_marker_activity(CUpti_ActivityMarker2 const* r
   }
   auto object_id  = add_object_id(fbb_, r->objectKind, r->objectId);
   auto has_name   = r->name != nullptr;
-  auto has_domain = r->name != nullptr;
+  auto has_domain = r->domain != nullptr;
   flatbuffers::Offset<flatbuffers::String> name;
   flatbuffers::Offset<flatbuffers::String> domain;
   if (has_name) { name = fbb_.CreateSharedString(r->name); }

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -77,10 +77,10 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "1b70488a0ee6ed7590ca16618e8ee5d8e6605853",
+      "git_tag" : "d8787fc1ae9db44aa233612aefa2b9111202ce73",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
-      "version" : "25.10"
+      "version" : "25.12"
     },
     "nanoarrow" : 
     {


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-25.10` to create a PR keeping `branch-25.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.