### PR TITLE
Replace nvtx CUDF_FUNC_RANGE() with SRJ_FUNC_RANGE()

### DIFF
--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@
 #define ARITHMETIC_RIGHT_SHIFT 1
 #include "cudf_jni_apis.hpp"
 #include "jni_utils.hpp"
-
-#include <cudf/detail/nvtx/ranges.hpp>
+#include "nvtx_ranges.hpp"
 
 #include <generated/parquet_types.h>
 #include <thrift/TApplicationException.h>
@@ -133,7 +132,7 @@ class column_pruner {
   column_pruning_maps filter_schema(std::vector<parquet::format::SchemaElement> const& schema,
                                     bool const ignore_case) const
   {
-    CUDF_FUNC_RANGE();
+    SRJ_FUNC_RANGE();
 
     // These are the outputs of the computation.
     std::vector<int> chunk_map;
@@ -531,7 +530,7 @@ class column_pruner {
                        std::vector<Tag> const& tags,
                        int parent_num_children)
   {
-    CUDF_FUNC_RANGE();
+    SRJ_FUNC_RANGE();
     if (parent_num_children == 0) {
       // There is no point in doing more the tree is empty, and it lets us avoid some corner cases
       // in the code below
@@ -609,7 +608,7 @@ static int64_t get_offset(parquet::format::ColumnChunk const& column_chunk)
 static std::vector<parquet::format::RowGroup> filter_groups(
   parquet::format::FileMetaData const& meta, int64_t part_offset, int64_t part_length)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   // This is based off of the java parquet_mr code to find the groups in a range...
   auto num_row_groups             = meta.row_groups.size();
   int64_t pre_start_index         = 0;
@@ -665,7 +664,7 @@ void deserialize_parquet_footer(uint8_t* buffer, uint32_t len, parquet::format::
 {
   using ThriftBuffer = apache::thrift::transport::TMemoryBuffer;
 
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 // A lot of this came from the parquet source code...
 // Deserialize msg bytes into c++ thrift msg using memory transport.
 #if PARQUET_THRIFT_VERSION_MAJOR > 0 || PARQUET_THRIFT_VERSION_MINOR >= 14
@@ -695,7 +694,7 @@ void deserialize_parquet_footer(uint8_t* buffer, uint32_t len, parquet::format::
 
 void filter_columns(std::vector<parquet::format::RowGroup>& groups, std::vector<int>& chunk_filter)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   for (auto group_it = groups.begin(); group_it != groups.end(); ++group_it) {
     std::vector<parquet::format::ColumnChunk> new_chunks;
     for (auto it = chunk_filter.begin(); it != chunk_filter.end(); ++it) {
@@ -723,7 +722,7 @@ Java_com_nvidia_spark_rapids_jni_ParquetFooter_readAndFilter(JNIEnv* env,
                                                              jint parent_num_children,
                                                              jboolean ignore_case)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   JNI_TRY
   {
     auto meta    = std::make_unique<parquet::format::FileMetaData>();
@@ -822,7 +821,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_getNumCol
 JNIEXPORT jobject JNICALL Java_com_nvidia_spark_rapids_jni_ParquetFooter_serializeThriftFile(
   JNIEnv* env, jclass, jlong handle, jobject host_memory_allocator)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   JNI_TRY
   {
     parquet::format::FileMetaData* meta = reinterpret_cast<parquet::format::FileMetaData*>(handle);

--- a/src/main/cpp/src/cast_decimal_to_string.cu
+++ b/src/main/cpp/src/cast_decimal_to_string.cu
@@ -15,11 +15,11 @@
  */
 
 #include "cast_string.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/convert/int_to_string.cuh>
 #include <cudf/strings/detail/converters.hpp>
@@ -223,7 +223,7 @@ std::unique_ptr<column> decimal_to_non_ansi_string(column_view const& input,
                                                    rmm::cuda_stream_view stream,
                                                    rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::decimal_to_non_ansi_string(input, stream, mr);
 }
 

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -16,9 +16,9 @@
 
 #include "cast_string.hpp"
 #include "ftos_converter.cuh"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -121,7 +121,7 @@ std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::float_to_string(floats, stream, mr);
 }
 

--- a/src/main/cpp/src/cast_long_to_binary_string.cu
+++ b/src/main/cpp/src/cast_long_to_binary_string.cu
@@ -15,10 +15,10 @@
  */
 
 #include "cast_string.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/utilities/default_stream.hpp>
@@ -146,7 +146,7 @@ std::unique_ptr<cudf::column> long_to_binary_string(cudf::column_view const& inp
                                                     rmm::cuda_stream_view stream,
                                                     rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::long_to_binary_string(input, stream, mr);
 }
 

--- a/src/main/cpp/src/datetime_rebase.cu
+++ b/src/main/cpp/src/datetime_rebase.cu
@@ -15,10 +15,10 @@
  */
 
 #include "datetime_utils.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 
 #include <rmm/exec_policy.hpp>
@@ -343,7 +343,7 @@ std::unique_ptr<cudf::column> rebase_gregorian_to_julian(cudf::column_view const
                                                          rmm::cuda_stream_view stream,
                                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const type = input.type().id();
   CUDF_EXPECTS(
@@ -359,7 +359,7 @@ std::unique_ptr<cudf::column> rebase_julian_to_gregorian(cudf::column_view const
                                                          rmm::cuda_stream_view stream,
                                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const type = input.type().id();
   CUDF_EXPECTS(

--- a/src/main/cpp/src/datetime_truncate.cu
+++ b/src/main/cpp/src/datetime_truncate.cu
@@ -15,11 +15,11 @@
  */
 
 #include "datetime_utils.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/string_view.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/utilities/span.hpp>
@@ -382,7 +382,7 @@ std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::truncate(datetime, format, stream, mr);
 }
 
@@ -391,7 +391,7 @@ std::unique_ptr<cudf::column> truncate(cudf::column_view const& datetime,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::truncate(datetime, format, stream, mr);
 }
 

--- a/src/main/cpp/src/format_float.cu
+++ b/src/main/cpp/src/format_float.cu
@@ -16,9 +16,9 @@
 
 #include "cast_string.hpp"
 #include "ftos_converter.cuh"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -125,7 +125,7 @@ std::unique_ptr<cudf::column> format_float(cudf::column_view const& floats,
                                            rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::format_float(floats, digits, stream, mr);
 }
 

--- a/src/main/cpp/src/from_json_to_structs.cu
+++ b/src/main/cpp/src/from_json_to_structs.cu
@@ -16,11 +16,11 @@
 
 #include "cast_string.hpp"
 #include "json_utils.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/io/json.hpp>
@@ -147,7 +147,7 @@ std::unique_ptr<cudf::column> cast_strings_to_booleans(cudf::column_view const& 
                                                        rmm::cuda_stream_view stream,
                                                        rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const string_count = input.size();
   if (string_count == 0) { return cudf::make_empty_column(cudf::data_type{cudf::type_id::BOOL8}); }
@@ -201,7 +201,7 @@ std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& 
                                                        rmm::cuda_stream_view stream,
                                                        rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const string_count = input.size();
   if (string_count == 0) { return cudf::make_empty_column(output_type); }
@@ -267,7 +267,7 @@ std::unique_ptr<cudf::column> cast_strings_to_integers(cudf::column_view const& 
 std::pair<std::unique_ptr<cudf::column>, bool> try_remove_quotes_for_floats(
   cudf::column_view const& input, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const string_count = input.size();
   if (string_count == 0) { return {nullptr, false}; }
@@ -353,7 +353,7 @@ std::unique_ptr<cudf::column> cast_strings_to_floats(cudf::column_view const& in
                                                      rmm::cuda_stream_view stream,
                                                      rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const string_count = input.size();
   if (string_count == 0) { return cudf::make_empty_column(output_type); }
@@ -380,7 +380,7 @@ std::unique_ptr<cudf::column> cast_strings_to_decimals(cudf::column_view const& 
                                                        rmm::cuda_stream_view stream,
                                                        rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const string_count = input.size();
   if (string_count == 0) { return cudf::make_empty_column(output_type); }
@@ -523,7 +523,7 @@ std::pair<std::unique_ptr<cudf::column>, bool> try_remove_quotes(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const string_count = input.size();
   if (string_count == 0) { return {nullptr, false}; }
@@ -606,7 +606,7 @@ std::unique_ptr<cudf::column> convert_data_type(InputType&& input,
                                                 rmm::cuda_stream_view stream,
                                                 rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   using DecayInputT                  = std::decay_t<InputType>;
   auto constexpr input_is_const_cv   = std::is_same_v<DecayInputT, cudf::column_view>;
@@ -895,7 +895,7 @@ std::unique_ptr<cudf::column> from_json_to_structs(cudf::strings_column_view con
                                                    rmm::cuda_stream_view stream,
                                                    rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   return detail::from_json_to_structs(input,
                                       col_names,
@@ -922,7 +922,7 @@ std::unique_ptr<cudf::column> convert_from_strings(cudf::strings_column_view con
                                                    rmm::cuda_stream_view stream,
                                                    rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   [[maybe_unused]] auto const [schema, schema_with_precision] = detail::generate_struct_schema(
     /*dummy col_names*/ std::vector<std::string>(num_children.size(), std::string{}),
@@ -947,7 +947,7 @@ std::unique_ptr<cudf::column> remove_quotes(cudf::strings_column_view const& inp
                                             rmm::cuda_stream_view stream,
                                             rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto const input_cv = input.parent();
   auto [removed_quotes, success] =

--- a/src/main/cpp/src/get_json_object.cu
+++ b/src/main/cpp/src/get_json_object.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #include "get_json_object.hpp"
 #include "json_parser.cuh"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
@@ -1239,7 +1239,7 @@ std::unique_ptr<cudf::column> get_json_object(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return std::move(detail::get_json_object(input, {instructions}, -1, -1, stream, mr).front());
 }
 
@@ -1252,7 +1252,7 @@ std::vector<std::unique_ptr<cudf::column>> get_json_object_multiple_paths(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::get_json_object(
     input, json_paths, memory_budget_bytes, parallel_override, stream, mr);
 }

--- a/src/main/cpp/src/iceberg/iceberg_bucket.cu
+++ b/src/main/cpp/src/iceberg/iceberg_bucket.cu
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include "../nvtx_ranges.hpp"
 #include "iceberg_bucket.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/null_mask.hpp>
@@ -463,7 +463,7 @@ std::unique_ptr<cudf::column> compute_bucket(cudf::column_view const& input,
                                              rmm::cuda_stream_view stream,
                                              rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return compute_bucket_impl(input, num_buckets, stream, mr);
 }
 

--- a/src/main/cpp/src/iceberg/iceberg_datetime_util.cu
+++ b/src/main/cpp/src/iceberg/iceberg_datetime_util.cu
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+#include "../nvtx_ranges.hpp"
 #include "datetime_utils.cuh"
 #include "iceberg_datetime_util.hpp"
 #include "integer_utils.cuh"
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
 
@@ -253,7 +253,7 @@ std::unique_ptr<cudf::column> years_from_epoch(cudf::column_view const& input,
                                                rmm::cuda_stream_view stream,
                                                rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return compute_years_from_epoch(input, stream, mr);
 }
 
@@ -261,7 +261,7 @@ std::unique_ptr<cudf::column> months_from_epoch(cudf::column_view const& input,
                                                 rmm::cuda_stream_view stream,
                                                 rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return compute_months_from_epoch(input, stream, mr);
 }
 
@@ -269,7 +269,7 @@ std::unique_ptr<cudf::column> days_from_epoch(cudf::column_view const& input,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return compute_days_from_epoch(input, stream, mr);
 }
 
@@ -277,7 +277,7 @@ std::unique_ptr<cudf::column> hours_from_epoch(cudf::column_view const& input,
                                                rmm::cuda_stream_view stream,
                                                rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return compute_hours_from_epoch(input, stream, mr);
 }
 

--- a/src/main/cpp/src/iceberg/iceberg_truncate.cu
+++ b/src/main/cpp/src/iceberg/iceberg_truncate.cu
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include "../nvtx_ranges.hpp"
 #include "iceberg_truncate.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/lists/detail/lists_column_factories.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/null_mask.hpp>
@@ -245,7 +245,7 @@ std::unique_ptr<cudf::column> truncate_integral(cudf::column_view const& input,
                                                 rmm::cuda_stream_view stream,
                                                 rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return truncate_integral_impl(input, width, stream, mr);
 }
 
@@ -254,7 +254,7 @@ std::unique_ptr<cudf::column> truncate_string(cudf::column_view const& input,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return truncate_string_impl(input, truncate_length, stream, mr);
 }
 
@@ -263,7 +263,7 @@ std::unique_ptr<cudf::column> truncate_binary(cudf::column_view const& input,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return truncate_binary_impl(input, truncate_length, stream, mr);
 }
 

--- a/src/main/cpp/src/join_primitives.cu
+++ b/src/main/cpp/src/join_primitives.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 
 #include "join_primitives.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
 #include <cudf/ast/detail/expression_parser.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/join/hash_join.hpp>
 #include <cudf/join/sort_merge_join.hpp>
@@ -185,7 +185,7 @@ sort_merge_inner_join(cudf::table_view const& left_keys,
                       rmm::cuda_stream_view stream,
                       rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   // Validate inputs
   CUDF_EXPECTS(left_keys.num_columns() > 0, "Left keys table must have at least one column");
@@ -210,7 +210,7 @@ hash_inner_join(cudf::table_view const& left_keys,
                 rmm::cuda_stream_view stream,
                 rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   // Validate inputs
   CUDF_EXPECTS(left_keys.num_columns() > 0, "Left keys table must have at least one column");
@@ -242,7 +242,7 @@ filter_gather_maps_by_ast(cudf::device_span<cudf::size_type const> left_indices,
                           rmm::cuda_stream_view stream,
                           rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   CUDF_EXPECTS(left_indices.size() == right_indices.size(),
                "Left and right gather maps must have the same size");
@@ -366,7 +366,7 @@ make_left_outer(cudf::device_span<cudf::size_type const> left_indices,
                 rmm::cuda_stream_view stream,
                 rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   CUDF_EXPECTS(left_indices.size() == right_indices.size(),
                "Left and right gather maps must have the same size");
@@ -411,7 +411,7 @@ make_full_outer(cudf::device_span<cudf::size_type const> left_indices,
                 rmm::cuda_stream_view stream,
                 rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   CUDF_EXPECTS(left_indices.size() == right_indices.size(),
                "Left and right gather maps must have the same size");
@@ -473,7 +473,7 @@ rmm::device_uvector<cudf::size_type> make_semi(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   // Create a boolean mask for all left rows (default-initialized to false)
   auto left_has_match =
@@ -512,7 +512,7 @@ rmm::device_uvector<cudf::size_type> make_anti(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   // Create a boolean mask for all left rows (default-initialized to false)
   auto left_has_match =
@@ -554,7 +554,7 @@ std::unique_ptr<cudf::column> get_matched_rows(cudf::device_span<cudf::size_type
                                                rmm::cuda_stream_view stream,
                                                rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   // Create a boolean column initialized to false
   auto result = cudf::make_numeric_column(

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+#include "nvtx_ranges.hpp"
+
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/strings/detail/combine.hpp>
@@ -224,7 +225,7 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::concat_json(input, nullify_invalid_rows, stream, mr);
 }
 

--- a/src/main/cpp/src/list_slice.cu
+++ b/src/main/cpp/src/list_slice.cu
@@ -15,12 +15,12 @@
  */
 
 #include "list_slice.hpp"
+#include "nvtx_ranges.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/gather.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sizes_to_offsets_iterator.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
@@ -358,7 +358,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::list_slice(input, start, length, check_start_length, stream, mr);
 }
 
@@ -369,7 +369,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::list_slice(input, start, length, check_start_length, stream, mr);
 }
 
@@ -380,7 +380,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::list_slice(input, start, length, check_start_length, stream, mr);
 }
 
@@ -391,7 +391,7 @@ std::unique_ptr<cudf::column> list_slice(lists_column_view const& input,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::list_slice(input, start, length, check_start_length, stream, mr);
 }
 

--- a/src/main/cpp/src/nvtx_ranges.hpp
+++ b/src/main/cpp/src/nvtx_ranges.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <nvtx3/nvtx3.hpp>
+
+namespace spark_rapids_jni {
+/**
+ * @brief Tag type for the NVTX domain
+ */
+struct srj_domain {
+  static constexpr char const* name{"srj"};  ///< Name of the domain
+};
+
+}  // namespace spark_rapids_jni
+
+/**
+ * @brief Convenience macro for generating an NVTX range in the
+ * spark_rapids_jni domain for the lifetime of a function.
+ *
+ * Uses the name of the immediately enclosing function returned by `__func__` to
+ * name the range.
+ *
+ * Example:
+ * ```
+ * void some_function(){
+ *    SRJ_FUNC_RANGE();
+ *    ...
+ * }
+ * ```
+ */
+#define SRJ_FUNC_RANGE() NVTX3_FUNC_RANGE_IN(spark_rapids_jni::srj_domain)

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -15,10 +15,10 @@
  */
 
 #include "exception_with_row_index_utilities.hpp"
+#include "nvtx_ranges.hpp"
 #include "parse_uri.hpp"
 
 #include <cudf/detail/get_value.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
@@ -1002,7 +1002,7 @@ std::unique_ptr<column> parse_uri_to_protocol(strings_column_view const& input,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   if (ansi_mode) { detail::validate_input_uris(input, stream); }
   return detail::parse_uri(input, detail::URI_chunks::PROTOCOL, std::nullopt, stream, mr);
 }
@@ -1012,7 +1012,7 @@ std::unique_ptr<column> parse_uri_to_host(strings_column_view const& input,
                                           rmm::cuda_stream_view stream,
                                           rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   if (ansi_mode) { detail::validate_input_uris(input, stream); }
   return detail::parse_uri(input, detail::URI_chunks::HOST, std::nullopt, stream, mr);
 }
@@ -1022,7 +1022,7 @@ std::unique_ptr<column> parse_uri_to_query(strings_column_view const& input,
                                            rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   if (ansi_mode) { detail::validate_input_uris(input, stream); }
   return detail::parse_uri(input, detail::URI_chunks::QUERY, std::nullopt, stream, mr);
 }
@@ -1033,7 +1033,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
                                                  rmm::cuda_stream_view stream,
                                                  rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   if (ansi_mode) { detail::validate_input_uris(input, stream); }
 
   // build string_column_view from incoming query_match string
@@ -1049,7 +1049,7 @@ std::unique_ptr<cudf::column> parse_uri_to_query(cudf::strings_column_view const
                                                  rmm::cuda_stream_view stream,
                                                  rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   CUDF_EXPECTS(input.size() == query_match.size(), "Query column must be the same size as input!");
 
   if (ansi_mode) { detail::validate_input_uris(input, stream); }
@@ -1061,7 +1061,7 @@ std::unique_ptr<column> parse_uri_to_path(strings_column_view const& input,
                                           rmm::cuda_stream_view stream,
                                           rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   if (ansi_mode) { detail::validate_input_uris(input, stream); }
   return detail::parse_uri(input, detail::URI_chunks::PATH, std::nullopt, stream, mr);
 }

--- a/src/main/cpp/src/regex_rewrite_utils.cu
+++ b/src/main/cpp/src/regex_rewrite_utils.cu
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include "nvtx_ranges.hpp"
+
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/utf8.hpp>
 #include <cudf/strings/string_view.cuh>
@@ -126,7 +127,7 @@ std::unique_ptr<cudf::column> literal_range_pattern(cudf::strings_column_view co
                                                     rmm::cuda_stream_view stream,
                                                     rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return find_literal_range_pattern(input, prefix, range_len, start, end, stream, mr);
 }
 

--- a/src/main/cpp/src/round_float.cu
+++ b/src/main/cpp/src/round_float.cu
@@ -15,12 +15,12 @@
  */
 
 #include "exception_with_row_index.hpp"
+#include "nvtx_ranges.hpp"
 #include "round_float.hpp"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
@@ -162,7 +162,7 @@ std::unique_ptr<cudf::column> round(cudf::column_view const& input,
                                     rmm::cuda_stream_view stream,
                                     rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   CUDF_EXPECTS(cudf::is_numeric(input.type()) || cudf::is_fixed_point(input.type()),
                "Only integral/floating point/fixed point currently supported.");
 
@@ -310,7 +310,7 @@ std::unique_ptr<cudf::column> round(cudf::column_view const& input,
                                     rmm::cuda_stream_view stream,
                                     rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   if (input.is_empty()) { return cudf::empty_like(input); }
 

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "nvtx_ranges.hpp"
 #include "shuffle_split.hpp"
 #include "shuffle_split_detail.hpp"
 
@@ -21,7 +22,6 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/batched_memset.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
@@ -1920,7 +1920,7 @@ shuffle_assemble_result shuffle_assemble(shuffle_split_metadata const& metadata,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   auto temp_mr = cudf::get_current_device_resource_ref();
 

--- a/src/main/cpp/src/shuffle_split.cu
+++ b/src/main/cpp/src/shuffle_split.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "nvtx_ranges.hpp"
 #include "shuffle_split.hpp"
 #include "shuffle_split_detail.hpp"
 
@@ -21,7 +22,6 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
@@ -800,7 +800,7 @@ std::pair<shuffle_split_result, shuffle_split_metadata> shuffle_split(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
 
   // empty inputs
   CUDF_EXPECTS(input.num_columns() != 0, "Encountered input with no columns.");

--- a/src/main/cpp/src/substring_index.cu
+++ b/src/main/cpp/src/substring_index.cu
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "nvtx_ranges.hpp"
 #include "substring_index.hpp"
 
 #include <cudf/column/column.hpp>
@@ -20,7 +21,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/indexalator.cuh>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/strings/slice.hpp>
@@ -155,7 +155,7 @@ std::unique_ptr<column> substring_index(strings_column_view const& strings,
                                         size_type count,
                                         rmm::device_async_resource_ref mr)
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return detail::substring_index(strings,
                                  cudf::detail::make_pair_iterator<string_view>(delimiter),
                                  count,

--- a/src/main/cpp/src/uuid.cu
+++ b/src/main/cpp/src/uuid.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+#include "nvtx_ranges.hpp"
 #include "uuid.hpp"
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.hpp>
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
@@ -186,7 +186,7 @@ std::unique_ptr<cudf::column> random_uuids(int row_count,
                                            rmm::device_async_resource_ref mr)
 
 {
-  CUDF_FUNC_RANGE();
+  SRJ_FUNC_RANGE();
   return generate_uuids(row_count, seed, stream, mr);
 }
 


### PR DESCRIPTION
Creates a spark-rapids-jni specific NVTX range name to be used in place of the cudf one.
This will help identify functions within the NSight Compute profiles correctly.