### PR TITLE
Add Ansi check for round/bround operators

### DIFF
--- a/src/main/cpp/src/ArithmeticJni.cpp
+++ b/src/main/cpp/src/ArithmeticJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/round_float.cu
+++ b/src/main/cpp/src/round_float.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/src/round_float.hpp
+++ b/src/main/cpp/src/round_float.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/Arithmetic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/nvidia/spark/rapids/jni/ArithmeticTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ArithmeticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/7520

### Spark changes
From Spark 340, introduced ANSI check for round/bround.
Refer to RoundBase in [link](https://github.com/apache/spark/blob/v3.4.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L1549)
```scala
      case ByteType if ansiEnabled =>
        MathUtils.withOverflow(
          f = BigDecimal(input1.asInstanceOf[Byte]).setScale(_scale, mode).toByteExact,
          context = getContextOrNull)
...
      case ShortType if ansiEnabled =>
        MathUtils.withOverflow(
          f = BigDecimal(input1.asInstanceOf[Short]).setScale(_scale, mode).toShortExact,
          context = getContextOrNull)
...
      case IntegerType if ansiEnabled =>
        MathUtils.withOverflow(
          f = BigDecimal(input1.asInstanceOf[Int]).setScale(_scale, mode).toIntExact,
          context = getContextOrNull)
...
      case LongType if ansiEnabled =>
        MathUtils.withOverflow(
          f = BigDecimal(input1.asInstanceOf[Long]).setScale(_scale, mode).toLongExact,
          context = getContextOrNull)
```
For byte/short/int/long, now checks overflow using Decimal utilities.

### examples
For byte value 125, and scale -1, means round to tens, the answer is 130: round 5 to 10, and add 120 is 130.
But byte values range is [-128, 127], so overflow occurs.


### How to fix
Given a col type, scale, and round mode(HALF_UP/HALF_EVEN),  we can calculates the safe value range in advance.
e.g.:
```csv
type,round,scale,safe_min,safe_max
int8,HALF_UP,-1,-124,124
int8,HALF_EVEN,-1,-125,125
```
This PR computes the safe value range, and then find if any value is out of this safe range.
Note: `compute_non_overflow_range` is used to compute the safe range, test all the combinations:
type: int8, int16, int32, int64
round: HALF_UP, HALF_EVEN
scale: -1 to -22

Signed-off-by: Chong Gao <res_life@163.com>