### PR TITLE
Use resource refs

### DIFF
--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -434,7 +434,7 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
                            null_mask.end(),
                            cuda::std::identity{},
                            cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource());
+                           rmm::mr::get_current_device_resource_ref());
 
   return std::make_unique<cudf::column>(
     cudf::data_type{cudf::type_to_id<T>()},
@@ -518,7 +518,7 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
                            null_mask.end() - 1,
                            cuda::std::identity{},
                            cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource());
+                           rmm::mr::get_current_device_resource_ref());
 
   return cudf::make_strings_column(
     num_rows,
@@ -554,7 +554,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::string_view>(data_profi
                                         cudf::out_of_bounds_policy::DONT_CHECK,
                                         cudf::detail::negative_index_policy::NOT_ALLOWED,
                                         cudf::get_default_stream(),
-                                        rmm::mr::get_current_device_resource());
+                                        rmm::mr::get_current_device_resource_ref());
   return std::move(str_table->release()[0]);
 }
 
@@ -642,7 +642,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
                                         valids.end(),
                                         cuda::std::identity{},
                                         cudf::get_default_stream(),
-                                        rmm::mr::get_current_device_resource());
+                                        rmm::mr::get_current_device_resource_ref());
         }
         return std::pair<rmm::device_buffer, cudf::size_type>{};
       }();
@@ -728,12 +728,13 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
                                                          rmm::device_buffer{},
                                                          0);
 
-    auto [null_mask, null_count] = cudf::detail::valid_if(valids.begin(),
-                                                          valids.end(),
-                                                          cuda::std::identity{},
-                                                          cudf::get_default_stream(),
-                                                          rmm::mr::get_current_device_resource());
-    list_column                  = cudf::make_lists_column(
+    auto [null_mask, null_count] =
+      cudf::detail::valid_if(valids.begin(),
+                             valids.end(),
+                             cuda::std::identity{},
+                             cudf::get_default_stream(),
+                             rmm::mr::get_current_device_resource_ref());
+    list_column = cudf::make_lists_column(
       num_rows,
       std::move(offsets_column),
       std::move(current_child_column),
@@ -852,7 +853,7 @@ std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
                                   thrust::make_counting_iterator<cudf::size_type>(size),
                                   bool_generator{seed, 1.0 - *null_probability},
                                   cudf::get_default_stream(),
-                                  rmm::mr::get_current_device_resource());
+                                  rmm::mr::get_current_device_resource_ref());
   }
 }
 

--- a/src/main/cpp/src/KudoGpuSerializerJni.cpp
+++ b/src/main/cpp/src/KudoGpuSerializerJni.cpp
@@ -34,7 +34,7 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_splitAndSerializeToDevic
     std::vector<cudf::size_type> splits = n_splits.to_vector<int>();
 
     auto [split_result, split_meta] = spark_rapids_jni::shuffle_split(
-      *table, splits, cudf::get_default_stream(), cudf::get_current_device_resource());
+      *table, splits, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
 
     // The following code is ugly. We need to return two device buffers to java, but
     // there is no good way to do this. For this we return three values for each buffer.
@@ -106,8 +106,11 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_assembleFromDeviceRawNat
     }
 
     // Get shuffle assemble result from shuffle_assemble
-    auto assemble_result = shuffle_assemble(
-      meta, partitions, offsets, cudf::get_default_stream(), cudf::get_current_device_resource());
+    auto assemble_result = shuffle_assemble(meta,
+                                            partitions,
+                                            offsets,
+                                            cudf::get_default_stream(),
+                                            cudf::get_current_device_resource_ref());
 
     // Create buffer metadata
     jlong buffer_size   = static_cast<jlong>(assemble_result.shared_buffer.size());

