### PR TITLE
Add <cuda/functional> header to map_zip_with_utils.cu and list_slice.cu

### DIFF
--- a/src/main/cpp/src/list_slice.cu
+++ b/src/main/cpp/src/list_slice.cu
@@ -28,6 +28,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <thrust/logical.h>
 
 using namespace cudf;

--- a/src/main/cpp/src/map_zip_with_utils.cu
+++ b/src/main/cpp/src/map_zip_with_utils.cu
@@ -27,6 +27,7 @@
 #include <cudf/unary.hpp>
 #include <cudf/utilities/span.hpp>
 
+#include <cuda/functional>
 #include <thrust/scan.h>
 
 using namespace cudf;


### PR DESCRIPTION
 Fixes #4414

Stop relying on transitive include for <cude/functional>
    
 Signed-off-by: Gera Shegalov <gshegalov@nvidia.com>