### PR TITLE
Fix various leaks in the tests

### DIFF
--- a/src/test/java/com/nvidia/spark/rapids/jni/BloomFilterTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/BloomFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,16 +113,21 @@ public class BloomFilterTest {
       BloomFilter.put(bloomFilterA, colA);
       BloomFilter.put(bloomFilterB, colB);
       BloomFilter.put(bloomFilterC, colC);
-      
-      ColumnVector premerge = ColumnVector.concatenate(ColumnVector.fromScalar(bloomFilterA, 1),
-                                                       ColumnVector.fromScalar(bloomFilterB, 1),
-                                                       ColumnVector.fromScalar(bloomFilterC, 1));
 
-      try(ColumnVector probe = ColumnVector.fromLongs(-9, 200, 300, 6000, -2546, 99, 65535, 0, -100, -200, -300, -400);
-          ColumnVector expected = ColumnVector.fromBooleans(true, true, true, false, false, true, false, false, true, true, true, true);
-          Scalar merged = BloomFilter.merge(premerge);
-          ColumnVector result = BloomFilter.probe(merged, probe)){
-          AssertUtils.assertColumnsAreEqual(expected, result);
+      try (ColumnVector bloomA = ColumnVector.fromScalar(bloomFilterA, 1);
+           ColumnVector bloomB = ColumnVector.fromScalar(bloomFilterB, 1);
+           ColumnVector bloomC = ColumnVector.fromScalar(bloomFilterC, 1)) {
+
+        try (ColumnVector premerge = ColumnVector.concatenate(bloomA, bloomB, bloomC)) {
+          try (ColumnVector probe = ColumnVector.fromLongs(-9, 200, 300, 6000, -2546, 99,
+                  65535, 0, -100, -200, -300, -400);
+               ColumnVector expected = ColumnVector.fromBooleans(true, true, true,
+                  false, false, true, false, false, true, true, true, true);
+              Scalar merged = BloomFilter.merge(premerge);
+              ColumnVector result = BloomFilter.probe(merged, probe)) {
+            AssertUtils.assertColumnsAreEqual(expected, result);
+          }
+        }
       }
     }
   }