--- a/src/main/cpp/src/bloom_filter.hpp
+++ b/src/main/cpp/src/bloom_filter.hpp
@@ -48,7 +48,7 @@ std::unique_ptr<cudf::list_scalar> bloom_filter_create(
   int num_hashes,
   int bloom_filter_longs,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Inserts input values into a bloom filter.
@@ -79,7 +79,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
   cudf::column_view const& input,
   cudf::device_span<uint8_t const> bloom_filter,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Probe a bloom filter with an input column of int64_t values.
@@ -96,7 +96,7 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
   cudf::column_view const& input,
   cudf::list_scalar& bloom_filter,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Merge multiple bloom filters into a single output.
@@ -114,6 +114,6 @@ std::unique_ptr<cudf::column> bloom_filter_probe(
 std::unique_ptr<cudf::list_scalar> bloom_filter_merge(
   cudf::column_view const& bloom_filters,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/case_when.hpp
+++ b/src/main/cpp/src/case_when.hpp
@@ -48,6 +48,6 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> select_first_true_index(
   cudf::table_view const& when_bool_columns,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -78,7 +78,7 @@ std::unique_ptr<cudf::column> string_to_integer(
   bool ansi_mode,
   bool strip,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Convert a string column into an decimal column.
@@ -100,7 +100,7 @@ std::unique_ptr<cudf::column> string_to_decimal(
   bool ansi_mode,
   bool strip,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Convert a string column into an float column.
@@ -118,28 +118,28 @@ std::unique_ptr<cudf::column> string_to_float(
   cudf::strings_column_view const& string_col,
   bool ansi_mode,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> format_float(
   cudf::column_view const& input,
   int const digits,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> long_to_binary_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Parse a timestamp string column into an intermediate struct column.

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -973,7 +973,7 @@ std::unique_ptr<cudf::table> multiply_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1008,7 +1008,7 @@ std::unique_ptr<cudf::table> divide_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1042,7 +1042,7 @@ std::unique_ptr<cudf::table> integer_divide_decimal128(cudf::column_view const& 
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1075,7 +1075,7 @@ std::unique_ptr<cudf::table> remainder_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1108,7 +1108,7 @@ std::unique_ptr<cudf::table> add_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1141,7 +1141,7 @@ std::unique_ptr<cudf::table> sub_decimal128(cudf::column_view const& a,
   auto const num_rows = a.size();
   CUDF_EXPECTS(num_rows == b.size(), "inputs have mismatched row counts");
   auto [result_null_mask, result_null_count] = cudf::detail::bitmask_and(
-    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource());
+    cudf::table_view{{a, b}}, stream, rmm::mr::get_current_device_resource_ref());
   std::vector<std::unique_ptr<cudf::column>> columns;
   // copy the null mask here, as it will be used again later
   columns.push_back(cudf::make_fixed_width_column(cudf::data_type{cudf::type_id::BOOL8},
@@ -1391,7 +1391,7 @@ std::pair<std::unique_ptr<cudf::column>, cudf::size_type> floating_point_to_deci
     output_type, input.size(), cudf::mask_state::UNALLOCATED, stream, mr);
 
   auto const decimal_places = -output_type.scale();
-  auto const default_mr     = rmm::mr::get_current_device_resource();
+  auto const default_mr     = rmm::mr::get_current_device_resource_ref();
 
   rmm::device_uvector<int8_t> validity(input.size(), stream, default_mr);
   rmm::device_scalar<cudf::size_type> failure_row_id(-1, stream, default_mr);

--- a/src/main/cpp/src/decimal_utils.hpp
+++ b/src/main/cpp/src/decimal_utils.hpp
@@ -79,6 +79,6 @@ std::pair<std::unique_ptr<cudf::column>, cudf::size_type> floating_point_to_deci
   cudf::data_type output_type,
   int32_t precision,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace cudf::jni

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -76,7 +76,7 @@ std::unique_ptr<cudf::column> make_empty_map(rmm::cuda_stream_view stream,
 std::tuple<rmm::device_buffer, char, std::unique_ptr<cudf::column>> unify_json_strings(
   cudf::strings_column_view const& input, rmm::cuda_stream_view stream)
 {
-  auto const default_mr = cudf::get_current_device_resource();
+  auto const default_mr = cudf::get_current_device_resource_ref();
   auto [concatenated_buff, delimiter, should_be_nullified] =
     concat_json(input, /*nullify_invalid_rows*/ true, stream, default_mr);
 
@@ -737,7 +737,7 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(cudf::strings_column_view con
       .unquoted_control_chars(allow_unquoted_control)
       .build(),
     stream,
-    cudf::get_current_device_resource());
+    cudf::get_current_device_resource_ref());
 
 #ifdef DEBUG_FROM_JSON
   print_debug(tokens, "Tokens", ", ", stream);

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -811,7 +811,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(cudf::strings_column_view con
                                                    rmm::device_async_resource_ref mr)
 {
   auto const [concat_input, delimiter, should_be_nullified] =
-    concat_json(input, false, stream, cudf::get_current_device_resource());
+    concat_json(input, false, stream, cudf::get_current_device_resource_ref());
   auto const [schema, schema_with_precision] =
     generate_struct_schema(col_names, num_children, types, scales, precisions);
 

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -951,7 +951,7 @@ construct_path_commands(
   d_path_commands.reserve(h_path_commands->size());
   for (auto const& path_commands : *h_path_commands) {
     d_path_commands.emplace_back(cudf::detail::make_device_uvector_async(
-      path_commands, stream, rmm::mr::get_current_device_resource()));
+      path_commands, stream, rmm::mr::get_current_device_resource_ref()));
   }
 
   return {std::move(d_path_commands),
@@ -1051,7 +1051,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
                                                        d_error_check.data() + idx});
   }
   auto d_path_data = cudf::detail::make_device_uvector_async(
-    h_path_data, stream, rmm::mr::get_current_device_resource());
+    h_path_data, stream, rmm::mr::get_current_device_resource_ref());
   thrust::uninitialized_fill(
     rmm::exec_policy_nosync(stream), d_error_check.begin(), d_error_check.end(), 0);
 
@@ -1134,7 +1134,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_batch(
 
   // Push data to the GPU and launch the kernel again.
   d_path_data = cudf::detail::make_device_uvector_async(
-    h_path_data, stream, rmm::mr::get_current_device_resource());
+    h_path_data, stream, rmm::mr::get_current_device_resource_ref());
   thrust::uninitialized_fill(
     rmm::exec_policy_nosync(stream), d_error_check.begin(), d_error_check.end(), 0);
   kernel_launcher::exec(input, d_path_data, d_max_path_depth_exceeded, stream);

--- a/src/main/cpp/src/get_json_object.hpp
+++ b/src/main/cpp/src/get_json_object.hpp
@@ -45,7 +45,7 @@ std::unique_ptr<cudf::column> get_json_object(
   cudf::strings_column_view const& input,
   std::vector<std::tuple<path_instruction_type, std::string, int32_t>> const& instructions,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Extract multiple JSON objects from a JSON string based on the specified JSON paths.
@@ -67,6 +67,6 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   int64_t memory_budget_bytes,
   int32_t parallel_override,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hash.hpp
+++ b/src/main/cpp/src/hash.hpp
@@ -41,7 +41,7 @@ std::unique_ptr<cudf::column> murmur_hash3_32(
   cudf::table_view const& input,
   uint32_t seed                     = 0,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Computes the xxhash64 hash value of each row in the input set of columns.
@@ -57,7 +57,7 @@ std::unique_ptr<cudf::column> xxhash64(
   cudf::table_view const& input,
   int64_t seed                      = DEFAULT_XXHASH64_SEED,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Computes the Hive hash value of each row in the input set of columns.
@@ -71,6 +71,6 @@ std::unique_ptr<cudf::column> xxhash64(
 std::unique_ptr<cudf::column> hive_hash(
   cudf::table_view const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -191,8 +191,8 @@ struct percentile_dispatcher {
     // We may always have nulls in the output due to either:
     // - Having nulls in the input, and/or,
     // - Having empty histograms.
-    auto out_validities =
-      rmm::device_uvector<int8_t>(num_histograms, stream, rmm::mr::get_current_device_resource());
+    auto out_validities = rmm::device_uvector<int8_t>(
+      num_histograms, stream, rmm::mr::get_current_device_resource_ref());
 
     auto const fill_percentile = [&](auto const sorted_validity_it) {
       auto const sorted_input_it =
@@ -307,7 +307,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
     }
   }
 
-  auto const default_mr = rmm::mr::get_current_device_resource();
+  auto const default_mr = rmm::mr::get_current_device_resource_ref();
 
   // We only check if there is any row in frequencies that are negative (invalid) or zero.
   auto check_invalid_and_zero =
@@ -439,7 +439,7 @@ std::unique_ptr<cudf::column> percentile_from_histogram(cudf::column_view const&
   auto const data_col       = cudf::structs_column_view{histograms}.get_sliced_child(0);
   auto const counts_col     = cudf::structs_column_view{histograms}.get_sliced_child(1);
 
-  auto const default_mr    = rmm::mr::get_current_device_resource();
+  auto const default_mr    = rmm::mr::get_current_device_resource_ref();
   auto const d_data        = cudf::column_device_view::create(data_col, stream);
   auto const d_percentages = cudf::detail::make_device_uvector(percentages, stream, default_mr);
 

--- a/src/main/cpp/src/histogram.hpp
+++ b/src/main/cpp/src/histogram.hpp
@@ -52,7 +52,7 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(
   cudf::column_view const& frequencies,
   bool output_as_lists,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Compute percentiles from the given histograms and percentage values.
@@ -72,6 +72,6 @@ std::unique_ptr<cudf::column> percentile_from_histogram(
   std::vector<double> const& percentage,
   bool output_as_lists,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -82,7 +82,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
   }
 
   auto const d_input_ptr = cudf::column_device_view::create(input.parent(), stream);
-  auto const default_mr  = rmm::mr::get_current_device_resource();
+  auto const default_mr  = rmm::mr::get_current_device_resource_ref();
 
   // Check if the input rows are null, empty (containing only whitespaces), and invalid JSON.
   // This will be used for masking out the null/empty/invalid input rows when doing string

--- a/src/main/cpp/src/json_utils.hpp
+++ b/src/main/cpp/src/json_utils.hpp
@@ -37,7 +37,7 @@ std::unique_ptr<cudf::column> from_json_to_raw_map(
   bool allow_nonnumeric_numbers,
   bool allow_unquoted_control,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Parse JSON strings into a struct column followed by a given data schema.
@@ -57,7 +57,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(
   bool allow_unquoted_control,
   bool is_us_locale,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert from a strings column to a column with the desired type given by a data schema.
@@ -73,7 +73,7 @@ std::unique_ptr<cudf::column> convert_from_strings(
   bool allow_nonnumeric_numbers,
   bool is_us_locale,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Remove quotes from each string in the given strings column.
@@ -85,7 +85,7 @@ std::unique_ptr<cudf::column> remove_quotes(
   cudf::strings_column_view const& input,
   bool nullify_if_not_quoted,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Concatenate the JSON objects given by a strings column into one single character buffer,
@@ -111,6 +111,6 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
   cudf::strings_column_view const& input,
   bool nullify_invalid_rows         = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/parse_uri.hpp
+++ b/src/main/cpp/src/parse_uri.hpp
@@ -39,7 +39,7 @@ std::unique_ptr<cudf::column> parse_uri_to_protocol(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Parse host and copy from the input string column to the output string column.
@@ -53,7 +53,7 @@ std::unique_ptr<cudf::column> parse_uri_to_host(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Parse query and copy from the input string column to the output string column.
@@ -67,7 +67,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Parse query and copy from the input string column to the output string column.
@@ -83,7 +83,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   std::string const& query_match,
   bool ansi_mode                    = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Parse query and copy from the input string column to the output string column.
@@ -99,7 +99,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(
   cudf::strings_column_view const& query_match,
   bool ansi_mode                    = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 /**
  * @brief Parse path and copy from the input string column to the output string column.
@@ -113,6 +113,6 @@ std::unique_ptr<cudf::column> parse_uri_to_path(
   cudf::strings_column_view const& input,
   bool ansi_mode                    = false,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/regex_rewrite_utils.hpp
+++ b/src/main/cpp/src/regex_rewrite_utils.hpp
@@ -41,5 +41,5 @@ std::unique_ptr<cudf::column> literal_range_pattern(
   int const start,
   int const end,
   rmm::cuda_stream_view stream      = rmm::cuda_stream_default,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.hpp
+++ b/src/main/cpp/src/row_conversion.hpp
@@ -31,24 +31,24 @@ std::vector<std::unique_ptr<cudf::column>> convert_to_rows_fixed_width_optimized
   cudf::table_view const& tbl,
   // TODO need something for validity
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::vector<std::unique_ptr<cudf::column>> convert_to_rows(
   cudf::table_view const& tbl,
   // TODO need something for validity
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::table> convert_from_rows_fixed_width_optimized(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::table> convert_from_rows(
   cudf::lists_column_view const& input,
   std::vector<cudf::data_type> const& schema,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/shuffle_split.cu
+++ b/src/main/cpp/src/shuffle_split.cu
@@ -860,7 +860,7 @@ std::pair<shuffle_split_result, shuffle_split_metadata> shuffle_split(
   size_t const offset_stack_size = offset_stack_partition_size * num_partitions * sizeof(size_type);
   rmm::device_buffer d_indices_and_source_info(indices_size + src_buf_info_size + offset_stack_size,
                                                stream,
-                                               rmm::mr::get_current_device_resource());
+                                               rmm::mr::get_current_device_resource_ref());
   auto* d_indices              = reinterpret_cast<size_type*>(d_indices_and_source_info.data());
   src_buf_info* d_src_buf_info = reinterpret_cast<src_buf_info*>(
     reinterpret_cast<uint8_t*>(d_indices_and_source_info.data()) + indices_size);

--- a/src/main/cpp/src/substring_index.cu
+++ b/src/main/cpp/src/substring_index.cu
@@ -124,11 +124,11 @@ std::unique_ptr<column> substring_index(strings_column_view const& strings,
   auto start_chars_pos_vec = make_column_from_scalar(numeric_scalar<size_type>(0, true, stream),
                                                      strings_count,
                                                      stream,
-                                                     rmm::mr::get_current_device_resource());
+                                                     rmm::mr::get_current_device_resource_ref());
   auto stop_chars_pos_vec  = make_column_from_scalar(numeric_scalar<size_type>(0, true, stream),
                                                     strings_count,
                                                     stream,
-                                                    rmm::mr::get_current_device_resource());
+                                                    rmm::mr::get_current_device_resource_ref());
 
   auto start_char_pos = start_chars_pos_vec->mutable_view().data<size_type>();
   auto end_char_pos   = stop_chars_pos_vec->mutable_view().data<size_type>();

--- a/src/main/cpp/src/substring_index.hpp
+++ b/src/main/cpp/src/substring_index.hpp
@@ -35,6 +35,6 @@ std::unique_ptr<cudf::column> substring_index(
   cudf::strings_column_view const& strings,
   cudf::string_scalar const& delimiter,
   cudf::size_type count,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -45,7 +45,7 @@ std::unique_ptr<cudf::column> convert_timestamp_to_utc(
   cudf::table_view const& timezone_info,
   cudf::size_type const tz_index,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert input column timestamps in UTC to specified timezone
@@ -67,7 +67,7 @@ std::unique_ptr<cudf::column> convert_utc_timestamp_to_timezone(
   cudf::table_view const& timezone_info,
   cudf::size_type const tz_index,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert timestamps in multiple timezones to UTC.
@@ -98,7 +98,7 @@ std::unique_ptr<cudf::column> convert_timestamp_to_utc(
   cudf::table_view const& timezone_info,
   cudf::column_view const tz_indices,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert between ORC writer timezone and reader timezone.

--- a/src/main/cpp/src/utilities.cu
+++ b/src/main/cpp/src/utilities.cu
@@ -55,7 +55,7 @@ std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::transform(
     input.begin(), input.end(), h_input.begin(), [](auto mask) { return mask.data(); });
   auto d_input = cudf::detail::make_device_uvector_async(
-    h_input, stream, rmm::mr::get_current_device_resource());
+    h_input, stream, rmm::mr::get_current_device_resource_ref());
 
   std::unique_ptr<rmm::device_buffer> out =
     std::make_unique<rmm::device_buffer>(mask_size * sizeof(cudf::bitmask_type), stream, mr);

--- a/src/main/cpp/src/utilities.hpp
+++ b/src/main/cpp/src/utilities.hpp
@@ -48,6 +48,6 @@ bool is_basic_spark_numeric(cudf::data_type type);
 std::unique_ptr<rmm::device_buffer> bitmask_bitwise_or(
   std::vector<cudf::device_span<cudf::bitmask_type const>> const& input,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/zorder.hpp
+++ b/src/main/cpp/src/zorder.hpp
@@ -29,12 +29,12 @@ namespace spark_rapids_jni {
 std::unique_ptr<cudf::column> interleave_bits(
   cudf::table_view const& tbl,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> hilbert_index(
   int32_t const num_bits,
   cudf::table_view const& tbl,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -118,8 +118,12 @@ TEST_F(TimeZoneTest, ConvertToUTCSeconds)
                                     -28800L,
                                     1699537367L,
                                     568008000L};
-  auto const actual   = spark_rapids_jni::convert_timestamp_to_utc(
-    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+  auto const actual =
+    spark_rapids_jni::convert_timestamp_to_utc(ts_col,
+                                               *transitions,
+                                               1,
+                                               cudf::get_default_stream(),
+                                               rmm::mr::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -147,8 +151,12 @@ TEST_F(TimeZoneTest, ConvertToUTCMilliseconds)
                                    -28800000L,
                                    1699542834312L,
                                    568008000000L};
-  auto const actual   = spark_rapids_jni::convert_timestamp_to_utc(
-    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+  auto const actual =
+    spark_rapids_jni::convert_timestamp_to_utc(ts_col,
+                                               *transitions,
+                                               1,
+                                               cudf::get_default_stream(),
+                                               rmm::mr::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -176,8 +184,12 @@ TEST_F(TimeZoneTest, ConvertToUTCMicroseconds)
                                    -28800000000L,
                                    1699542834312000L,
                                    568008000000000L};
-  auto const actual   = spark_rapids_jni::convert_timestamp_to_utc(
-    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+  auto const actual =
+    spark_rapids_jni::convert_timestamp_to_utc(ts_col,
+                                               *transitions,
+                                               1,
+                                               cudf::get_default_stream(),
+                                               rmm::mr::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -205,8 +217,12 @@ TEST_F(TimeZoneTest, ConvertFromUTCSeconds)
     1699566167L,
     568036800L,
   };
-  auto const actual = spark_rapids_jni::convert_utc_timestamp_to_timezone(
-    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+  auto const actual =
+    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
+                                                        *transitions,
+                                                        1,
+                                                        cudf::get_default_stream(),
+                                                        rmm::mr::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -234,8 +250,12 @@ TEST_F(TimeZoneTest, ConvertFromUTCMilliseconds)
     1699571634312L,
     568036800000L,
   };
-  auto const actual = spark_rapids_jni::convert_utc_timestamp_to_timezone(
-    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+  auto const actual =
+    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
+                                                        *transitions,
+                                                        1,
+                                                        cudf::get_default_stream(),
+                                                        rmm::mr::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
@@ -263,8 +283,12 @@ TEST_F(TimeZoneTest, ConvertFromUTCMicroseconds)
     1699571634312000L,
     568036800000000L,
   };
-  auto const actual = spark_rapids_jni::convert_utc_timestamp_to_timezone(
-    ts_col, *transitions, 1, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+  auto const actual =
+    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
+                                                        *transitions,
+                                                        1,
+                                                        cudf::get_default_stream(),
+                                                        rmm::mr::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }


### PR DESCRIPTION
`cudf::get_current_device_resource()` is deprecated and will be removed in https://github.com/rapidsai/cudf/pull/20688. The replacement is `cudf::get_current_device_resource_ref()`.

Similarly, `rmm::mr::get_current_device_resource()` will be removed soon in favor of `rmm::mr::get_current_device_resource_ref()`.

This PR migrates spark-rapids-jni for both of these changes.
