### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.04 to release/26.04 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -68,7 +68,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "47a6ada39950bff50bf08522e0fa5e9aea10c213",
+      "git_tag" : "1877b4265bb1e5574c91ab6c8d43f1d8f2fcf13a",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
       "version" : "26.04"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: 9f46f0d80980990329b8e9852f16ec592d80d62c, cudf commit SHA: https://github.com/rapidsai/cudf/commit/b13ada2c8970be62e713d197e0ad3fa596ea32ef

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.