### PR TITLE
Update automerge pattern to release/* [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-      - branch-*
+      - release/*
     types: [closed]
 
 jobs:


### PR DESCRIPTION
New: `release/* -> main`

The automerge will be working only in burndown&code freeze phase now