### PR TITLE
Add comment for artifactory migration notice for pre-merge CI

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -69,10 +69,14 @@ pipeline {
     environment {
         JENKINS_ROOT = 'jenkins'
         GITHUB_TOKEN = credentials("github-token")
+
+        // v1 instance for maven mirror only, will be migrated to v2 soon
         ART_URL = "https://${common.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
         MVN_MIRROR = '-s ci/settings.xml -P mirror-apache-to-urm'
+        // v2 instance for CI images usage
         ART_CREDS = credentials("urm_creds_v2")
         ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME_V2}"
+
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         PVC_MOUNT_PATH = "/pvc"


### PR DESCRIPTION
Make clear comments for ENVs used during the migration period.

1. Add comments for different ART ENVs used in pre-merge
2. Update Dockerfile to trigger the pre-merge docker build validation