### PR TITLE
Add .gitmodules to auto-merge exception list [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -29,6 +29,6 @@ jobs:
       owner: ${{ github.repository_owner }}
       repo: spark-rapids-jni
       branch: ${{ github.event.pull_request.base.ref }}
-      file_use_base: 'thirdparty/cudf thirdparty/cudf-pins'
+      file_use_base: 'thirdparty/cudf thirdparty/cudf-pins .gitmodules'
     secrets:
       token: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Since new branching model, 
we must also ignore `.gitmodules` file ub release/XX.YY to main automerge workflow