### PR TITLE
Remove stream and mr parameters from calls to make_lists_column

### DIFF
--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -151,8 +151,7 @@ std::unique_ptr<cudf::column> make_empty_map(rmm::cuda_stream_view stream,
   auto child =
     cudf::make_structs_column(0, std::move(out_keys_vals), 0, rmm::device_buffer{}, stream, mr);
   auto offsets = cudf::make_empty_column(cudf::data_type(cudf::type_id::INT32));
-  return cudf::make_lists_column(
-    0, std::move(offsets), std::move(child), 0, rmm::device_buffer{}, stream, mr);
+  return cudf::make_lists_column(0, std::move(offsets), std::move(child), 0, rmm::device_buffer{});
 }
 
 // Concatenating all input strings into one string, for which each input string is appended by a

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -267,13 +267,8 @@ std::unique_ptr<cudf::column> wrap_in_list(std::unique_ptr<cudf::column>&& input
   auto const sizes_itr = thrust::make_constant_iterator(num_percentages);
   auto offsets         = std::get<0>(
     cudf::detail::make_offsets_child_column(sizes_itr, sizes_itr + num_histograms, stream, mr));
-  auto output = cudf::make_lists_column(num_histograms,
-                                        std::move(offsets),
-                                        std::move(input),
-                                        null_count,
-                                        std::move(null_mask),
-                                        stream,
-                                        mr);
+  auto output = cudf::make_lists_column(
+    num_histograms, std::move(offsets), std::move(input), null_count, std::move(null_mask));
   if (null_count > 0) { return cudf::purge_nonempty_nulls(output->view(), stream, mr); }
 
   return output;
@@ -387,13 +382,8 @@ std::unique_ptr<cudf::column> create_histogram_if_valid(cudf::column_view const&
     auto const sizes_itr = thrust::make_constant_iterator(1);
     auto offsets         = std::get<0>(
       cudf::detail::make_offsets_child_column(sizes_itr, sizes_itr + num_elements, stream, mr));
-    return cudf::make_lists_column(num_elements,
-                                   std::move(offsets),
-                                   std::move(structs_histogram),
-                                   0,
-                                   rmm::device_buffer{},
-                                   stream,
-                                   mr);
+    return cudf::make_lists_column(
+      num_elements, std::move(offsets), std::move(structs_histogram), 0, rmm::device_buffer{});
   };
 
   if (output_as_lists) {

--- a/src/main/cpp/src/list_slice.cu
+++ b/src/main/cpp/src/list_slice.cu
@@ -207,13 +207,8 @@ std::unique_ptr<cudf::column> legal_list_slice(lists_column_view const& input,
   // Assemble list column & return
   auto null_mask  = cudf::copy_bitmask(input.parent(), stream, mr);
   auto null_count = input.null_count();
-  return make_lists_column(num_rows,
-                           std::move(output_offset),
-                           std::move(child),
-                           null_count,
-                           std::move(null_mask),
-                           stream,
-                           mr);
+  return make_lists_column(
+    num_rows, std::move(output_offset), std::move(child), null_count, std::move(null_mask));
 }
 
 }  // namespace

--- a/src/main/cpp/src/map.cu
+++ b/src/main/cpp/src/map.cu
@@ -59,9 +59,7 @@ std::unique_ptr<cudf::column> sort_map_column(cudf::column_view const& input,
                                  std::make_unique<cudf::column>(segments),  // copy segment offsets
                                  std::move(sorted->release().front()),      // child column
                                  input.null_count(),
-                                 cudf::copy_bitmask(input, stream, mr),
-                                 stream,
-                                 mr);
+                                 cudf::copy_bitmask(input, stream, mr));
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/map_zip_with_utils.cu
+++ b/src/main/cpp/src/map_zip_with_utils.cu
@@ -417,9 +417,7 @@ std::unique_ptr<cudf::column> map_zip(
                            std::make_unique<column>(search_keys_list.offsets()),
                            std::move(map_structs),
                            null_count,
-                           std::move(result_mask),
-                           stream,
-                           mr);
+                           std::move(result_mask));
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -1262,9 +1262,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
                            std::move(offsets),
                            std::move(data),
                            0,
-                           rmm::device_buffer{0, cudf::get_default_stream(), mr},
-                           stream,
-                           mr);
+                           rmm::device_buffer{0, cudf::get_default_stream(), mr});
 }
 
 static inline bool are_all_fixed_width(std::vector<data_type> const& schema)
@@ -1978,9 +1976,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
                                             std::move(offsets),
                                             std::move(data),
                                             0,
-                                            rmm::device_buffer{0, cudf::get_default_stream(), mr},
-                                            stream,
-                                            mr);
+                                            rmm::device_buffer{0, cudf::get_default_stream(), mr});
                  });
 
   return ret;

