### PR TITLE
CI: Artifactory v2 URL and Maven server creds

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -70,10 +70,8 @@ pipeline {
         JENKINS_ROOT = 'jenkins'
         GITHUB_TOKEN = credentials("github-token")
 
-        // v1 instance for maven mirror only, will be migrated to v2 soon
-        ART_URL = "https://${common.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
+        ART_URL = "https://${common.ARTIFACTORY_NAME_V2}/artifactory/sw-spark-maven"
         MVN_MIRROR = '-s ci/settings.xml -P mirror-apache-to-urm'
-        // v2 instance for CI images usage
         ART_CREDS = credentials("urm_creds_v2")
         ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME_V2}"
 

--- a/ci/settings.xml
+++ b/ci/settings.xml
@@ -29,6 +29,21 @@
       <id>snapshots</id>
     </server>
     <server>
+      <username>${env.ART_CREDS_USR}</username>
+      <password>${env.ART_CREDS_PSW}</password>
+      <id>apache.snapshots</id>
+    </server>
+    <server>
+      <username>${env.ART_CREDS_USR}</username>
+      <password>${env.ART_CREDS_PSW}</password>
+      <id>apache.snapshots.https</id>
+    </server>
+    <server>
+      <username>${env.ART_CREDS_USR}</username>
+      <password>${env.ART_CREDS_PSW}</password>
+      <id>apache-snapshots-repo</id>
+    </server>
+    <server>
       <id>ossrh</id>
       <username>${env.SONATYPE_USR}</username>
       <password>${env.SONATYPE_PSW}</password>


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids-jni/issues/4424

- Point ART_URL at ARTIFACTORY_NAME_V2 sw-spark-maven; 

- Add servers for apache.snapshots* repos so ART_URL uses ART_CREDS