@@ -137,9 +142,8 @@ public class BloomFilterTest {
 
       BloomFilter.put(bloomFilter, colA);
 
-      ColumnVector premerge = ColumnVector.fromScalar(bloomFilter, 1);
-
-      try(ColumnVector probe = ColumnVector.fromLongs(-9, 200, 300, 6000, -2546, 99, 65535, 0, -100, -200, -300, -400);
+      try(ColumnVector premerge = ColumnVector.fromScalar(bloomFilter, 1);
+          ColumnVector probe = ColumnVector.fromLongs(-9, 200, 300, 6000, -2546, 99, 65535, 0, -100, -200, -300, -400);
           ColumnVector expected = ColumnVector.fromBooleans(true, false, false, false, false, true, false, false, false, false, false, false);
           Scalar merged = BloomFilter.merge(premerge);
           ColumnVector result = BloomFilter.probe(merged, probe)){
@@ -165,9 +169,10 @@ public class BloomFilterTest {
       try (Scalar bloomFilterA = BloomFilter.create(3, 1024);
            Scalar bloomFilterB = BloomFilter.create(4, 1024);
            Scalar bloomFilterC = BloomFilter.create(4, 1024);
-           ColumnVector premerge = ColumnVector.concatenate(ColumnVector.fromScalar(bloomFilterA, 1),
-                                                            ColumnVector.fromScalar(bloomFilterB, 1),
-                                                            ColumnVector.fromScalar(bloomFilterC, 1));
+           ColumnVector bloomA = ColumnVector.fromScalar(bloomFilterA, 1);
+           ColumnVector bloomB = ColumnVector.fromScalar(bloomFilterB, 1);
+           ColumnVector bloomC = ColumnVector.fromScalar(bloomFilterC, 1);
+           ColumnVector premerge = ColumnVector.concatenate(bloomA, bloomB, bloomC);
            Scalar merged = BloomFilter.merge(premerge)){}
     });
 
@@ -176,9 +181,10 @@ public class BloomFilterTest {
       try (Scalar bloomFilterA = BloomFilter.create(3, 1024);
            Scalar bloomFilterB = BloomFilter.create(3, 1024);
            Scalar bloomFilterC = BloomFilter.create(3, 2048);
-           ColumnVector premerge = ColumnVector.concatenate(ColumnVector.fromScalar(bloomFilterA, 1),
-                                                            ColumnVector.fromScalar(bloomFilterB, 1),
-                                                            ColumnVector.fromScalar(bloomFilterC, 1));
+           ColumnVector bloomA = ColumnVector.fromScalar(bloomFilterA, 1);
+           ColumnVector bloomB = ColumnVector.fromScalar(bloomFilterB, 1);
+           ColumnVector bloomC = ColumnVector.fromScalar(bloomFilterC, 1);
+           ColumnVector premerge = ColumnVector.concatenate(bloomA, bloomB, bloomC);
            Scalar merged = BloomFilter.merge(premerge)){}
     });
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -436,7 +436,9 @@ public class CastStringsTest {
     data.add(new HostColumnVector.StructData("CTT", 0, false));
     data.add(new HostColumnVector.StructData("JST", 1, false));
     data.add(new HostColumnVector.StructData("PST", 2, true));
-    return HostColumnVector.fromStructs(type, data).copyToDevice();
+    try(HostColumnVector hcv = HostColumnVector.fromStructs(type, data)) {
+      return hcv.copyToDevice();
+    }
   }
 
   private static final Version SPARK_320_VERSION =

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuSubstringIndexUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuSubstringIndexUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,23 +53,25 @@ public class GpuSubstringIndexUtilsTest {
             tb2.column("大千世界大千世界");
             tb2.column("www||apache||org");
 
-            Scalar dotScalar = Scalar.fromString(".");
-            Scalar cnChar = Scalar.fromString("千");
-            Scalar verticalBar = Scalar.fromString("||");
-            Scalar[] delimiterArray = new Scalar[]{dotScalar, dotScalar, dotScalar, dotScalar,dotScalar, dotScalar, dotScalar, dotScalar, cnChar, verticalBar};
-            int[] countArray = new int[]{3, 2, 1, 0, -1, -2, -3, -2, 2, 2};
-            List<ColumnVector> result = new ArrayList<>();
-            try (Table origTable = tb2.build()){
-                for(int i = 0; i < origTable.getNumberOfColumns(); i++){
-                    ColumnVector string_col = origTable.getColumn(i);
-                    result.add(GpuSubstringIndexUtils.substringIndex(string_col, delimiterArray[i], countArray[i]));
+            try (Scalar dotScalar = Scalar.fromString(".");
+                 Scalar cnChar = Scalar.fromString("千");
+                 Scalar verticalBar = Scalar.fromString("||")) {
+                Scalar[] delimiterArray = new Scalar[] { dotScalar, dotScalar, dotScalar, dotScalar, dotScalar,
+                        dotScalar, dotScalar, dotScalar, cnChar, verticalBar };
+                int[] countArray = new int[] { 3, 2, 1, 0, -1, -2, -3, -2, 2, 2 };
+                List<ColumnVector> result = new ArrayList<>();
+                try (Table origTable = tb2.build()) {
+                    for (int i = 0; i < origTable.getNumberOfColumns(); i++) {
+                        ColumnVector string_col = origTable.getColumn(i);
+                        result.add(GpuSubstringIndexUtils.substringIndex(string_col, delimiterArray[i], countArray[i]));
+                    }
+                    try (Table result_tbl = new Table(
+                            result.toArray(new ColumnVector[result.size()]))) {
+                        AssertUtils.assertTablesAreEqual(expected, result_tbl);
+                    }
+                } finally {
+                    result.forEach(ColumnVector::close);
                 }
-                try (Table result_tbl = new Table(
-                        result.toArray(new ColumnVector[result.size()]))){
-                    AssertUtils.assertTablesAreEqual(expected, result_tbl);
-                }
-            }finally {
-                result.forEach(ColumnVector::close);
             }
         }
     }

--- a/src/test/java/com/nvidia/spark/rapids/jni/HostTableTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/HostTableTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024, NVIDIA CORPORATION.
+ *  Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -33,8 +33,9 @@ public class HostTableTest {
   public void testRoundTripSync() {
     try (Table expected = buildTable()) {
       try (HostTable ht = HostTable.fromTable(expected, Cuda.DEFAULT_STREAM)) {
-        Table actual = ht.toTable(Cuda.DEFAULT_STREAM);
-        AssertUtils.assertTablesAreEqual(expected, actual);
+        try (Table actual = ht.toTable(Cuda.DEFAULT_STREAM)) {
+          AssertUtils.assertTablesAreEqual(expected, actual);
+        }
       }
     }
   }
@@ -43,8 +44,9 @@ public class HostTableTest {
   public void testRoundTripSyncDefault() {
     try (Table expected = buildTable()) {
       try (HostTable ht = HostTable.fromTable(expected)) {
-        Table actual = ht.toTable();
-        AssertUtils.assertTablesAreEqual(expected, actual);
+        try (Table actual = ht.toTable()) {
+          AssertUtils.assertTablesAreEqual(expected, actual);
+        }
       }
     }
   }
@@ -62,8 +64,9 @@ public class HostTableTest {
   private void testRoundTripAsync(Table expected) {
     try (Table t = expected) {
       try (HostTable ht = HostTable.fromTableAsync(t, Cuda.DEFAULT_STREAM)) {
-        Table actual = ht.toTableAsync(Cuda.DEFAULT_STREAM);
-        AssertUtils.assertTablesAreEqual(expected, actual);
+        try (Table actual = ht.toTableAsync(Cuda.DEFAULT_STREAM)) {
+          AssertUtils.assertTablesAreEqual(expected, actual);
+        }
       }
     }
   }


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids-jni/issues/3866

We have leaks in the unit tests that appear to be causing issues sometimes, as documented in https://github.com/NVIDIA/spark-rapids-jni/issues/3866. I spent some time going after them and found a bunch in jni and cuDF. This PR takes care of the jni ones.