### PR TITLE
Re-enable sanitizer for cuda13 w/ --track-stream-ordered-races no

### DIFF
--- a/build/sanitizer-java/bin/java
+++ b/build/sanitizer-java/bin/java
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,14 @@
 # limitations under the License.
 #
 
-# This special Java executable is specified to the "jvm" configuration of the
-# the surefire plugin to intercept forking the processes for tests. Then
-# the tests will run with the compute-sanitizer tool.
+# Java wrapper script for Maven Surefire plugin's "jvm" configuration.
+# Intercepts test process forking to run tests with NVIDIA Compute Sanitizer
+# for memory error detection and analysis.
+
+# Workaround for known issue: https://github.com/NVIDIA/spark-rapids-jni/issues/4127
+# Disabling stream-ordered race detection (--track-stream-ordered-races no)
 exec compute-sanitizer --tool memcheck \
+    --track-stream-ordered-races no \
     --launch-timeout 600 \
     --error-exitcode -2 \
     --log-file "./sanitizer_for_pid_%p.log" \

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -47,8 +47,6 @@ fi
 if [ "${CUDA_VER}" == "cuda13" ]; then
   BUILD_FAULTINJ="OFF"
   BUILD_PROFILER="OFF"
-  # Disable sanitizer https://github.com/NVIDIA/spark-rapids-jni/issues/4127
-  USE_SANITIZER="OFF"
 fi
 
 ${MVN} clean package ${MVN_MIRROR}  \


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids-jni/issues/4127

Re-enable sanitizer run in nightly with `--track-stream-ordered-races no`.

This has been validated for both cuda12 and cuda13 runs