### PR TITLE
Remove dependency of cudf/detail/utilities/algorithm.cuh

### DIFF
--- a/src/main/cpp/src/hash/xxhash64.cu
+++ b/src/main/cpp/src/hash/xxhash64.cu
@@ -309,7 +309,7 @@ class device_row_hasher {
     auto result = _seed;
     auto itr    = _table.begin();
 
-    auto op = [row_index, nulls = _check_nulls](auto hash, auto& column) -> hash_value_type {
+    auto op = [row_index, nulls = _check_nulls](auto hash, auto column) -> hash_value_type {
       return cudf::type_dispatcher(
         column.type(), element_hasher_adapter{}, column, row_index, nulls, hash);
     };


### PR DESCRIPTION
Found another dependency on `cudf/detail/utilities/algorithm.cuh' that can be removed.
This libcudf internal header is being removed in https://github.com/rapidsai/cudf/pull/21387
Missed this when working on #4265 
