### PR TITLE
Increase pre-merge CI timeout [skip ci]

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -227,7 +227,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             unstash "source_tree"
                             container('gpu') {
-                                timeout(time: 4, unit: 'HOURS') { // step only timeout for test run
+                                timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     common.resolveIncompatibleDriverIssue(this)
                                     try {
                                         sh 'source build/env.sh && ${sclCMD} "ci/premerge-build.sh"'
@@ -260,7 +260,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                         script {
                             unstash "source_tree"
                             container('gpu') {
-                                timeout(time: 4, unit: 'HOURS') { // step only timeout for test run
+                                timeout(time: 6, unit: 'HOURS') { // step only timeout for test run
                                     common.resolveIncompatibleDriverIssue(this)
                                     try {
                                         sh 'source build/env.sh && ${sclCMD} "ci/premerge-build.sh"'


### PR DESCRIPTION
Originally reported from 

https://github.com/NVIDIA/spark-rapids-jni/pull/4174#issuecomment-3782095544

Let's try increase the CI timeout to mitigate potential compilation timeout issue for now