--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -212,13 +212,8 @@ std::unique_ptr<cudf::column> interleave_bits(cudf::table_view const& tbl,
   auto offsets_column = std::get<0>(
     cudf::detail::make_offsets_child_column(offset_begin, offset_begin + num_rows, stream, mr));
 
-  return cudf::make_lists_column(num_rows,
-                                 std::move(offsets_column),
-                                 std::move(output_data_col),
-                                 0,
-                                 rmm::device_buffer(),
-                                 stream,
-                                 mr);
+  return cudf::make_lists_column(
+    num_rows, std::move(offsets_column), std::move(output_data_col), 0, rmm::device_buffer());
 }
 
 std::unique_ptr<cudf::column> hilbert_index(int32_t const num_bits_per_entry,

--- a/src/main/cpp/tests/shuffle_split.cu
+++ b/src/main/cpp/tests/shuffle_split.cu
@@ -294,24 +294,12 @@ TEST_F(ShuffleSplitTests, Lists)
     cudf::test::strings_column_wrapper strings0{{"*", "*", "****", "", "*", ""},
                                                 {1, 1, 1, 1, 1, 0}};
     cudf::test::fixed_width_column_wrapper<int> offsets0{0, 1, 2, 3, 6};
-    auto col0 = cudf::make_lists_column(4,
-                                        offsets0.release(),
-                                        strings0.release(),
-                                        0,
-                                        {},
-                                        cudf::get_default_stream(),
-                                        rmm::mr::get_current_device_resource_ref());
+    auto col0 = cudf::make_lists_column(4, offsets0.release(), strings0.release(), 0, {});
 
     cudf::test::strings_column_wrapper strings1{{"", "", "", "", "", "", ""},
                                                 {0, 0, 0, 0, 0, 0, 0}};
     cudf::test::fixed_width_column_wrapper<int> offsets1{0, 4, 4, 7, 7};
-    auto col1 = cudf::make_lists_column(4,
-                                        offsets1.release(),
-                                        strings1.release(),
-                                        0,
-                                        {},
-                                        cudf::get_default_stream(),
-                                        rmm::mr::get_current_device_resource_ref());
+    auto col1 = cudf::make_lists_column(4, offsets1.release(), strings1.release(), 0, {});
 
     cudf::table_view tbl{{*col0, *col1}};
     run_split(tbl, {});
@@ -456,26 +444,14 @@ TEST_F(ShuffleSplitTests, EmptyOffsets)
   // list<string> with empty strings
   cudf::test::strings_column_wrapper strings0{};
   cudf::test::fixed_width_column_wrapper<int> offsets0{0, 0, 0};
-  auto col0 = cudf::make_lists_column(2,
-                                      offsets0.release(),
-                                      strings0.release(),
-                                      0,
-                                      {},
-                                      cudf::get_default_stream(),
-                                      rmm::mr::get_current_device_resource_ref());
+  auto col0 = cudf::make_lists_column(2, offsets0.release(), strings0.release(), 0, {});
   cudf::lists_column_view lcv(*col0);
   CUDF_EXPECTS(lcv.child().num_children() == 0, "String column is expected to have no offsets");
 
   // list<list<int>> with empty inner list
   cudf::test::lists_column_wrapper<int> list0{};
   cudf::test::fixed_width_column_wrapper<int> offsets1{0, 0, 0};
-  auto col1 = cudf::make_lists_column(2,
-                                      offsets1.release(),
-                                      list0.release(),
-                                      0,
-                                      {},
-                                      cudf::get_default_stream(),
-                                      rmm::mr::get_current_device_resource_ref());
+  auto col1 = cudf::make_lists_column(2, offsets1.release(), list0.release(), 0, {});
 
   // list<struct<int, int>>
   cudf::test::fixed_width_column_wrapper<int> ints0{-210, 311};
@@ -485,13 +461,7 @@ TEST_F(ShuffleSplitTests, EmptyOffsets)
   inner_children.push_back(ints1.release());
   cudf::test::structs_column_wrapper inner_struct(std::move(inner_children));
   cudf::test::fixed_width_column_wrapper<int> offsets2{0, 1, 2};
-  auto col2 = cudf::make_lists_column(2,
-                                      offsets2.release(),
-                                      inner_struct.release(),
-                                      0,
-                                      {},
-                                      cudf::get_default_stream(),
-                                      rmm::mr::get_current_device_resource_ref());
+  auto col2 = cudf::make_lists_column(2, offsets2.release(), inner_struct.release(), 0, {});
 
   cudf::table_view tbl{{*col0, *col1, *col2, *col1}};
   auto result = run_split(tbl, {});


### PR DESCRIPTION
This removes the `stream` and `mr` parameters from calls to the `cudf::make_lists_column`.
These parameters are not actually used and have been removed in https://github.com/rapidsai/cudf/pull/21548