### PR TITLE
[submodule-sync] bot-submodule-sync-release/25.12 to release/25.12 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -69,7 +69,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "143bc118a43ea24fd787224c644f54b8eebc4ee0",
+      "git_tag" : "5e42b11c3339471c0fcb6ac69c8c53b6c933ac4d",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
       "version" : "25.12"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: 096edf27c14655df4276bccfa4d9e4dab39b2ecc, cudf commit SHA: https://github.com/rapidsai/cudf/commit/181bd7b85c614e9c8f755a62f07f4b9c9334b615

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.