### PR TITLE
[auto-merge] bot-auto-merge-branch-25.10 to branch-25.12 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -130,7 +130,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "278d5596227df7ba91f59b056f1dfe34d6af68f7",
+      "git_tag" : "5b465769af7d0128b8bf08471fe3ecc5c82b1f7d",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "25.10"

--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -77,10 +77,10 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "1b70488a0ee6ed7590ca16618e8ee5d8e6605853",
+      "git_tag" : "d8787fc1ae9db44aa233612aefa2b9111202ce73",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
-      "version" : "25.10"
+      "version" : "25.12"
     },
     "nanoarrow" : 
     {
@@ -130,7 +130,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "5b465769af7d0128b8bf08471fe3ecc5c82b1f7d",
+      "git_tag" : "278d5596227df7ba91f59b056f1dfe34d6af68f7",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "25.10"


### PR DESCRIPTION
auto-merge triggered by github actions on `bot-auto-merge-branch-25.10` to create a PR keeping `branch-25.12` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.