### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.04 to release/26.04 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -120,7 +120,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "6ed480503ea740a0eb2c3fdac0c0a4a88c778027",
+      "git_tag" : "b5c81cdc43d3ba04027b20cd8b839385313ac3e3",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.04"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: a5ec02091474f767c70afaecb9d648bd53699978, cudf commit SHA: https://github.com/rapidsai/cudf/commit/b13ada2c8970be62e713d197e0ad3fa596ea32ef

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.