### PR TITLE
clangd workaround:  Explicit types instead of CTAD

### DIFF
--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -689,7 +689,7 @@ std::pair<rmm::device_buffer, cudf::size_type> create_null_mask(
 
   auto const valid_it          = should_be_nullified->view().begin<bool>();
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    valid_it, valid_it + should_be_nullified->size(), thrust::logical_not{}, stream, mr);
+    valid_it, valid_it + should_be_nullified->size(), thrust::logical_not<bool>{}, stream, mr);
   return {null_count > 0 ? std::move(null_mask) : rmm::device_buffer{0, stream, mr}, null_count};
 }
 

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -864,7 +864,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(cudf::strings_column_view con
 
   auto const valid_it          = should_be_nullified->view().begin<bool>();
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    valid_it, valid_it + should_be_nullified->size(), thrust::logical_not{}, stream, mr);
+    valid_it, valid_it + should_be_nullified->size(), thrust::logical_not<bool>{}, stream, mr);
 
   // Do not use `cudf::make_structs_column` since we do not need to call `superimpose_nulls`
   // on the children columns.

--- a/src/main/cpp/src/shuffle_split.cu
+++ b/src/main/cpp/src/shuffle_split.cu
@@ -1039,7 +1039,7 @@ std::pair<shuffle_split_result, shuffle_split_metadata> shuffle_split(
                         buf_sizes_by_type,
                         thrust::make_discard_iterator(),
                         d_partition_sizes_unpadded,
-                        thrust::equal_to{},  // key equality check
+                        thrust::equal_to<size_t>{},  // key equality check
                         buf_size_reduce);
 
   // - compute: padded section sizes


### PR DESCRIPTION
This is a workaround for a crash one sees in clangd when loading the `spark-rapids-jni` project in VSCode / Cursor.

It looks like even the latest version of the
`llvm-vs-code-extensions.vscode-clangd` extension (with Clangd v21.x) seems to crash.  Perusing the logs reveals that it crashes because of our use of Class Template Argument Deduction in a couple of places in code.

This change introduces explicit types, so that code completion works correctly in VSCode /Cursor.

There is no material change to functionality. 
