### PR TITLE
Add support for chunked output and ignore truncated files in profile converter

### DIFF
--- a/src/main/cpp/profiler/README.md
+++ b/src/main/cpp/profiler/README.md
@@ -71,10 +71,11 @@ The output will look similar to this:
 
 If the profile file is truncated (e.g. incomplete download or crash), you can use `--ignore-truncated` to convert as much data as possible.
 
-If the input is a truncated zstd file, first uncompress it with max effort:
+If the input is a truncated zstd file, first uncompress it with max effort. Because `zstd`
+returns a non-zero status when it encounters truncation, briefly disable `set -e` (or append
+`|| true`) so the partial output is still written:
 ```bash
-set +e
-zstd -dc broken.bin.zstd > salvaged.bin
+zstd -dc broken.bin.zstd > salvaged.bin || true
 ```
 Then process `salvaged.bin` with the converter.
 

--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -847,10 +847,13 @@ int convert_to_nvtxw(std::ifstream& in,
     try {
       fb_ptr = read_flatbuffer(in);
     } catch (std::runtime_error const& e) {
-      if (opts.ignore_truncated && std::string_view(e.what()) == "Unexpected EOF") {
-        truncated = true;
-        in.clear();
-        break;
+      if (opts.ignore_truncated) {
+        std::string_view err_msg(e.what());
+        if (err_msg.find("Unexpected EOF") != std::string_view::npos) {
+          truncated = true;
+          in.clear();
+          break;
+        }
       }
       throw;
     }


### PR DESCRIPTION
This PR enhances the `spark_rapids_profile_converter` tool to better handle large and potentially incomplete profile captures.

1. **Chunked NVTXW Export**:
   - Added `--nvtxw-chunk-records=N` to split large NVTXW (`.nsys-rep`) outputs into multiple files based on a record count.
   - When enabled, output files are automatically suffixed (e.g., `output-part000.nsys-rep`, `output-part001.nsys-rep`) to ensure consistent naming and easier handling.
   - Disabled by default; standard behavior (single output file) is preserved.

2. **Truncated Profile Recovery**:
   - Added `--ignore-truncated` flag to allow best-effort conversion of incomplete profile binaries (e.g., from crashed applications).
   - The tool now gracefully handles `Unexpected EOF` errors, finalizing the current NVTXW session and saving all valid data processed up to that point instead of failing hard.

3. **Progress Tracking**:
   - Added `-v`/`--verbose` flag to display progress logs (percentage and processed size) and confirm saved file segments.
   - This replaces the previous silent execution for long-running conversions on large files.

**Usage Examples:**
```bash
# Convert a potentially truncated profile into 100-record chunks with progress logging
./spark_rapids_profile_converter -v --ignore-truncated --nvtxw-chunk-records=100 -w -o profile.nsys-rep incomplete_capture.bin
```

Tested locally it works.