### PR TITLE
Add a parameter to enable debug for RmmEventHandler

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/RmmSpark.java
@@ -52,7 +52,7 @@ public class RmmSpark {
    * the future it is likely to change.
    */
   public static void setEventHandler(RmmEventHandler handler) throws RmmException {
-    setEventHandler(handler, null);
+    setEventHandler(handler, null, false);
   }
 
   /**
@@ -65,6 +65,22 @@ public class RmmSpark {
    *                    is treated as a file.
    */
   public static void setEventHandler(RmmEventHandler handler, String logLocation) throws RmmException {
+    setEventHandler(handler, logLocation, false);
+  }
+
+  /**
+   * Set the event handler in a way that Spark wants it. For now this is the same as RMM, but in
+   * the future it is likely to change.
+   * @param handler the handler to set
+   * @param logLocation the location where you want spark state transitions. Alloc and free logging
+   *                    is handled separately when setting up RMM. "stderr" or "stdout" are treated
+   *                    as `std::cerr` and `std::cout` respectively in native code. Anything else
+   *                    is treated as a file.
+   * @param enableDebug if true, enable debug callbacks (onAllocated, onDeallocated) in the handler.
+   *                    Note: enabling debug mode may impact performance.
+   */
+  public static void setEventHandler(RmmEventHandler handler, String logLocation,
+      boolean enableDebug) throws RmmException {
     // synchronize with RMM not RmmSpark to stay in sync with Rmm itself.
     Rmm.writeLock.lock();
     try {
@@ -83,7 +99,7 @@ public class RmmSpark {
         throw new RuntimeException("A tracker must be set for the event handler to work");
       }
       RmmEventHandlerResourceAdaptor<RmmDeviceMemoryResource> eventHandler =
-          new RmmEventHandlerResourceAdaptor<>(deviceResource, tracker, handler, false);
+          new RmmEventHandlerResourceAdaptor<>(deviceResource, tracker, handler, enableDebug);
       SparkResourceAdaptor.initializeLogger(logLocation);
       sra = new SparkResourceAdaptor(eventHandler);
       boolean success = false;


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/13672

For debugging, I'd like to expose an `enableDebug` parameter in `RmmSpark.setEventHandler` to check if every memory allocation is covered withRetry in spark-rapids. See https://github.com/NVIDIA/spark-rapids/pull/13995

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
