### PR TITLE
Change references to `cudf::detail::copy_if_safe`

### DIFF
--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -562,7 +562,7 @@ std::unique_ptr<cudf::column> compute_list_offsets(
 #endif
 
   auto list_offsets   = rmm::device_uvector<cudf::size_type>(n_lists + 1, stream, mr);
-  auto const copy_end = cudf::detail::copy_if_safe(
+  auto const copy_end = cudf::detail::copy_if(
     node_child_counts.begin(),
     node_child_counts.end(),
     list_offsets.begin(),
@@ -636,11 +636,11 @@ std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
 
   auto const node_id_it = thrust::counting_iterator<NodeIndexT>(0);
   auto const invalid_copy_end =
-    cudf::detail::copy_if_safe(node_id_it,
-                               node_id_it + node_token_ids.size(),
-                               invalid_indices.begin(),
-                               is_invalid_struct_begin{tokens, node_token_ids, token_positions},
-                               stream);
+    cudf::detail::copy_if(node_id_it,
+                          node_id_it + node_token_ids.size(),
+                          invalid_indices.begin(),
+                          is_invalid_struct_begin{tokens, node_token_ids, token_positions},
+                          stream);
   auto const num_invalid = cuda::std::distance(invalid_indices.begin(), invalid_copy_end);
 #ifdef DEBUG_FROM_JSON
   print_debug(invalid_indices,
@@ -656,11 +656,11 @@ std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
     // We must have such list having size equal to the number of original input JSON strings.
     rmm::device_uvector<NodeIndexT> line_begin_indices(num_nodes, stream);
     auto const line_begin_copy_end =
-      cudf::detail::copy_if_safe(node_id_it,
-                                 node_id_it + node_token_ids.size(),
-                                 line_begin_indices.begin(),
-                                 is_line_begin{tokens, node_token_ids, parent_node_ids},
-                                 stream);
+      cudf::detail::copy_if(node_id_it,
+                            node_id_it + node_token_ids.size(),
+                            line_begin_indices.begin(),
+                            is_line_begin{tokens, node_token_ids, parent_node_ids},
+                            stream);
     auto const num_line_begin =
       cuda::std::distance(line_begin_indices.begin(), line_begin_copy_end);
     CUDF_EXPECTS(num_line_begin == num_rows, "Incorrect count of JSON objects.");


### PR DESCRIPTION
Fixes #4078.

This commit switches out calls to `cudf::detail::copy_if_safe` for `cudf::detail::copy_if` (which is implemented via CUB).

`copy_if_safe` is now deprecated in CUDF, causing build warnings such as follows:
```
[INFO]      [exec]   658 |     auto const line_begin_copy_end =
[INFO]      [exec]       |                                  ~~~
^
[INFO]      [exec]
/home/mithunr/workspace/dev/spark-rapids-jni/3/target/libcudf-install/include/cudf/detail/utilities/algorithm.cuh:85:68:
not
e: declared here
[INFO]      [exec]    85 | [[deprecated("Use cudf::detail::copy_if
instead")]] OutputIterator copy_if_safe(
```

This commit fixes the warning, and protects against future breaks when the deprecated function is removed.

Note that it's the 5-argument version of `copy_if_safe` that is deprecated.  The 6-argument version is not.  References to that function should be safe to leave unchanged.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please create a draft pull rqeuest
   or prefix the pull request summary with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it then remove any `[WIP]` prefix in the summary and
   restore it from draft status if necessary.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
