### PR TITLE
Use Rmm read/write locks in RmmSpark

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -343,7 +343,6 @@ public class RmmSpark {
       Rmm.readLock.unlock();
     }
   }
-  }
 
   /**
    * Remove the current thread from being associated with the given task.


### PR DESCRIPTION
This change contributes to https://github.com/NVIDIA/spark-rapids-jni/issues/3905 and follows this change in cuDF https://github.com/rapidsai/cudf/pull/20521 that introduces reader and writer locks for Rmm.class.

We would like to move to this mode because we don't need to exclusively lock all of Rmm.class for every operation we do here (for example, starting retry blocks and ending them). The idea here is we instead take out reader locks, allowing concurrent calls to these functions.

Note that, we will hit other coarse locks usually inside, but having the even coarser Rmm.class lock, we can't begin to think about changing the locking of these calls internally in spark-rapids-jni.