### PR TITLE
from_protobuf kernel (part1): scalar field decoding

### DIFF
--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -862,18 +862,25 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   }
   if (fail_on_errors && h_error != 0) throw cudf::logic_error(error_message(h_error));
 
-  // Build final struct null mask from PERMISSIVE-mode row invalidation.
-  // Note: input null mask is NOT merged here — the Scala/Java caller handles input-row-level
-  // nulls via mergeAndSetValidity after the JNI call returns.
+  // Build final struct null mask by combining input nulls with PERMISSIVE-mode row invalidation.
   cudf::size_type struct_null_count = 0;
   rmm::device_buffer struct_mask{0, stream, mr};
+  auto const input_null_count = binary_input.null_count();
 
-  if (track_permissive_null_rows) {
+  if (track_permissive_null_rows || input_null_count > 0) {
+    auto const* input_mask = binary_input.null_mask();
+    auto input_offset      = binary_input.offset();
     auto [mask, null_count] = cudf::detail::valid_if(
       thrust::make_counting_iterator<cudf::size_type>(0),
       thrust::make_counting_iterator<cudf::size_type>(num_rows),
-      [row_invalid = d_row_force_null.data()] __device__(cudf::size_type row) {
-        return !row_invalid[row];
+      [row_invalid = track_permissive_null_rows ? d_row_force_null.data() : nullptr,
+       input_mask,
+       input_offset] __device__(cudf::size_type row) {
+        if (input_mask != nullptr && !cudf::bit_is_set(input_mask, input_offset + row)) {
+          return false;
+        }
+        if (row_invalid != nullptr && row_invalid[row]) return false;
+        return true;
       },
       stream,
       mr);
@@ -881,10 +888,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     struct_null_count = null_count;
   }
 
-  // cuDF child views do not automatically inherit parent nulls. Push PERMISSIVE nulls down into
-  // every top-level child, then recursively through nested STRUCT/LIST children, so callers that
+  // cuDF child views do not automatically inherit parent nulls. Push nulls down into every
+  // top-level child, then recursively through nested STRUCT/LIST children, so callers that
   // access backing grandchildren directly still observe logically-null rows.
-  if (track_permissive_null_rows && struct_null_count > 0) {
+  if (struct_null_count > 0) {
     auto const* struct_mask_ptr = static_cast<cudf::bitmask_type const*>(struct_mask.data());
     for (auto& child : top_level_children) {
       apply_parent_mask_to_row_aligned_column(

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -852,8 +852,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   auto const input_null_count = binary_input.null_count();
 
   if (track_permissive_null_rows || input_null_count > 0) {
-    auto const* input_mask = binary_input.null_mask();
-    auto input_offset      = binary_input.offset();
+    auto const* input_mask  = binary_input.null_mask();
+    auto input_offset       = binary_input.offset();
     auto [mask, null_count] = cudf::detail::valid_if(
       thrust::make_counting_iterator<cudf::size_type>(0),
       thrust::make_counting_iterator<cudf::size_type>(num_rows),

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -390,26 +390,12 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   // Extract shared input data pointers (used by scalar, repeated, and nested sections)
   cudf::lists_column_view const in_list_view(binary_input);
   auto const* message_data = reinterpret_cast<uint8_t const*>(in_list_view.child().data<int8_t>());
-  auto const message_data_size = static_cast<cudf::size_type>(in_list_view.child().size());
-  auto const* list_offsets     = in_list_view.offsets().data<cudf::size_type>();
+  auto const* list_offsets = in_list_view.offsets().data<cudf::size_type>();
 
   cudf::size_type base_offset = 0;
   CUDF_CUDA_TRY(cudaMemcpyAsync(
     &base_offset, list_offsets, sizeof(cudf::size_type), cudaMemcpyDeviceToHost, stream.value()));
   stream.synchronize();
-
-  // Copy schema to device
-  std::vector<device_nested_field_descriptor> h_device_schema(num_fields);
-  for (int i = 0; i < num_fields; i++) {
-    h_device_schema[i] = device_nested_field_descriptor{schema[i]};
-  }
-
-  rmm::device_uvector<device_nested_field_descriptor> d_schema(num_fields, stream, mr);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(d_schema.data(),
-                                h_device_schema.data(),
-                                num_fields * sizeof(device_nested_field_descriptor),
-                                cudaMemcpyHostToDevice,
-                                stream.value()));
 
   auto d_in = cudf::column_device_view::create(binary_input, stream);
   // Identify repeated and nested fields at depth 0
@@ -429,9 +415,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     }
   }
 
-  int num_repeated = static_cast<int>(repeated_field_indices.size());
-  int num_nested   = static_cast<int>(nested_field_indices.size());
-  int num_scalar   = static_cast<int>(scalar_field_indices.size());
+  int num_scalar = static_cast<int>(scalar_field_indices.size());
 
   // Error flag
   rmm::device_uvector<int> d_error(1, stream, mr);

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -862,16 +862,26 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   }
   if (fail_on_errors && h_error != 0) throw cudf::logic_error(error_message(h_error));
 
-  // Build final struct with PERMISSIVE mode null mask for invalid enums
+  // Build final struct null mask by combining input nulls with PERMISSIVE-mode row invalidation.
   cudf::size_type struct_null_count = 0;
   rmm::device_buffer struct_mask{0, stream, mr};
+  auto const input_null_count = binary_input.null_count();
 
-  if (track_permissive_null_rows) {
+  if (track_permissive_null_rows || input_null_count > 0) {
+    auto const* input_mask = binary_input.null_mask();
+    auto input_offset      = binary_input.offset();
     auto [mask, null_count] = cudf::detail::valid_if(
       thrust::make_counting_iterator<cudf::size_type>(0),
       thrust::make_counting_iterator<cudf::size_type>(num_rows),
-      [row_invalid = d_row_force_null.data()] __device__(cudf::size_type row) {
-        return !row_invalid[row];
+      [row_invalid    = track_permissive_null_rows ? d_row_force_null.data() : nullptr,
+       input_mask,
+       input_offset] __device__(cudf::size_type row) {
+        if (input_mask != nullptr &&
+            !cudf::bit_is_set(input_mask, input_offset + row)) {
+          return false;
+        }
+        if (row_invalid != nullptr && row_invalid[row]) { return false; }
+        return true;
       },
       stream,
       mr);
@@ -879,10 +889,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     struct_null_count = null_count;
   }
 
-  // cuDF child views do not automatically inherit parent nulls. Push PERMISSIVE invalid-enum
-  // nulls down into every top-level child, then recursively through nested STRUCT/LIST children,
-  // so callers that access backing grandchildren directly still observe logically-null rows.
-  if (track_permissive_null_rows && struct_null_count > 0) {
+  // cuDF child views do not automatically inherit parent nulls. Push nulls down into every
+  // top-level child, then recursively through nested STRUCT/LIST children, so callers that
+  // access backing grandchildren directly still observe logically-null rows.
+  if (struct_null_count > 0) {
     auto const* struct_mask_ptr = static_cast<cudf::bitmask_type const*>(struct_mask.data());
     for (auto& child : top_level_children) {
       apply_parent_mask_to_row_aligned_column(

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -19,6 +19,9 @@
 
 #include <cudf/lists/lists_column_view.hpp>
 
+#include <thrust/binary_search.h>
+
+#include <set>
 #include <string>
 #include <unordered_set>
 
@@ -27,6 +30,112 @@ namespace spark_rapids_jni::protobuf {
 namespace detail {
 
 namespace {
+
+void propagate_nulls_to_descendants(cudf::column& col,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::device_async_resource_ref mr);
+
+void apply_parent_mask_to_row_aligned_column(cudf::column& col,
+                                             cudf::bitmask_type const* parent_mask_ptr,
+                                             cudf::size_type parent_null_count,
+                                             cudf::size_type num_rows,
+                                             rmm::cuda_stream_view stream,
+                                             rmm::device_async_resource_ref mr)
+{
+  if (parent_null_count == 0) { return; }
+  auto child_view = col.mutable_view();
+  CUDF_EXPECTS(child_view.size() == num_rows,
+               "struct child size must match parent row count for null propagation");
+
+  if (child_view.nullable()) {
+    auto const child_mask_words =
+      cudf::num_bitmask_words(static_cast<size_t>(child_view.size() + child_view.offset()));
+    std::array<cudf::bitmask_type const*, 2> masks{child_view.null_mask(), parent_mask_ptr};
+    std::array<cudf::size_type, 2> begin_bits{child_view.offset(), 0};
+    auto const valid_count = cudf::detail::inplace_bitmask_and(
+      cudf::device_span<cudf::bitmask_type>(child_view.null_mask(), child_mask_words),
+      cudf::host_span<cudf::bitmask_type const* const>(masks.data(), masks.size()),
+      cudf::host_span<cudf::size_type const>(begin_bits.data(), begin_bits.size()),
+      child_view.size(),
+      stream);
+    col.set_null_count(child_view.size() - valid_count);
+  } else {
+    CUDF_EXPECTS(child_view.offset() == 0,
+                 "non-nullable child with nonzero offset not supported for null propagation");
+    auto child_mask = cudf::detail::copy_bitmask(parent_mask_ptr, 0, num_rows, stream, mr);
+    col.set_null_mask(std::move(child_mask), parent_null_count);
+  }
+}
+
+void propagate_list_nulls_to_descendants(cudf::column& list_col,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
+{
+  if (list_col.type().id() != cudf::type_id::LIST || list_col.null_count() == 0) { return; }
+
+  cudf::lists_column_view const list_view(list_col.view());
+  auto const* list_mask_ptr = list_view.null_mask();
+  auto const num_rows       = list_view.size();
+  auto& child               = list_col.child(cudf::lists_column_view::child_column_index);
+  auto const child_size     = child.size();
+  if (child_size == 0) { return; }
+
+  CUDF_EXPECTS(list_view.offset() == 0,
+               "decoder list null propagation expects unsliced list columns");
+  auto const* offsets_begin = list_view.offsets_begin();
+  auto const* offsets_end   = list_view.offsets_end();
+  // LIST children are not row-aligned with their parent. Expand the list-row null mask across
+  // every covered child element so direct access to the backing child column also observes nulls.
+  auto [element_mask, element_null_count] = cudf::detail::valid_if(
+    thrust::make_counting_iterator<cudf::size_type>(0),
+    thrust::make_counting_iterator<cudf::size_type>(child_size),
+    [list_mask_ptr, offsets_begin, offsets_end] __device__(cudf::size_type idx) {
+      auto const it  = thrust::upper_bound(thrust::seq, offsets_begin, offsets_end, idx);
+      auto const row = static_cast<cudf::size_type>(it - offsets_begin) - 1;
+      return list_mask_ptr == nullptr || cudf::bit_is_set(list_mask_ptr, row);
+    },
+    stream,
+    mr);
+
+  apply_parent_mask_to_row_aligned_column(
+    child,
+    static_cast<cudf::bitmask_type const*>(element_mask.data()),
+    element_null_count,
+    child_size,
+    stream,
+    mr);
+  propagate_nulls_to_descendants(child, stream, mr);
+}
+
+void propagate_struct_nulls_to_descendants(cudf::column& struct_col,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr)
+{
+  if (struct_col.type().id() != cudf::type_id::STRUCT || struct_col.null_count() == 0) { return; }
+
+  auto const struct_view      = struct_col.view();
+  auto const* struct_mask_ptr = struct_view.null_mask();
+  auto const num_rows         = struct_view.size();
+  auto const null_count       = struct_col.null_count();
+
+  for (cudf::size_type i = 0; i < struct_col.num_children(); ++i) {
+    auto& child = struct_col.child(i);
+    apply_parent_mask_to_row_aligned_column(
+      child, struct_mask_ptr, null_count, num_rows, stream, mr);
+    propagate_nulls_to_descendants(child, stream, mr);
+  }
+}
+
+void propagate_nulls_to_descendants(cudf::column& col,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::device_async_resource_ref mr)
+{
+  switch (col.type().id()) {
+    case cudf::type_id::STRUCT: propagate_struct_nulls_to_descendants(col, stream, mr); break;
+    case cudf::type_id::LIST: propagate_list_nulls_to_descendants(col, stream, mr); break;
+    default: break;
+  }
+}
 
 std::unique_ptr<cudf::column> make_null_column_with_schema(
   std::vector<nested_field_descriptor> const& schema,
@@ -106,137 +215,102 @@ bool is_encoding_compatible(nested_field_descriptor const& field, cudf::data_typ
 void validate_decode_context(protobuf_decode_context const& context)
 {
   auto const num_fields = context.schema.size();
-  if (context.default_ints.size() != num_fields) {
-    CUDF_FAIL("protobuf decode context: default_ints size mismatch with schema (" +
-                std::to_string(context.default_ints.size()) + " vs " + std::to_string(num_fields) +
-                ")",
-              std::invalid_argument);
-  }
-  if (context.default_floats.size() != num_fields) {
-    CUDF_FAIL("protobuf decode context: default_floats size mismatch with schema (" +
-                std::to_string(context.default_floats.size()) + " vs " +
-                std::to_string(num_fields) + ")",
-              std::invalid_argument);
-  }
-  if (context.default_bools.size() != num_fields) {
-    CUDF_FAIL("protobuf decode context: default_bools size mismatch with schema (" +
-                std::to_string(context.default_bools.size()) + " vs " + std::to_string(num_fields) +
-                ")",
-              std::invalid_argument);
-  }
-  if (context.default_strings.size() != num_fields) {
-    CUDF_FAIL("protobuf decode context: default_strings size mismatch with schema (" +
-                std::to_string(context.default_strings.size()) + " vs " +
-                std::to_string(num_fields) + ")",
-              std::invalid_argument);
-  }
-  if (context.enum_valid_values.size() != num_fields) {
-    CUDF_FAIL("protobuf decode context: enum_valid_values size mismatch with schema (" +
-                std::to_string(context.enum_valid_values.size()) + " vs " +
-                std::to_string(num_fields) + ")",
-              std::invalid_argument);
-  }
-  if (context.enum_names.size() != num_fields) {
-    CUDF_FAIL("protobuf decode context: enum_names size mismatch with schema (" +
-                std::to_string(context.enum_names.size()) + " vs " + std::to_string(num_fields) +
-                ")",
-              std::invalid_argument);
-  }
+  CUDF_EXPECTS(context.default_ints.size() == num_fields,
+               "protobuf decode context: default_ints size mismatch",
+               std::invalid_argument);
+  CUDF_EXPECTS(context.default_floats.size() == num_fields,
+               "protobuf decode context: default_floats size mismatch",
+               std::invalid_argument);
+  CUDF_EXPECTS(context.default_bools.size() == num_fields,
+               "protobuf decode context: default_bools size mismatch",
+               std::invalid_argument);
+  CUDF_EXPECTS(context.default_strings.size() == num_fields,
+               "protobuf decode context: default_strings size mismatch",
+               std::invalid_argument);
+  CUDF_EXPECTS(context.enum_valid_values.size() == num_fields,
+               "protobuf decode context: enum_valid_values size mismatch",
+               std::invalid_argument);
+  CUDF_EXPECTS(context.enum_names.size() == num_fields,
+               "protobuf decode context: enum_names size mismatch",
+               std::invalid_argument);
 
-  std::unordered_set<uint64_t> seen_field_numbers;
+  std::set<std::pair<int, int>> seen_field_numbers;
   for (size_t i = 0; i < num_fields; ++i) {
     auto const& field = context.schema[i];
     auto const type   = cudf::data_type{field.output_type};
-    if (field.field_number <= 0 || field.field_number > MAX_FIELD_NUMBER) {
-      CUDF_FAIL("protobuf decode context: invalid field number at field " + std::to_string(i),
-                std::invalid_argument);
-    }
-    if (field.depth < 0 || field.depth >= MAX_NESTING_DEPTH) {
-      CUDF_FAIL("protobuf decode context: field depth exceeds supported limit at field " +
-                  std::to_string(i),
-                std::invalid_argument);
-    }
-    if (field.parent_idx < -1 || field.parent_idx >= static_cast<int>(i)) {
-      CUDF_FAIL("protobuf decode context: invalid parent index at field " + std::to_string(i),
-                std::invalid_argument);
-    }
-    auto const key = (static_cast<uint64_t>(static_cast<uint32_t>(field.parent_idx)) << 32) |
-                     static_cast<uint64_t>(field.field_number);
-    if (!seen_field_numbers.insert(key).second) {
-      CUDF_FAIL("protobuf decode context: duplicate field number under same parent at field " +
-                  std::to_string(i),
-                std::invalid_argument);
-    }
+    CUDF_EXPECTS(field.field_number > 0 && field.field_number <= MAX_FIELD_NUMBER,
+                 "protobuf decode context: invalid field number at field " + std::to_string(i),
+                 std::invalid_argument);
+    CUDF_EXPECTS(field.depth >= 0 && field.depth < MAX_NESTING_DEPTH,
+                 "protobuf decode context: field depth exceeds limit at field " + std::to_string(i),
+                 std::invalid_argument);
+    CUDF_EXPECTS(field.parent_idx >= -1 && field.parent_idx < static_cast<int>(i),
+                 "protobuf decode context: invalid parent index at field " + std::to_string(i),
+                 std::invalid_argument);
+    CUDF_EXPECTS(seen_field_numbers.emplace(field.parent_idx, field.field_number).second,
+                 "protobuf decode context: duplicate field number under same parent at field " +
+                   std::to_string(i),
+                 std::invalid_argument);
 
     if (field.parent_idx == -1) {
-      if (field.depth != 0) {
-        CUDF_FAIL("protobuf decode context: top-level field must have depth 0 at field " +
-                    std::to_string(i),
-                  std::invalid_argument);
-      }
+      CUDF_EXPECTS(
+        field.depth == 0,
+        "protobuf decode context: top-level field must have depth 0 at field " + std::to_string(i),
+        std::invalid_argument);
     } else {
       auto const& parent = context.schema[field.parent_idx];
-      if (field.depth != parent.depth + 1) {
-        CUDF_FAIL("protobuf decode context: child depth mismatch at field " + std::to_string(i),
-                  std::invalid_argument);
-      }
-      if (cudf::data_type{context.schema[field.parent_idx].output_type}.id() !=
-          cudf::type_id::STRUCT) {
-        CUDF_FAIL("protobuf decode context: parent must be STRUCT at field " + std::to_string(i),
-                  std::invalid_argument);
-      }
+      CUDF_EXPECTS(field.depth == parent.depth + 1,
+                   "protobuf decode context: child depth mismatch at field " + std::to_string(i),
+                   std::invalid_argument);
+      CUDF_EXPECTS(context.schema[field.parent_idx].output_type == cudf::type_id::STRUCT,
+                   "protobuf decode context: parent must be STRUCT at field " + std::to_string(i),
+                   std::invalid_argument);
     }
 
-    if (field.wire_type != proto_wire_type::VARINT && field.wire_type != proto_wire_type::I64BIT &&
-        field.wire_type != proto_wire_type::LEN && field.wire_type != proto_wire_type::I32BIT) {
-      CUDF_FAIL("protobuf decode context: invalid wire type at field " + std::to_string(i),
-                std::invalid_argument);
-    }
-    if (field.encoding < proto_encoding::DEFAULT || field.encoding > proto_encoding::ENUM_STRING) {
-      CUDF_FAIL("protobuf decode context: invalid encoding at field " + std::to_string(i),
-                std::invalid_argument);
-    }
-    if (field.is_repeated && field.is_required) {
-      CUDF_FAIL("protobuf decode context: field cannot be both repeated and required at field " +
-                  std::to_string(i),
-                std::invalid_argument);
-    }
-    if (field.is_repeated && field.has_default_value) {
-      CUDF_FAIL("protobuf decode context: repeated field cannot carry default value at field " +
-                  std::to_string(i),
-                std::invalid_argument);
-    }
-    if (field.has_default_value &&
-        (type.id() == cudf::type_id::STRUCT || type.id() == cudf::type_id::LIST)) {
-      CUDF_FAIL("protobuf decode context: STRUCT/LIST field cannot carry default value at field " +
-                  std::to_string(i),
-                std::invalid_argument);
-    }
-    if (!is_encoding_compatible(field, type)) {
-      CUDF_FAIL("protobuf decode context: incompatible wire type/encoding/output type at field " +
-                  std::to_string(i),
-                std::invalid_argument);
-    }
+    CUDF_EXPECTS(
+      field.wire_type == proto_wire_type::VARINT || field.wire_type == proto_wire_type::I64BIT ||
+        field.wire_type == proto_wire_type::LEN || field.wire_type == proto_wire_type::I32BIT,
+      "protobuf decode context: invalid wire type at field " + std::to_string(i),
+      std::invalid_argument);
+    CUDF_EXPECTS(
+      field.encoding >= proto_encoding::DEFAULT && field.encoding <= proto_encoding::ENUM_STRING,
+      "protobuf decode context: invalid encoding at field " + std::to_string(i),
+      std::invalid_argument);
+    CUDF_EXPECTS(!(field.is_repeated && field.is_required),
+                 "protobuf decode context: field cannot be both repeated and required at field " +
+                   std::to_string(i),
+                 std::invalid_argument);
+    CUDF_EXPECTS(!(field.is_repeated && field.has_default_value),
+                 "protobuf decode context: repeated field cannot carry default value at field " +
+                   std::to_string(i),
+                 std::invalid_argument);
+    CUDF_EXPECTS(!(field.has_default_value &&
+                   (type.id() == cudf::type_id::STRUCT || type.id() == cudf::type_id::LIST)),
+                 "protobuf decode context: STRUCT/LIST field cannot carry default value at field " +
+                   std::to_string(i),
+                 std::invalid_argument);
+    CUDF_EXPECTS(is_encoding_compatible(field, type),
+                 "protobuf decode context: incompatible wire type/encoding/output type at field " +
+                   std::to_string(i),
+                 std::invalid_argument);
 
     if (field.encoding == proto_encoding::ENUM_STRING) {
-      if (context.enum_valid_values[i].empty() || context.enum_names[i].empty()) {
-        CUDF_FAIL(
-          "protobuf decode context: enum-as-string field requires non-empty metadata at field " +
-            std::to_string(i),
-          std::invalid_argument);
-      }
-      if (context.enum_valid_values[i].size() != context.enum_names[i].size()) {
-        CUDF_FAIL(
-          "protobuf decode context: enum-as-string metadata mismatch at field " + std::to_string(i),
-          std::invalid_argument);
-      }
+      CUDF_EXPECTS(
+        !(context.enum_valid_values[i].empty() || context.enum_names[i].empty()),
+        "protobuf decode context: enum-as-string field requires non-empty metadata at field " +
+          std::to_string(i),
+        std::invalid_argument);
+      CUDF_EXPECTS(
+        context.enum_valid_values[i].size() == context.enum_names[i].size(),
+        "protobuf decode context: enum-as-string metadata mismatch at field " + std::to_string(i),
+        std::invalid_argument);
       auto const& ev = context.enum_valid_values[i];
       for (size_t j = 1; j < ev.size(); ++j) {
-        if (ev[j] <= ev[j - 1]) {
-          CUDF_FAIL("protobuf decode context: enum_valid_values must be strictly sorted at field " +
-                      std::to_string(i),
-                    std::invalid_argument);
-        }
+        CUDF_EXPECTS(
+          ev[j] > ev[j - 1],
+          "protobuf decode context: enum_valid_values must be strictly sorted at field " +
+            std::to_string(i),
+          std::invalid_argument);
       }
     }
   }
@@ -262,7 +336,13 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                                         rmm::device_async_resource_ref mr)
 {
   validate_decode_context(context);
-  auto const& schema = context.schema;
+  auto const& schema            = context.schema;
+  auto const& default_ints      = context.default_ints;
+  auto const& default_floats    = context.default_floats;
+  auto const& default_bools     = context.default_bools;
+  auto const& enum_valid_values = context.enum_valid_values;
+  auto const& enum_names        = context.enum_names;
+  bool fail_on_errors           = context.fail_on_errors;
   CUDF_EXPECTS(binary_input.type().id() == cudf::type_id::LIST,
                "binary_input must be a LIST<INT8/UINT8> column");
   cudf::lists_column_view const in_list(binary_input);
@@ -307,8 +387,459 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       0, std::move(empty_children), 0, rmm::device_buffer{}, stream, mr);
   }
 
+  // Extract shared input data pointers (used by scalar, repeated, and nested sections)
+  cudf::lists_column_view const in_list_view(binary_input);
+  auto const* message_data = reinterpret_cast<uint8_t const*>(in_list_view.child().data<int8_t>());
+  auto const message_data_size = static_cast<cudf::size_type>(in_list_view.child().size());
+  auto const* list_offsets     = in_list_view.offsets().data<cudf::size_type>();
+
+  cudf::size_type base_offset = 0;
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+    &base_offset, list_offsets, sizeof(cudf::size_type), cudaMemcpyDeviceToHost, stream.value()));
+  stream.synchronize();
+
+  // Copy schema to device
+  std::vector<device_nested_field_descriptor> h_device_schema(num_fields);
+  for (int i = 0; i < num_fields; i++) {
+    h_device_schema[i] = device_nested_field_descriptor{schema[i]};
+  }
+
+  rmm::device_uvector<device_nested_field_descriptor> d_schema(num_fields, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_schema.data(),
+                                h_device_schema.data(),
+                                num_fields * sizeof(device_nested_field_descriptor),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+
+  auto d_in = cudf::column_device_view::create(binary_input, stream);
+  // Identify repeated and nested fields at depth 0
+  std::vector<int> repeated_field_indices;
+  std::vector<int> nested_field_indices;
+  std::vector<int> scalar_field_indices;
+
+  for (int i = 0; i < num_fields; i++) {
+    if (schema[i].parent_idx == -1) {  // Top-level fields only
+      if (schema[i].is_repeated) {
+        repeated_field_indices.push_back(i);
+      } else if (schema[i].output_type == cudf::type_id::STRUCT) {
+        nested_field_indices.push_back(i);
+      } else {
+        scalar_field_indices.push_back(i);
+      }
+    }
+  }
+
+  int num_repeated = static_cast<int>(repeated_field_indices.size());
+  int num_nested   = static_cast<int>(nested_field_indices.size());
+  int num_scalar   = static_cast<int>(scalar_field_indices.size());
+
+  // Error flag
+  rmm::device_uvector<int> d_error(1, stream, mr);
+  CUDF_CUDA_TRY(cudaMemsetAsync(d_error.data(), 0, sizeof(int), stream.value()));
+  auto error_message = [](int code) -> char const* {
+    switch (code) {
+      case ERR_BOUNDS: return "Protobuf decode error: message data out of bounds";
+      case ERR_VARINT: return "Protobuf decode error: invalid or truncated varint";
+      case ERR_FIELD_NUMBER: return "Protobuf decode error: invalid field number";
+      case ERR_WIRE_TYPE: return "Protobuf decode error: unexpected wire type";
+      case ERR_OVERFLOW: return "Protobuf decode error: length-delimited field overflows message";
+      case ERR_FIELD_SIZE: return "Protobuf decode error: invalid field size";
+      case ERR_SKIP: return "Protobuf decode error: unable to skip unknown field";
+      case ERR_FIXED_LEN:
+        return "Protobuf decode error: invalid fixed-width or packed field length";
+      case ERR_REQUIRED: return "Protobuf decode error: missing required field";
+      case ERR_SCHEMA_TOO_LARGE:
+        return "Protobuf decode error: schema exceeds maximum supported repeated fields per kernel "
+               "(128)";
+      case ERR_MISSING_ENUM_META:
+        return "Protobuf decode error: missing or mismatched enum metadata for enum-as-string "
+               "field";
+      case ERR_REPEATED_COUNT_MISMATCH:
+        return "Protobuf decode error: repeated-field count/scan mismatch";
+      default: return "Protobuf decode error: unknown error";
+    }
+  };
+  // PERMISSIVE-mode row nulling support. Unknown enum values and malformed rows should both
+  // surface as null structs instead of partially decoded data.
+  bool has_enum_fields = std::any_of(
+    enum_valid_values.begin(), enum_valid_values.end(), [](auto const& v) { return !v.empty(); });
+  bool track_permissive_null_rows = !fail_on_errors;
+  rmm::device_uvector<bool> d_row_force_null(track_permissive_null_rows ? num_rows : 0, stream, mr);
+  if (track_permissive_null_rows) {
+    CUDF_CUDA_TRY(
+      cudaMemsetAsync(d_row_force_null.data(), 0, num_rows * sizeof(bool), stream.value()));
+  }
+
+  auto const threads = THREADS_PER_BLOCK;
+  auto const blocks  = static_cast<int>((num_rows + threads - 1u) / threads);
+
+  // Store decoded columns by schema index for ordered assembly at the end.
   std::vector<std::unique_ptr<cudf::column>> column_map(num_fields);
 
+  // Process scalar fields using scan + extract infrastructure
+  if (num_scalar > 0) {
+    std::vector<field_descriptor> h_field_descs(num_scalar);
+    for (int i = 0; i < num_scalar; i++) {
+      int schema_idx                      = scalar_field_indices[i];
+      h_field_descs[i].field_number       = schema[schema_idx].field_number;
+      h_field_descs[i].expected_wire_type = static_cast<int>(schema[schema_idx].wire_type);
+      h_field_descs[i].is_repeated        = false;
+    }
+
+    rmm::device_uvector<field_descriptor> d_field_descs(num_scalar, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(d_field_descs.data(),
+                                  h_field_descs.data(),
+                                  num_scalar * sizeof(field_descriptor),
+                                  cudaMemcpyHostToDevice,
+                                  stream.value()));
+
+    rmm::device_uvector<field_location> d_locations(
+      static_cast<size_t>(num_rows) * num_scalar, stream, mr);
+
+    auto h_field_lookup = build_field_lookup_table(h_field_descs.data(), num_scalar);
+    rmm::device_uvector<int> d_field_lookup(h_field_lookup.size(), stream, mr);
+    if (!h_field_lookup.empty()) {
+      CUDF_CUDA_TRY(cudaMemcpyAsync(d_field_lookup.data(),
+                                    h_field_lookup.data(),
+                                    h_field_lookup.size() * sizeof(int),
+                                    cudaMemcpyHostToDevice,
+                                    stream.value()));
+    }
+
+    launch_scan_all_fields(*d_in,
+                           d_field_descs.data(),
+                           num_scalar,
+                           h_field_lookup.empty() ? nullptr : d_field_lookup.data(),
+                           static_cast<int>(h_field_lookup.size()),
+                           d_locations.data(),
+                           d_error.data(),
+                           track_permissive_null_rows ? d_row_force_null.data() : nullptr,
+                           num_rows,
+                           stream);
+
+    // Required-field validation applies to all scalar leaves, not just top-level numerics.
+    maybe_check_required_fields(d_locations.data(),
+                                scalar_field_indices,
+                                schema,
+                                num_rows,
+                                binary_input.null_count() > 0 ? binary_input.null_mask() : nullptr,
+                                binary_input.offset(),
+                                nullptr,
+                                track_permissive_null_rows ? d_row_force_null.data() : nullptr,
+                                nullptr,
+                                d_error.data(),
+                                stream);
+
+    // Batched scalar extraction: group non-special fixed-width fields by extraction
+    // category and extract all fields of each category with a single 2D kernel launch.
+    {
+      struct scalar_buf_pair {
+        rmm::device_uvector<uint8_t> out_bytes;
+        rmm::device_uvector<bool> valid;
+        scalar_buf_pair(rmm::cuda_stream_view s, rmm::device_async_resource_ref m)
+          : out_bytes(0, s, m), valid(0, s, m)
+        {
+        }
+      };
+
+      // Classify each scalar field
+      // 0=I32, 1=U32, 2=I64, 3=U64, 4=BOOL, 5=I32zz, 6=I64zz, 7=F32, 8=F64,
+      // 9=I32fixed, 10=I64fixed, 11=fallback
+      constexpr int NUM_GROUPS   = 12;
+      constexpr int GRP_FALLBACK = 11;
+      std::vector<int> group_lists[NUM_GROUPS];
+
+      for (int i = 0; i < num_scalar; i++) {
+        int si   = scalar_field_indices[i];
+        auto tid = cudf::data_type{schema[si].output_type}.id();
+        auto enc = schema[si].encoding;
+        bool zz  = (enc == proto_encoding::ZIGZAG);
+
+        // STRING, LIST, and enum-as-string go to per-field path
+        if (tid == cudf::type_id::STRING || tid == cudf::type_id::LIST) continue;
+
+        bool is_fixed = (enc == proto_encoding::FIXED);
+
+        // INT32 with enum validation goes to fallback
+        if (tid == cudf::type_id::INT32 && !zz && !is_fixed &&
+            si < static_cast<int>(enum_valid_values.size()) && !enum_valid_values[si].empty()) {
+          group_lists[GRP_FALLBACK].push_back(i);
+          continue;
+        }
+
+        int g = GRP_FALLBACK;
+        if (tid == cudf::type_id::INT32 && is_fixed) {
+          g = 9;
+        } else if (tid == cudf::type_id::INT64 && is_fixed) {
+          g = 10;
+        } else if (tid == cudf::type_id::UINT32 && is_fixed) {
+          g = 9;
+        } else if (tid == cudf::type_id::UINT64 && is_fixed) {
+          g = 10;
+        } else if (tid == cudf::type_id::INT32 && !zz) {
+          g = 0;
+        } else if (tid == cudf::type_id::UINT32) {
+          g = 1;
+        } else if (tid == cudf::type_id::INT64 && !zz) {
+          g = 2;
+        } else if (tid == cudf::type_id::UINT64) {
+          g = 3;
+        } else if (tid == cudf::type_id::BOOL8) {
+          g = 4;
+        } else if (tid == cudf::type_id::INT32 && zz) {
+          g = 5;
+        } else if (tid == cudf::type_id::INT64 && zz) {
+          g = 6;
+        } else if (tid == cudf::type_id::FLOAT32) {
+          g = 7;
+        } else if (tid == cudf::type_id::FLOAT64) {
+          g = 8;
+        }
+        group_lists[g].push_back(i);
+      }
+
+      // Helper: batch-extract one group using a 2D kernel, then build columns.
+      auto do_batch = [&](std::vector<int> const& idxs, auto kernel_launcher) {
+        int nf = static_cast<int>(idxs.size());
+        if (nf == 0) return;
+
+        std::vector<std::unique_ptr<scalar_buf_pair>> bufs;
+        bufs.reserve(nf);
+        std::vector<batched_scalar_desc> h_descs(nf);
+
+        for (int j = 0; j < nf; j++) {
+          int li   = idxs[j];
+          int si   = scalar_field_indices[li];
+          bool hd  = schema[si].has_default_value;
+          auto& bp = *bufs.emplace_back(std::make_unique<scalar_buf_pair>(stream, mr));
+          bp.valid = rmm::device_uvector<bool>(std::max(1, num_rows), stream, mr);
+          // BOOL8 default comes from default_bools (converted to 0/1 int)
+          bool is_bool  = (cudf::data_type{schema[si].output_type}.id() == cudf::type_id::BOOL8);
+          int64_t def_i = hd ? (is_bool ? (default_bools[si] ? 1 : 0) : default_ints[si]) : 0;
+          h_descs[j]    = {li, nullptr, bp.valid.data(), hd, def_i, hd ? default_floats[si] : 0.0};
+        }
+
+        // kernel_launcher allocates out_bytes, sets h_descs[j].output, and launches kernel
+        kernel_launcher(nf, h_descs, bufs);
+
+        // Build columns
+        for (int j = 0; j < nf; j++) {
+          int si                  = scalar_field_indices[idxs[j]];
+          auto dt                 = cudf::data_type{schema[si].output_type};
+          auto& bp                = *bufs[j];
+          auto [mask, null_count] = make_null_mask_from_valid(bp.valid, stream, mr);
+          column_map[si]          = std::make_unique<cudf::column>(
+            dt, num_rows, bp.out_bytes.release(), std::move(mask), null_count);
+        }
+      };
+
+      // Varint launcher for type T with zigzag ZZ
+      auto varint_launch = [&](int nf,
+                               std::vector<batched_scalar_desc>& h_descs,
+                               std::vector<std::unique_ptr<scalar_buf_pair>>& bufs,
+                               size_t elem_size,
+                               auto kernel_fn) {
+        for (int j = 0; j < nf; j++) {
+          bufs[j]->out_bytes = rmm::device_uvector<uint8_t>(num_rows * elem_size, stream, mr);
+          h_descs[j].output  = bufs[j]->out_bytes.data();
+        }
+        rmm::device_uvector<batched_scalar_desc> d_descs(nf, stream, mr);
+        CUDF_CUDA_TRY(cudaMemcpyAsync(d_descs.data(),
+                                      h_descs.data(),
+                                      nf * sizeof(h_descs[0]),
+                                      cudaMemcpyHostToDevice,
+                                      stream.value()));
+        dim3 grid((num_rows + threads - 1u) / threads, nf);
+        kernel_fn(grid,
+                  threads,
+                  stream.value(),
+                  message_data,
+                  list_offsets,
+                  base_offset,
+                  d_locations.data(),
+                  num_scalar,
+                  d_descs.data(),
+                  nf,
+                  num_rows,
+                  d_error.data());
+      };
+
+// Dispatch groups 0-8 as batched
+#define LAUNCH_VARINT_BATCH(GROUP, TYPE, ZZ)                                                  \
+  do_batch(group_lists[GROUP], [&](int nf, auto& hd, auto& bf) {                              \
+    varint_launch(nf, hd, bf, sizeof(TYPE), [](dim3 g, int t, cudaStream_t s, auto... args) { \
+      extract_varint_batched_kernel<TYPE, ZZ><<<g, t, 0, s>>>(args...);                       \
+    });                                                                                       \
+  })
+
+#define LAUNCH_FIXED_BATCH(GROUP, TYPE, WT_VAL)                                               \
+  do_batch(group_lists[GROUP], [&](int nf, auto& hd, auto& bf) {                              \
+    varint_launch(nf, hd, bf, sizeof(TYPE), [](dim3 g, int t, cudaStream_t s, auto... args) { \
+      extract_fixed_batched_kernel<TYPE, WT_VAL><<<g, t, 0, s>>>(args...);                    \
+    });                                                                                       \
+  })
+
+      LAUNCH_VARINT_BATCH(0, int32_t, false);
+      LAUNCH_VARINT_BATCH(1, uint32_t, false);
+      LAUNCH_VARINT_BATCH(2, int64_t, false);
+      LAUNCH_VARINT_BATCH(3, uint64_t, false);
+      LAUNCH_VARINT_BATCH(4, uint8_t, false);
+      LAUNCH_VARINT_BATCH(5, int32_t, true);
+      LAUNCH_VARINT_BATCH(6, int64_t, true);
+      LAUNCH_FIXED_BATCH(7, float, wire_type_value(proto_wire_type::I32BIT));
+      LAUNCH_FIXED_BATCH(8, double, wire_type_value(proto_wire_type::I64BIT));
+      LAUNCH_FIXED_BATCH(9, int32_t, wire_type_value(proto_wire_type::I32BIT));
+      LAUNCH_FIXED_BATCH(10, int64_t, wire_type_value(proto_wire_type::I64BIT));
+
+#undef LAUNCH_VARINT_BATCH
+#undef LAUNCH_FIXED_BATCH
+
+      // Per-field fallback (INT32 with enum, etc.)
+      for (int i : group_lists[GRP_FALLBACK]) {
+        int schema_idx        = scalar_field_indices[i];
+        auto const field_meta = make_field_meta_view(context, schema_idx);
+        auto const dt         = field_meta.output_type;
+        auto const enc        = static_cast<int>(field_meta.schema.encoding);
+        bool has_def          = field_meta.schema.has_default_value;
+        top_level_location_provider loc_provider{
+          list_offsets, base_offset, d_locations.data(), i, num_scalar};
+        column_map[schema_idx] = extract_typed_column(dt,
+                                                      enc,
+                                                      message_data,
+                                                      loc_provider,
+                                                      num_rows,
+                                                      blocks,
+                                                      threads,
+                                                      has_def,
+                                                      has_def ? field_meta.default_int : 0,
+                                                      has_def ? field_meta.default_float : 0.0,
+                                                      has_def ? field_meta.default_bool : false,
+                                                      field_meta.default_string,
+                                                      schema_idx,
+                                                      enum_valid_values,
+                                                      enum_names,
+                                                      d_row_force_null,
+                                                      d_error,
+                                                      stream,
+                                                      mr);
+      }
+    }
+
+    // Per-field extraction for STRING and LIST types
+    for (int i = 0; i < num_scalar; i++) {
+      int schema_idx        = scalar_field_indices[i];
+      auto const field_meta = make_field_meta_view(context, schema_idx);
+      auto const dt         = field_meta.output_type;
+      if (dt.id() != cudf::type_id::STRING && dt.id() != cudf::type_id::LIST) { continue; }
+      auto const enc = field_meta.schema.encoding;
+      bool has_def   = field_meta.schema.has_default_value;
+
+      switch (dt.id()) {
+        case cudf::type_id::STRING: {
+          if (enc == proto_encoding::ENUM_STRING) {
+            // ENUM-as-string path:
+            // 1. Decode enum numeric value as INT32 varint.
+            // 2. Validate against enum_valid_values.
+            // 3. Convert INT32 -> UTF-8 enum name bytes.
+            rmm::device_uvector<int32_t> out(num_rows, stream, mr);
+            rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
+            int64_t def_int = has_def ? field_meta.default_int : 0;
+            top_level_location_provider loc_provider{
+              list_offsets, base_offset, d_locations.data(), i, num_scalar};
+            extract_varint_kernel<int32_t, false, top_level_location_provider>
+              <<<blocks, threads, 0, stream.value()>>>(message_data,
+                                                       loc_provider,
+                                                       num_rows,
+                                                       out.data(),
+                                                       valid.data(),
+                                                       d_error.data(),
+                                                       has_def,
+                                                       def_int);
+
+            if (schema_idx < static_cast<int>(enum_valid_values.size()) &&
+                schema_idx < static_cast<int>(enum_names.size())) {
+              auto const& valid_enums     = enum_valid_values[schema_idx];
+              auto const& enum_name_bytes = enum_names[schema_idx];
+              if (!valid_enums.empty() && valid_enums.size() == enum_name_bytes.size()) {
+                column_map[schema_idx] = build_enum_string_column(
+                  out, valid, valid_enums, enum_name_bytes, d_row_force_null, num_rows, stream, mr);
+              } else {
+                // Missing enum metadata for enum-as-string field; mark as decode error.
+                set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+                column_map[schema_idx] = make_null_column(dt, num_rows, stream, mr);
+              }
+            } else {
+              set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+              column_map[schema_idx] = make_null_column(dt, num_rows, stream, mr);
+            }
+          } else {
+            // Regular protobuf STRING (length-delimited)
+            bool has_def_str    = has_def;
+            auto const& def_str = field_meta.default_string;
+            top_level_location_provider len_provider{
+              list_offsets, base_offset, d_locations.data(), i, num_scalar};
+            top_level_location_provider copy_provider{
+              list_offsets, base_offset, d_locations.data(), i, num_scalar};
+            auto valid_fn = [locs = d_locations.data(), i, num_scalar, has_def_str] __device__(
+                              cudf::size_type row) {
+              return locs[flat_index(static_cast<size_t>(row),
+                                     static_cast<size_t>(num_scalar),
+                                     static_cast<size_t>(i))]
+                         .offset >= 0 ||
+                     has_def_str;
+            };
+            column_map[schema_idx] = extract_and_build_string_or_bytes_column(false,
+                                                                              message_data,
+                                                                              num_rows,
+                                                                              len_provider,
+                                                                              copy_provider,
+                                                                              valid_fn,
+                                                                              has_def_str,
+                                                                              def_str,
+                                                                              d_error,
+                                                                              stream,
+                                                                              mr);
+          }
+          break;
+        }
+        case cudf::type_id::LIST: {
+          // bytes (BinaryType) represented as LIST<UINT8>
+          bool has_def_bytes    = has_def;
+          auto const& def_bytes = field_meta.default_string;
+          top_level_location_provider len_provider{
+            list_offsets, base_offset, d_locations.data(), i, num_scalar};
+          top_level_location_provider copy_provider{
+            list_offsets, base_offset, d_locations.data(), i, num_scalar};
+          auto valid_fn = [locs = d_locations.data(), i, num_scalar, has_def_bytes] __device__(
+                            cudf::size_type row) {
+            return locs[flat_index(static_cast<size_t>(row),
+                                   static_cast<size_t>(num_scalar),
+                                   static_cast<size_t>(i))]
+                       .offset >= 0 ||
+                   has_def_bytes;
+          };
+          column_map[schema_idx] = extract_and_build_string_or_bytes_column(true,
+                                                                            message_data,
+                                                                            num_rows,
+                                                                            len_provider,
+                                                                            copy_provider,
+                                                                            valid_fn,
+                                                                            has_def_bytes,
+                                                                            def_bytes,
+                                                                            d_error,
+                                                                            stream,
+                                                                            mr);
+          break;
+        }
+        default:
+          // For LIST (bytes) and other unsupported types, create placeholder columns
+          column_map[schema_idx] = make_null_column(dt, num_rows, stream, mr);
+          break;
+      }
+    }
+  }
+
+  // Assemble top_level_children in schema order (not processing order)
   std::vector<std::unique_ptr<cudf::column>> top_level_children;
   for (int i = 0; i < num_fields; i++) {
     if (schema[i].parent_idx == -1) {
@@ -321,15 +852,47 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     }
   }
 
-  auto const input_null_count = binary_input.null_count();
-  if (input_null_count > 0) {
-    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
-    return cudf::make_structs_column(
-      num_rows, std::move(top_level_children), input_null_count, std::move(null_mask), stream, mr);
+  CUDF_CUDA_TRY(cudaPeekAtLastError());
+  int h_error = 0;
+  CUDF_CUDA_TRY(
+    cudaMemcpyAsync(&h_error, d_error.data(), sizeof(int), cudaMemcpyDeviceToHost, stream.value()));
+  stream.synchronize();
+  if (h_error == ERR_SCHEMA_TOO_LARGE || h_error == ERR_REPEATED_COUNT_MISMATCH) {
+    throw cudf::logic_error(error_message(h_error));
+  }
+  if (fail_on_errors && h_error != 0) throw cudf::logic_error(error_message(h_error));
+
+  // Build final struct with PERMISSIVE mode null mask for invalid enums
+  cudf::size_type struct_null_count = 0;
+  rmm::device_buffer struct_mask{0, stream, mr};
+
+  if (track_permissive_null_rows) {
+    auto [mask, null_count] = cudf::detail::valid_if(
+      thrust::make_counting_iterator<cudf::size_type>(0),
+      thrust::make_counting_iterator<cudf::size_type>(num_rows),
+      [row_invalid = d_row_force_null.data()] __device__(cudf::size_type row) {
+        return !row_invalid[row];
+      },
+      stream,
+      mr);
+    struct_mask       = std::move(mask);
+    struct_null_count = null_count;
+  }
+
+  // cuDF child views do not automatically inherit parent nulls. Push PERMISSIVE invalid-enum
+  // nulls down into every top-level child, then recursively through nested STRUCT/LIST children,
+  // so callers that access backing grandchildren directly still observe logically-null rows.
+  if (track_permissive_null_rows && struct_null_count > 0) {
+    auto const* struct_mask_ptr = static_cast<cudf::bitmask_type const*>(struct_mask.data());
+    for (auto& child : top_level_children) {
+      apply_parent_mask_to_row_aligned_column(
+        *child, struct_mask_ptr, struct_null_count, num_rows, stream, mr);
+      propagate_nulls_to_descendants(*child, stream, mr);
+    }
   }
 
   return cudf::make_structs_column(
-    num_rows, std::move(top_level_children), 0, rmm::device_buffer{}, stream, mr);
+    num_rows, std::move(top_level_children), struct_null_count, std::move(struct_mask), stream, mr);
 }
 
 }  // namespace detail

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -862,26 +862,18 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   }
   if (fail_on_errors && h_error != 0) throw cudf::logic_error(error_message(h_error));
 
-  // Build final struct null mask by combining input nulls with PERMISSIVE-mode row invalidation.
+  // Build final struct null mask from PERMISSIVE-mode row invalidation.
+  // Note: input null mask is NOT merged here — the Scala/Java caller handles input-row-level
+  // nulls via mergeAndSetValidity after the JNI call returns.
   cudf::size_type struct_null_count = 0;
   rmm::device_buffer struct_mask{0, stream, mr};
-  auto const input_null_count = binary_input.null_count();
 
-  if (track_permissive_null_rows || input_null_count > 0) {
-    auto const* input_mask = binary_input.null_mask();
-    auto input_offset      = binary_input.offset();
+  if (track_permissive_null_rows) {
     auto [mask, null_count] = cudf::detail::valid_if(
       thrust::make_counting_iterator<cudf::size_type>(0),
       thrust::make_counting_iterator<cudf::size_type>(num_rows),
-      [row_invalid    = track_permissive_null_rows ? d_row_force_null.data() : nullptr,
-       input_mask,
-       input_offset] __device__(cudf::size_type row) {
-        if (input_mask != nullptr &&
-            !cudf::bit_is_set(input_mask, input_offset + row)) {
-          return false;
-        }
-        if (row_invalid != nullptr && row_invalid[row]) { return false; }
-        return true;
+      [row_invalid = d_row_force_null.data()] __device__(cudf::size_type row) {
+        return !row_invalid[row];
       },
       stream,
       mr);
@@ -889,10 +881,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     struct_null_count = null_count;
   }
 
-  // cuDF child views do not automatically inherit parent nulls. Push nulls down into every
-  // top-level child, then recursively through nested STRUCT/LIST children, so callers that
+  // cuDF child views do not automatically inherit parent nulls. Push PERMISSIVE nulls down into
+  // every top-level child, then recursively through nested STRUCT/LIST children, so callers that
   // access backing grandchildren directly still observe logically-null rows.
-  if (struct_null_count > 0) {
+  if (track_permissive_null_rows && struct_null_count > 0) {
     auto const* struct_mask_ptr = static_cast<cudf::bitmask_type const*>(struct_mask.data());
     for (auto& child : top_level_children) {
       apply_parent_mask_to_row_aligned_column(

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -418,7 +418,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   int num_scalar = static_cast<int>(scalar_field_indices.size());
 
   // Error flag
-  rmm::device_uvector<int> d_error(1, stream, mr);
+  rmm::device_uvector<int> d_error(1, stream, cudf::get_current_device_resource_ref());
   CUDF_CUDA_TRY(cudaMemsetAsync(d_error.data(), 0, sizeof(int), stream.value()));
   auto error_message = [](int code) -> char const* {
     switch (code) {
@@ -448,7 +448,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   bool has_enum_fields = std::any_of(
     enum_valid_values.begin(), enum_valid_values.end(), [](auto const& v) { return !v.empty(); });
   bool track_permissive_null_rows = !fail_on_errors;
-  rmm::device_uvector<bool> d_row_force_null(track_permissive_null_rows ? num_rows : 0, stream, mr);
+  rmm::device_uvector<bool> d_row_force_null(
+    track_permissive_null_rows ? num_rows : 0, stream, cudf::get_current_device_resource_ref());
   if (track_permissive_null_rows) {
     CUDF_CUDA_TRY(
       cudaMemsetAsync(d_row_force_null.data(), 0, num_rows * sizeof(bool), stream.value()));
@@ -470,7 +471,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       h_field_descs[i].is_repeated        = false;
     }
 
-    rmm::device_uvector<field_descriptor> d_field_descs(num_scalar, stream, mr);
+    rmm::device_uvector<field_descriptor> d_field_descs(
+      num_scalar, stream, cudf::get_current_device_resource_ref());
     CUDF_CUDA_TRY(cudaMemcpyAsync(d_field_descs.data(),
                                   h_field_descs.data(),
                                   num_scalar * sizeof(field_descriptor),
@@ -478,10 +480,12 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                   stream.value()));
 
     rmm::device_uvector<field_location> d_locations(
-      static_cast<size_t>(num_rows) * num_scalar, stream, mr);
+      static_cast<size_t>(num_rows) * num_scalar, stream,
+      cudf::get_current_device_resource_ref());
 
     auto h_field_lookup = build_field_lookup_table(h_field_descs.data(), num_scalar);
-    rmm::device_uvector<int> d_field_lookup(h_field_lookup.size(), stream, mr);
+    rmm::device_uvector<int> d_field_lookup(
+      h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
       CUDF_CUDA_TRY(cudaMemcpyAsync(d_field_lookup.data(),
                                     h_field_lookup.data(),
@@ -596,7 +600,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           int si   = scalar_field_indices[li];
           bool hd  = schema[si].has_default_value;
           auto& bp = *bufs.emplace_back(std::make_unique<scalar_buf_pair>(stream, mr));
-          bp.valid = rmm::device_uvector<bool>(std::max(1, num_rows), stream, mr);
+          bp.valid = rmm::device_uvector<bool>(
+            std::max(1, num_rows), stream, cudf::get_current_device_resource_ref());
           // BOOL8 default comes from default_bools (converted to 0/1 int)
           bool is_bool  = (cudf::data_type{schema[si].output_type}.id() == cudf::type_id::BOOL8);
           int64_t def_i = hd ? (is_bool ? (default_bools[si] ? 1 : 0) : default_ints[si]) : 0;
@@ -627,7 +632,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           bufs[j]->out_bytes = rmm::device_uvector<uint8_t>(num_rows * elem_size, stream, mr);
           h_descs[j].output  = bufs[j]->out_bytes.data();
         }
-        rmm::device_uvector<batched_scalar_desc> d_descs(nf, stream, mr);
+        rmm::device_uvector<batched_scalar_desc> d_descs(
+          nf, stream, cudf::get_current_device_resource_ref());
         CUDF_CUDA_TRY(cudaMemcpyAsync(d_descs.data(),
                                       h_descs.data(),
                                       nf * sizeof(h_descs[0]),
@@ -725,8 +731,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
             // 1. Decode enum numeric value as INT32 varint.
             // 2. Validate against enum_valid_values.
             // 3. Convert INT32 -> UTF-8 enum name bytes.
-            rmm::device_uvector<int32_t> out(num_rows, stream, mr);
-            rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
+            rmm::device_uvector<int32_t> out(
+              num_rows, stream, cudf::get_current_device_resource_ref());
+            rmm::device_uvector<bool> valid(
+              (num_rows > 0 ? num_rows : 1), stream, cudf::get_current_device_resource_ref());
             int64_t def_int = has_def ? field_meta.default_int : 0;
             top_level_location_provider loc_provider{
               list_offsets, base_offset, d_locations.data(), i, num_scalar};

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -480,8 +480,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                   stream.value()));
 
     rmm::device_uvector<field_location> d_locations(
-      static_cast<size_t>(num_rows) * num_scalar, stream,
-      cudf::get_current_device_resource_ref());
+      static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
 
     auto h_field_lookup = build_field_lookup_table(h_field_descs.data(), num_scalar);
     rmm::device_uvector<int> d_field_lookup(

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -123,4 +123,132 @@ std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::colum
     0, std::move(offsets_col), std::move(element_col), 0, rmm::device_buffer{});
 }
 
+// ============================================================================
+// Enum-as-string column builders
+// ============================================================================
+
+struct enum_string_lookup_tables {
+  rmm::device_uvector<int32_t> d_valid_enums;
+  rmm::device_uvector<int32_t> d_name_offsets;
+  rmm::device_uvector<uint8_t> d_name_chars;
+};
+
+enum_string_lookup_tables make_enum_string_lookup_tables(
+  cudf::detail::host_vector<int32_t> const& valid_enums,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto d_valid_enums = cudf::detail::make_device_uvector_async(
+    valid_enums, stream, cudf::get_current_device_resource_ref());
+
+  auto h_name_offsets =
+    cudf::detail::make_pinned_vector_async<int32_t>(valid_enums.size() + 1, stream);
+  std::fill(h_name_offsets.begin(), h_name_offsets.end(), 0);
+  int64_t total_name_chars = 0;
+  for (size_t k = 0; k < enum_name_bytes.size(); ++k) {
+    total_name_chars += static_cast<int64_t>(enum_name_bytes[k].size());
+    CUDF_EXPECTS(total_name_chars <= std::numeric_limits<int32_t>::max(),
+                 "Enum name data exceeds 2 GB limit");
+    h_name_offsets[k + 1] = static_cast<int32_t>(total_name_chars);
+  }
+
+  auto h_name_chars = cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream);
+  int32_t cursor    = 0;
+  for (auto const& name : enum_name_bytes) {
+    if (!name.empty()) {
+      std::copy(name.data(), name.data() + name.size(), h_name_chars.data() + cursor);
+      cursor += static_cast<int32_t>(name.size());
+    }
+  }
+
+  auto d_name_offsets = cudf::detail::make_device_uvector_async(
+    h_name_offsets, stream, cudf::get_current_device_resource_ref());
+
+  auto d_name_chars = [&]() {
+    if (total_name_chars > 0) {
+      return cudf::detail::make_device_uvector_async(
+        h_name_chars, stream, cudf::get_current_device_resource_ref());
+    }
+    return rmm::device_uvector<uint8_t>(0, stream, mr);
+  }();
+
+  return {std::move(d_valid_enums), std::move(d_name_offsets), std::move(d_name_chars)};
+}
+
+std::unique_ptr<cudf::column> build_enum_string_values_column(
+  rmm::device_uvector<int32_t>& enum_values,
+  rmm::device_uvector<bool>& valid,
+  enum_string_lookup_tables const& lookup,
+  int num_rows,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  rmm::device_uvector<int32_t> lengths(num_rows, stream, mr);
+  launch_compute_enum_string_lengths(enum_values.data(),
+                                     valid.data(),
+                                     lookup.d_valid_enums.data(),
+                                     lookup.d_name_offsets.data(),
+                                     static_cast<int>(lookup.d_valid_enums.size()),
+                                     lengths.data(),
+                                     num_rows,
+                                     stream);
+
+  auto [offsets_col, total_chars] =
+    cudf::strings::detail::make_offsets_child_column(lengths.begin(), lengths.end(), stream, mr);
+
+  rmm::device_uvector<char> chars(total_chars, stream, mr);
+  if (total_chars > 0) {
+    launch_copy_enum_string_chars(enum_values.data(),
+                                  valid.data(),
+                                  lookup.d_valid_enums.data(),
+                                  lookup.d_name_offsets.data(),
+                                  lookup.d_name_chars.data(),
+                                  static_cast<int>(lookup.d_valid_enums.size()),
+                                  offsets_col->view().data<int32_t>(),
+                                  chars.data(),
+                                  num_rows,
+                                  stream);
+  }
+
+  auto [mask, null_count] = make_null_mask_from_valid(valid, stream, mr);
+  return cudf::make_strings_column(
+    num_rows, std::move(offsets_col), chars.release(), null_count, std::move(mask));
+}
+
+std::unique_ptr<cudf::column> build_enum_string_column(
+  rmm::device_uvector<int32_t>& enum_values,
+  rmm::device_uvector<bool>& valid,
+  cudf::detail::host_vector<int32_t> const& valid_enums,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  rmm::device_uvector<bool>& d_row_force_null,
+  int num_rows,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr,
+  int32_t const* top_row_indices,
+  bool propagate_invalid_rows)
+{
+  auto lookup = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+  rmm::device_uvector<bool> d_item_has_invalid_enum(num_rows, stream, mr);
+  thrust::fill(rmm::exec_policy_nosync(stream),
+               d_item_has_invalid_enum.begin(),
+               d_item_has_invalid_enum.end(),
+               false);
+
+  launch_validate_enum_values(enum_values.data(),
+                              valid.data(),
+                              d_item_has_invalid_enum.data(),
+                              lookup.d_valid_enums.data(),
+                              static_cast<int>(valid_enums.size()),
+                              num_rows,
+                              stream);
+  propagate_invalid_enum_flags_to_rows(d_item_has_invalid_enum,
+                                       d_row_force_null,
+                                       num_rows,
+                                       top_row_indices,
+                                       propagate_invalid_rows,
+                                       stream);
+  return build_enum_string_values_column(enum_values, valid, lookup, num_rows, stream, mr);
+}
+
 }  // namespace spark_rapids_jni::protobuf::detail

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -170,7 +170,7 @@ enum_string_lookup_tables make_enum_string_lookup_tables(
       return cudf::detail::make_device_uvector_async(
         h_name_chars, stream, cudf::get_current_device_resource_ref());
     }
-    return rmm::device_uvector<uint8_t>(0, stream, mr);
+    return rmm::device_uvector<uint8_t>(0, stream, cudf::get_current_device_resource_ref());
   }();
 
   return {std::move(d_valid_enums), std::move(d_name_offsets), std::move(d_name_chars)};
@@ -184,7 +184,7 @@ std::unique_ptr<cudf::column> build_enum_string_values_column(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  rmm::device_uvector<int32_t> lengths(num_rows, stream, mr);
+  rmm::device_uvector<int32_t> lengths(num_rows, stream, cudf::get_current_device_resource_ref());
   launch_compute_enum_string_lengths(enum_values.data(),
                                      valid.data(),
                                      lookup.d_valid_enums.data(),
@@ -229,7 +229,8 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   bool propagate_invalid_rows)
 {
   auto lookup = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
-  rmm::device_uvector<bool> d_item_has_invalid_enum(num_rows, stream, mr);
+  rmm::device_uvector<bool> d_item_has_invalid_enum(
+    num_rows, stream, cudf::get_current_device_resource_ref());
   thrust::fill(rmm::exec_policy_nosync(stream),
                d_item_has_invalid_enum.begin(),
                d_item_has_invalid_enum.end(),

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -98,6 +98,20 @@ std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::colum
                                                      rmm::cuda_stream_view stream,
                                                      rmm::device_async_resource_ref mr);
 
+/**
+ * Extract output type from either nested_field_descriptor (.output_type is cudf::type_id)
+ * or device_nested_field_descriptor (.output_type_id is int).
+ */
+template <typename FieldT>
+inline cudf::type_id get_output_type_id(FieldT const& field)
+{
+  if constexpr (std::is_same_v<FieldT, device_nested_field_descriptor>) {
+    return static_cast<cudf::type_id>(field.output_type_id);
+  } else {
+    return field.output_type;
+  }
+}
+
 template <typename SchemaT>
 std::unique_ptr<cudf::column> make_empty_struct_column_with_schema(
   SchemaT const& schema,
@@ -110,7 +124,7 @@ std::unique_ptr<cudf::column> make_empty_struct_column_with_schema(
 
   std::vector<std::unique_ptr<cudf::column>> children;
   for (int child_idx : child_indices) {
-    auto child_type = cudf::data_type{schema[child_idx].output_type};
+    auto child_type = cudf::data_type{get_output_type_id(schema[child_idx])};
 
     std::unique_ptr<cudf::column> child_col;
     if (child_type.id() == cudf::type_id::STRUCT) {

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -17,6 +17,7 @@
 #include "protobuf/protobuf_kernels.cuh"
 
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/lists/lists_column_device_view.cuh>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -31,35 +32,403 @@ namespace spark_rapids_jni::protobuf::detail {
 
 namespace {
 
+// ============================================================================
+// Pass 1: Scan all fields kernel - records (offset, length) for each field
+// ============================================================================
+
 CUDF_KERNEL void set_error_if_unset_kernel(int* error_flag, int error_code)
 {
   if (blockIdx.x == 0 && threadIdx.x == 0) { set_error_once(error_flag, error_code); }
 }
 
-// Stub kernels — replaced with real implementations in follow-up PRs.
-CUDF_KERNEL void check_required_fields_kernel(field_location const*,
-                                              uint8_t const*,
-                                              int,
-                                              int,
-                                              cudf::bitmask_type const*,
-                                              cudf::size_type,
-                                              field_location const*,
-                                              bool*,
-                                              int32_t const*,
-                                              int*)
+/**
+ * Fused scanning kernel: scans each message once and records the location
+ * of all requested fields.
+ *
+ * For "last one wins" semantics (protobuf standard for repeated scalars),
+ * we continue scanning even after finding a field.
+ *
+ * If a row hits a parse error that leaves the cursor in an unsafe state (for example, malformed
+ * varint bytes or a schema-matching field with the wrong wire type), the scan aborts for that row
+ * instead of guessing where the next field begins. In permissive mode the caller may also supply a
+ * row-level invalidity buffer so the full struct row can be nulled to match Spark CPU semantics for
+ * malformed messages.
+ */
+CUDF_KERNEL void scan_all_fields_kernel(
+  cudf::column_device_view const d_in,
+  field_descriptor const* field_descs,  // [num_fields]
+  int num_fields,
+  int const* field_lookup,              // direct-mapped lookup table (nullable)
+  int field_lookup_size,                // size of lookup table (0 if null)
+  field_location* locations,            // [num_rows * num_fields] row-major
+  int* error_flag,
+  bool* row_has_invalid_data)
 {
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  cudf::detail::lists_column_device_view in{d_in};
+  if (row >= in.size()) { return; }
+
+  auto mark_row_error = [&]() {
+    if (row_has_invalid_data != nullptr) { row_has_invalid_data[row] = true; }
+  };
+
+  for (int f = 0; f < num_fields; f++) {
+    locations[flat_index(
+      static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(f))] = {-1, 0};
+  }
+
+  if (in.nullable() && in.is_null(row)) { return; }
+
+  auto const base   = in.offset_at(0);
+  auto const child  = in.get_sliced_child();
+  auto const* bytes = reinterpret_cast<uint8_t const*>(child.data<int8_t>());
+  int32_t start     = in.offset_at(row) - base;
+  int32_t end       = in.offset_at(row + 1) - base;
+
+  if (!check_message_bounds(start, end, child.size(), error_flag)) {
+    mark_row_error();
+    return;
+  }
+
+  uint8_t const* cur     = bytes + start;
+  uint8_t const* msg_end = bytes + end;
+
+  while (cur < msg_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, msg_end, tag, error_flag)) {
+      mark_row_error();
+      return;
+    }
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    int f = lookup_field(fn, field_lookup, field_lookup_size, field_descs, num_fields);
+    if (f >= 0) {
+      if (wt != field_descs[f].expected_wire_type) {
+        set_error_once(error_flag, ERR_WIRE_TYPE);
+        mark_row_error();
+        return;
+      }
+
+      // Record the location (relative to message start)
+      int data_offset = static_cast<int>(cur - bytes - start);
+
+      if (wt == wire_type_value(proto_wire_type::LEN)) {
+        // For length-delimited, record offset after length prefix and the data length
+        uint64_t len;
+        int len_bytes;
+        if (!read_varint(cur, msg_end, len, len_bytes)) {
+          set_error_once(error_flag, ERR_VARINT);
+          mark_row_error();
+          return;
+        }
+        if (len > static_cast<uint64_t>(msg_end - cur - len_bytes) ||
+            len > static_cast<uint64_t>(cuda::std::numeric_limits<int>::max())) {
+          set_error_once(error_flag, ERR_OVERFLOW);
+          mark_row_error();
+          return;
+        }
+        // Record offset pointing to the actual data (after length prefix)
+        int32_t data_location;
+        if (!checked_add_int32(data_offset, len_bytes, data_location)) {
+          set_error_once(error_flag, ERR_OVERFLOW);
+          mark_row_error();
+          return;
+        }
+        locations[flat_index(
+          static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(f))] = {
+          data_location, static_cast<int32_t>(len)};
+      } else {
+        // For fixed-size and varint fields, record offset and compute length
+        int field_size = get_wire_type_size(wt, cur, msg_end);
+        if (field_size < 0) {
+          set_error_once(error_flag, ERR_FIELD_SIZE);
+          mark_row_error();
+          return;
+        }
+        locations[flat_index(
+          static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(f))] = {
+          data_offset, field_size};
+      }
+    }
+
+    // Skip to next field
+    uint8_t const* next;
+    if (!skip_field(cur, msg_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      mark_row_error();
+      return;
+    }
+    cur = next;
+  }
 }
 
-CUDF_KERNEL void validate_enum_values_kernel(int32_t const*, bool*, bool*, int32_t const*, int, int)
+// ============================================================================
+// Kernel to check required fields after scan pass
+// ============================================================================
+
+/**
+ * Check if any required fields are missing (offset < 0) and set error flag.
+ * This is called after the scan pass to validate required field constraints.
+ */
+CUDF_KERNEL void check_required_fields_kernel(
+  field_location const* locations,  // [num_rows * num_fields]
+  uint8_t const* is_required,       // [num_fields] (1 = required, 0 = optional)
+  int num_fields,
+  int num_rows,
+  cudf::bitmask_type const* input_null_mask,  // optional top-level input null mask
+  cudf::size_type input_offset,               // bit offset for sliced top-level input
+  field_location const* parent_locs,          // [num_rows] optional parent presence for nested rows
+  bool* row_force_null,            // [top_level_num_rows] optional permissive row nulling
+  int32_t const* top_row_indices,  // [num_rows] optional nested-row -> top-row mapping
+  int* error_flag)
 {
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_rows) return;
+  if (input_null_mask != nullptr && !cudf::bit_is_set(input_null_mask, row + input_offset)) {
+    return;
+  }
+  if (parent_locs != nullptr && parent_locs[row].offset < 0) return;
+
+  for (int f = 0; f < num_fields; f++) {
+    if (is_required[f] != 0 && locations[flat_index(static_cast<size_t>(row),
+                                                    static_cast<size_t>(num_fields),
+                                                    static_cast<size_t>(f))]
+                                   .offset < 0) {
+      if (row_force_null != nullptr) {
+        auto const top_row =
+          top_row_indices != nullptr ? top_row_indices[row] : static_cast<int32_t>(row);
+        row_force_null[top_row] = true;
+      }
+      // Required field is missing - set error flag
+      set_error_once(error_flag, ERR_REQUIRED);
+      return;  // No need to check other fields for this row
+    }
+  }
 }
 
-}  // namespace
+/**
+ * Validate enum values against a set of valid values.
+ * If a value is not in the valid set:
+ * 1. Mark the field as invalid (valid[row] = false)
+ * 2. Mark the row as having an invalid enum (row_has_invalid_enum[row] = true)
+ *
+ * This matches Spark CPU PERMISSIVE mode behavior: when an unknown enum value is
+ * encountered, the entire struct row is set to null (not just the enum field).
+ *
+ * The valid_values array must be sorted for binary search.
+ *
+ * @note Time complexity: O(log(num_valid_values)) per row.
+ */
+CUDF_KERNEL void validate_enum_values_kernel(
+  int32_t const* values,             // [num_rows] extracted enum values
+  bool* valid,                       // [num_rows] field validity flags (will be modified)
+  bool* row_has_invalid_enum,        // [num_rows] row-level invalid enum flag (will be set to true)
+  int32_t const* valid_enum_values,  // sorted array of valid enum values
+  int num_valid_values,              // size of valid_enum_values
+  int num_rows)
+{
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_rows) return;
+
+  // Skip if already invalid (field was missing) - missing field is not an enum error
+  if (!valid[row]) return;
+
+  int32_t val = values[row];
+
+  // Binary search for the value in valid_enum_values
+  int left   = 0;
+  int right  = num_valid_values - 1;
+  bool found = false;
+
+  while (left <= right) {
+    int mid = left + (right - left) / 2;
+    if (valid_enum_values[mid] == val) {
+      found = true;
+      break;
+    } else if (valid_enum_values[mid] < val) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+
+  // If not found, mark as invalid
+  if (!found) {
+    valid[row] = false;
+    // Also mark the row as having an invalid enum - this will null the entire struct row
+    row_has_invalid_enum[row] = true;
+  }
+}
+
+/**
+ * Compute output UTF-8 length for enum-as-string rows.
+ * Invalid/missing values produce length 0 (null row/field semantics handled by valid[] and
+ * row_has_invalid_enum).
+ */
+CUDF_KERNEL void compute_enum_string_lengths_kernel(
+  int32_t const* values,             // [num_rows] enum numeric values
+  bool const* valid,                 // [num_rows] field validity
+  int32_t const* valid_enum_values,  // sorted enum numeric values
+  int32_t const* enum_name_offsets,  // [num_valid_values + 1]
+  int num_valid_values,
+  int32_t* lengths,                  // [num_rows]
+  int num_rows)
+{
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_rows) return;
+
+  if (!valid[row]) {
+    lengths[row] = 0;
+    return;
+  }
+
+  int32_t val = values[row];
+  int left    = 0;
+  int right   = num_valid_values - 1;
+  while (left <= right) {
+    int mid         = left + (right - left) / 2;
+    int32_t mid_val = valid_enum_values[mid];
+    if (mid_val == val) {
+      lengths[row] = enum_name_offsets[mid + 1] - enum_name_offsets[mid];
+      return;
+    } else if (mid_val < val) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+
+  // Should not happen when validate_enum_values_kernel has already run, but keep safe.
+  lengths[row] = 0;
+}
+
+/**
+ * Copy enum-as-string UTF-8 bytes into output chars buffer using precomputed row offsets.
+ */
+CUDF_KERNEL void copy_enum_string_chars_kernel(
+  int32_t const* values,             // [num_rows] enum numeric values
+  bool const* valid,                 // [num_rows] field validity
+  int32_t const* valid_enum_values,  // sorted enum numeric values
+  int32_t const* enum_name_offsets,  // [num_valid_values + 1]
+  uint8_t const* enum_name_chars,    // concatenated enum UTF-8 names
+  int num_valid_values,
+  int32_t const* output_offsets,     // [num_rows + 1]
+  char* out_chars,                   // [total_chars]
+  int num_rows)
+{
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_rows) return;
+  if (!valid[row]) return;
+
+  int32_t val = values[row];
+  int left    = 0;
+  int right   = num_valid_values - 1;
+  while (left <= right) {
+    int mid         = left + (right - left) / 2;
+    int32_t mid_val = valid_enum_values[mid];
+    if (mid_val == val) {
+      int32_t src_begin = enum_name_offsets[mid];
+      int32_t src_end   = enum_name_offsets[mid + 1];
+      int32_t dst_begin = output_offsets[row];
+      memcpy(out_chars + dst_begin,
+             enum_name_chars + src_begin,
+             static_cast<size_t>(src_end - src_begin));
+      return;
+    } else if (mid_val < val) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+}
+
+}  // anonymous namespace
+
+// ============================================================================
+// Host wrapper functions — callable from other translation units
+// ============================================================================
 
 void set_error_once_async(int* error_flag, int error_code, rmm::cuda_stream_view stream)
 {
   set_error_if_unset_kernel<<<1, 1, 0, stream.value()>>>(error_flag, error_code);
   CUDF_CUDA_TRY(cudaPeekAtLastError());
+}
+
+void launch_scan_all_fields(cudf::column_device_view const& d_in,
+                            field_descriptor const* field_descs,
+                            int num_fields,
+                            int const* field_lookup,
+                            int field_lookup_size,
+                            field_location* locations,
+                            int* error_flag,
+                            bool* row_has_invalid_data,
+                            int num_rows,
+                            rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  scan_all_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(d_in,
+                                                                           field_descs,
+                                                                           num_fields,
+                                                                           field_lookup,
+                                                                           field_lookup_size,
+                                                                           locations,
+                                                                           error_flag,
+                                                                           row_has_invalid_data);
+}
+
+void launch_validate_enum_values(int32_t const* values,
+                                 bool* valid,
+                                 bool* row_has_invalid_enum,
+                                 int32_t const* valid_enum_values,
+                                 int num_valid_values,
+                                 int num_rows,
+                                 rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  validate_enum_values_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    values, valid, row_has_invalid_enum, valid_enum_values, num_valid_values, num_rows);
+}
+
+void launch_compute_enum_string_lengths(int32_t const* values,
+                                        bool const* valid,
+                                        int32_t const* valid_enum_values,
+                                        int32_t const* enum_name_offsets,
+                                        int num_valid_values,
+                                        int32_t* lengths,
+                                        int num_rows,
+                                        rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  compute_enum_string_lengths_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    values, valid, valid_enum_values, enum_name_offsets, num_valid_values, lengths, num_rows);
+}
+
+void launch_copy_enum_string_chars(int32_t const* values,
+                                   bool const* valid,
+                                   int32_t const* valid_enum_values,
+                                   int32_t const* enum_name_offsets,
+                                   uint8_t const* enum_name_chars,
+                                   int num_valid_values,
+                                   int32_t const* output_offsets,
+                                   char* out_chars,
+                                   int num_rows,
+                                   rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  copy_enum_string_chars_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(values,
+                                                                                  valid,
+                                                                                  valid_enum_values,
+                                                                                  enum_name_offsets,
+                                                                                  enum_name_chars,
+                                                                                  num_valid_values,
+                                                                                  output_offsets,
+                                                                                  out_chars,
+                                                                                  num_rows);
 }
 
 void maybe_check_required_fields(field_location const* locations,
@@ -109,7 +478,7 @@ void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_
                                           bool propagate_to_rows,
                                           rmm::cuda_stream_view stream)
 {
-  if (num_items == 0 || row_invalid.size() == 0 || !propagate_to_rows) { return; }
+  if (num_items == 0 || row_invalid.size() == 0 || !propagate_to_rows) return;
 
   if (top_row_indices == nullptr) {
     CUDF_EXPECTS(static_cast<size_t>(num_items) <= row_invalid.size(),
@@ -131,7 +500,7 @@ void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_
                    [item_invalid = item_invalid.data(),
                     top_row_indices,
                     row_invalid = row_invalid.data()] __device__(int idx) {
-                     if (item_invalid[idx]) { row_invalid[top_row_indices[idx]] = true; }
+                     if (item_invalid[idx]) row_invalid[top_row_indices[idx]] = true;
                    });
 }
 
@@ -144,7 +513,7 @@ void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values
                                       bool propagate_to_rows,
                                       rmm::cuda_stream_view stream)
 {
-  if (num_items == 0 || valid_enums.empty()) { return; }
+  if (num_items == 0 || valid_enums.empty()) return;
 
   auto const blocks  = static_cast<int>((num_items + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
   auto d_valid_enums = cudf::detail::make_device_uvector_async(

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -934,4 +934,47 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
     num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
 }
 
+// ============================================================================
+// Host wrapper declarations for kernel launches
+// ============================================================================
+
+void launch_scan_all_fields(cudf::column_device_view const& d_in,
+                            field_descriptor const* field_descs,
+                            int num_fields,
+                            int const* field_lookup,
+                            int field_lookup_size,
+                            field_location* locations,
+                            int* error_flag,
+                            bool* row_has_invalid_data,
+                            int num_rows,
+                            rmm::cuda_stream_view stream);
+
+void launch_validate_enum_values(int32_t const* values,
+                                 bool* valid,
+                                 bool* row_has_invalid_enum,
+                                 int32_t const* valid_enum_values,
+                                 int num_valid_values,
+                                 int num_rows,
+                                 rmm::cuda_stream_view stream);
+
+void launch_compute_enum_string_lengths(int32_t const* values,
+                                        bool const* valid,
+                                        int32_t const* valid_enum_values,
+                                        int32_t const* enum_name_offsets,
+                                        int num_valid_values,
+                                        int32_t* lengths,
+                                        int num_rows,
+                                        rmm::cuda_stream_view stream);
+
+void launch_copy_enum_string_chars(int32_t const* values,
+                                   bool const* valid,
+                                   int32_t const* valid_enum_values,
+                                   int32_t const* enum_name_offsets,
+                                   uint8_t const* enum_name_chars,
+                                   int num_valid_values,
+                                   int32_t const* output_offsets,
+                                   char* out_chars,
+                                   int num_rows,
+                                   rmm::cuda_stream_view stream);
+
 }  // namespace spark_rapids_jni::protobuf::detail

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -164,7 +164,8 @@ public class ProtobufTest {
     if (typeId == DType.LIST.getTypeId().getNativeId()) return Protobuf.WT_LEN;
     if (typeId == DType.STRUCT.getTypeId().getNativeId()) return Protobuf.WT_LEN;
     if (encoding == Protobuf.ENC_FIXED) {
-      if (typeId == DType.INT64.getTypeId().getNativeId()) return Protobuf.WT_64BIT;
+      if (typeId == DType.INT64.getTypeId().getNativeId()
+          || typeId == DType.UINT64.getTypeId().getNativeId()) return Protobuf.WT_64BIT;
       return Protobuf.WT_32BIT;
     }
     return Protobuf.WT_VARINT;

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -16,26 +16,120 @@
 
 package com.nvidia.spark.rapids.jni;
 
+import ai.rapids.cudf.AssertUtils;
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.ColumnView;
 import ai.rapids.cudf.DType;
 import ai.rapids.cudf.HostColumnVector;
+import ai.rapids.cudf.HostColumnVectorCore;
+import ai.rapids.cudf.HostColumnVector.*;
 import ai.rapids.cudf.Table;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
- * Tests for the Protobuf GPU decoder — framework PR.
+ * Tests for the Protobuf GPU decoder.
  *
- * These tests verify the decode stub: schema validation, correct output shape,
- * null column construction, and empty-row handling. Actual data extraction tests
- * are added in follow-up PRs.
+ * Test cases are inspired by Google's protobuf conformance test suite:
+ * https://github.com/protocolbuffers/protobuf/tree/main/conformance
  */
 public class ProtobufTest {
+
+  // ============================================================================
+  // Helper methods for encoding protobuf wire format
+  // ============================================================================
+
+  /** Encode a value as a varint (variable-length integer). */
+  private static byte[] encodeVarint(long value) {
+    long v = value;
+    byte[] tmp = new byte[10];
+    int idx = 0;
+    while ((v & ~0x7FL) != 0) {
+      tmp[idx++] = (byte) ((v & 0x7F) | 0x80);
+      v >>>= 7;
+    }
+    tmp[idx++] = (byte) (v & 0x7F);
+    byte[] out = new byte[idx];
+    System.arraycopy(tmp, 0, out, 0, idx);
+    return out;
+  }
+
+  /** ZigZag encode a signed 32-bit integer, returning as unsigned long for varint encoding. */
+  private static long zigzagEncode32(int n) {
+    return Integer.toUnsignedLong((n << 1) ^ (n >> 31));
+  }
+
+  /** ZigZag encode a signed 64-bit integer. */
+  private static long zigzagEncode64(long n) {
+    return (n << 1) ^ (n >> 63);
+  }
+
+  /** Encode a 32-bit value in little-endian (fixed32). */
+  private static byte[] encodeFixed32(int v) {
+    return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(v).array();
+  }
+
+  /** Encode a 64-bit value in little-endian (fixed64). */
+  private static byte[] encodeFixed64(long v) {
+    return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(v).array();
+  }
+
+  /** Encode a float in little-endian (fixed32 wire type). */
+  private static byte[] encodeFloat(float f) {
+    return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(f).array();
+  }
+
+  /** Encode a double in little-endian (fixed64 wire type). */
+  private static byte[] encodeDouble(double d) {
+    return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(d).array();
+  }
+
+  /** Create a protobuf tag (field number + wire type). */
+  private static byte[] tag(int fieldNumber, int wireType) {
+    return encodeVarint(((long) fieldNumber << 3) | wireType);
+  }
+
+  // Wire type constants
+  private static final int WT_VARINT = 0;
+  private static final int WT_64BIT = 1;
+  private static final int WT_LEN = 2;
+  private static final int WT_32BIT = 5;
+
+  private static Byte[] box(byte[] bytes) {
+    if (bytes == null) return null;
+    Byte[] out = new Byte[bytes.length];
+    for (int i = 0; i < bytes.length; i++) {
+      out[i] = bytes[i];
+    }
+    return out;
+  }
+
+  private static Byte[] concat(Byte[]... parts) {
+    int len = 0;
+    for (Byte[] p : parts) if (p != null) len += p.length;
+    Byte[] out = new Byte[len];
+    int pos = 0;
+    for (Byte[] p : parts) {
+      if (p != null) {
+        System.arraycopy(p, 0, out, pos, p.length);
+        pos += p.length;
+      }
+    }
+    return out;
+  }
+
+  // ============================================================================
+  // Helper methods for calling the unified API
+  // ============================================================================
 
   private static ProtobufSchemaDescriptor makeScalarSchema(int[] fieldNumbers, int[] typeIds,
                                                            int[] encodings) {
@@ -76,6 +170,310 @@ public class ProtobufTest {
     return Protobuf.WT_VARINT;
   }
 
+  /**
+   * Test-only convenience: wrap raw parallel arrays into a ProtobufSchemaDescriptor
+   * and decode. Avoids verbose ProtobufSchemaDescriptor construction at every call site.
+   */
+  private static ColumnVector decodeRaw(ColumnView binaryInput,
+                                        int[] fieldNumbers, int[] parentIndices, int[] depthLevels,
+                                        int[] wireTypes, int[] outputTypeIds, int[] encodings,
+                                        boolean[] isRepeated, boolean[] isRequired,
+                                        boolean[] hasDefaultValue, long[] defaultInts,
+                                        double[] defaultFloats, boolean[] defaultBools,
+                                        byte[][] defaultStrings, int[][] enumValidValues,
+                                        boolean failOnErrors) {
+    return decodeRaw(binaryInput, fieldNumbers, parentIndices, depthLevels,
+        wireTypes, outputTypeIds, encodings, isRepeated, isRequired,
+        hasDefaultValue, defaultInts, defaultFloats, defaultBools,
+        defaultStrings, enumValidValues, new byte[fieldNumbers.length][][], failOnErrors);
+  }
+
+  private static ColumnVector decodeRaw(ColumnView binaryInput,
+                                        int[] fieldNumbers, int[] parentIndices, int[] depthLevels,
+                                        int[] wireTypes, int[] outputTypeIds, int[] encodings,
+                                        boolean[] isRepeated, boolean[] isRequired,
+                                        boolean[] hasDefaultValue, long[] defaultInts,
+                                        double[] defaultFloats, boolean[] defaultBools,
+                                        byte[][] defaultStrings, int[][] enumValidValues,
+                                        byte[][][] enumNames,
+                                        boolean failOnErrors) {
+    return Protobuf.decodeToStruct(binaryInput,
+        new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
+            wireTypes, outputTypeIds, encodings, isRepeated, isRequired,
+            hasDefaultValue, defaultInts, defaultFloats, defaultBools,
+            defaultStrings, enumValidValues, enumNames),
+        failOnErrors);
+  }
+
+  /**
+   * Helper to decode all scalar fields using the unified API.
+   * Builds a flat schema (parentIndices=-1, depth=0, isRepeated=false for all fields).
+   */
+  private static ColumnVector decodeScalarFields(ColumnView binaryInput,
+                                                 int[] fieldNumbers,
+                                                 int[] typeIds,
+                                                 int[] encodings,
+                                                 boolean[] isRequired,
+                                                 boolean[] hasDefaultValue,
+                                                 long[] defaultInts,
+                                                 double[] defaultFloats,
+                                                 boolean[] defaultBools,
+                                                 byte[][] defaultStrings,
+                                                 int[][] enumValidValues,
+                                                 boolean failOnErrors) {
+    int numFields = fieldNumbers.length;
+    int[] parentIndices = new int[numFields];
+    int[] depthLevels = new int[numFields];
+    int[] wireTypes = new int[numFields];
+    boolean[] isRepeated = new boolean[numFields];
+
+    java.util.Arrays.fill(parentIndices, -1);
+    // depthLevels already initialized to 0
+    // isRepeated already initialized to false
+    for (int i = 0; i < numFields; i++) {
+      wireTypes[i] = deriveWireType(typeIds[i], encodings[i]);
+    }
+
+    return Protobuf.decodeToStruct(binaryInput,
+        new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
+            wireTypes, typeIds, encodings, isRepeated, isRequired, hasDefaultValue,
+            defaultInts, defaultFloats, defaultBools, defaultStrings, enumValidValues,
+            new byte[fieldNumbers.length][][]),
+        failOnErrors);
+  }
+
+  /**
+   * Helper method that wraps the unified API for tests that decode all scalar fields.
+   */
+  private static ColumnVector decodeAllFields(ColumnView binaryInput,
+                                              int[] fieldNumbers,
+                                              int[] typeIds,
+                                              int[] encodings) {
+    return decodeAllFields(binaryInput, fieldNumbers, typeIds, encodings, true);
+  }
+
+  /**
+   * Helper method that wraps the unified API for tests that decode all scalar fields.
+   */
+  private static ColumnVector decodeAllFields(ColumnView binaryInput,
+                                              int[] fieldNumbers,
+                                              int[] typeIds,
+                                              int[] encodings,
+                                              boolean failOnErrors) {
+    int numFields = fieldNumbers.length;
+    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
+        new boolean[numFields], new boolean[numFields], new long[numFields],
+        new double[numFields], new boolean[numFields], new byte[numFields][],
+        new int[numFields][], failOnErrors);
+  }
+
+  private static void assertSingleNullStructRow(ColumnVector actual, String message) {
+    try (HostColumnVector hostStruct = actual.copyToHost()) {
+      assertEquals(1, actual.getNullCount(), message);
+      assertTrue(hostStruct.isNull(0), "Row 0 should be null");
+    }
+  }
+
+  /**
+   * Helper method for tests with required field support.
+   */
+  private static ColumnVector decodeAllFieldsWithRequired(ColumnView binaryInput,
+                                                          int[] fieldNumbers,
+                                                          int[] typeIds,
+                                                          int[] encodings,
+                                                          boolean[] isRequired,
+                                                          boolean failOnErrors) {
+    int numFields = fieldNumbers.length;
+    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
+        isRequired, new boolean[numFields], new long[numFields],
+        new double[numFields], new boolean[numFields], new byte[numFields][],
+        new int[numFields][], failOnErrors);
+  }
+
+  // ============================================================================
+  // Basic Type Tests
+  // ============================================================================
+
+  @Test
+  void decodeVarintAndStringToStruct() {
+    // message Msg { int64 id = 1; string name = 2; }
+    // Row0: id=100, name="alice"
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(100)),
+        box(tag(2, WT_LEN)),
+        box(encodeVarint(5)),
+        box("alice".getBytes()));
+
+    // Row1: id=200, name missing
+    Byte[] row1 = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(200)));
+
+    // Row2: null input message
+    Byte[] row2 = null;
+
+    try (Table input = new Table.TestBuilder().column(row0, row1, row2).build();
+         ColumnVector expectedId = ColumnVector.fromBoxedLongs(100L, 200L, null);
+         ColumnVector expectedName = ColumnVector.fromStrings("alice", null, null);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedId, expectedName);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{0, 0})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void decodeMoreTypes() {
+    // message Msg { uint32 u32 = 1; sint64 s64 = 2; fixed32 f32 = 3; bytes b = 4; }
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(4000000000L)),
+        box(tag(2, WT_VARINT)),
+        box(encodeVarint(zigzagEncode64(-1234567890123L))),
+        box(tag(3, WT_32BIT)),
+        box(encodeFixed32(12345)),
+        box(tag(4, WT_LEN)),
+        box(encodeVarint(3)),
+        box(new byte[]{1, 2, 3}));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row0}).build();
+         ColumnVector expectedU32 = ColumnVector.fromBoxedLongs(4000000000L);
+         ColumnVector expectedS64 = ColumnVector.fromBoxedLongs(-1234567890123L);
+         ColumnVector expectedF32 = ColumnVector.fromBoxedInts(12345);
+         ColumnVector expectedB = ColumnVector.fromLists(
+            new ListType(true, new BasicType(true, DType.UINT8)),
+             Arrays.asList((byte) 1, (byte) 2, (byte) 3));
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2, 3, 4},
+             new int[]{
+                 DType.UINT32.getTypeId().getNativeId(),
+                 DType.INT64.getTypeId().getNativeId(),
+                 DType.INT32.getTypeId().getNativeId(),
+                 DType.LIST.getTypeId().getNativeId()},
+             new int[]{
+                 Protobuf.ENC_DEFAULT,
+                 Protobuf.ENC_ZIGZAG,
+                 Protobuf.ENC_FIXED,
+                 Protobuf.ENC_DEFAULT})) {
+      try (ColumnVector expectedU32Correct = expectedU32.castTo(DType.UINT32);
+           ColumnVector expectedStructCorrect = ColumnVector.makeStruct(
+               expectedU32Correct, expectedS64, expectedF32, expectedB)) {
+        AssertUtils.assertStructColumnsAreEqual(expectedStructCorrect, actualStruct);
+      }
+    }
+  }
+
+  @Test
+  void decodeFloatDoubleAndBool() {
+    // message Msg { bool flag = 1; float f32 = 2; double f64 = 3; }
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)), new Byte[]{(byte)0x01},  // bool=true
+        box(tag(2, WT_32BIT)), box(encodeFloat(3.14f)),
+        box(tag(3, WT_64BIT)), box(encodeDouble(2.71828)));
+
+    Byte[] row1 = concat(
+        box(tag(1, WT_VARINT)), new Byte[]{(byte)0x00},  // bool=false
+        box(tag(2, WT_32BIT)), box(encodeFloat(-1.5f)),
+        box(tag(3, WT_64BIT)), box(encodeDouble(0.0)));
+
+    try (Table input = new Table.TestBuilder().column(row0, row1).build();
+         ColumnVector expectedBool = ColumnVector.fromBoxedBooleans(true, false);
+         ColumnVector expectedFloat = ColumnVector.fromBoxedFloats(3.14f, -1.5f);
+         ColumnVector expectedDouble = ColumnVector.fromBoxedDoubles(2.71828, 0.0);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedBool, expectedFloat, expectedDouble);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2, 3},
+             new int[]{
+                 DType.BOOL8.getTypeId().getNativeId(),
+                 DType.FLOAT32.getTypeId().getNativeId(),
+                 DType.FLOAT64.getTypeId().getNativeId()},
+             new int[]{0, 0, 0})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Schema Projection Tests (new API feature)
+  // ============================================================================
+
+  @Test
+  void testSchemaProjection() {
+    // message Msg { int64 f1 = 1; string f2 = 2; int32 f3 = 3; }
+    // Only decode f1 and f3, f2 should be null
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(100)),
+        box(tag(2, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()),
+        box(tag(3, WT_VARINT)), box(encodeVarint(42)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row0}).build();
+         // Expected: f1=100, f3=42 (schema projection: only decode these two)
+         ColumnVector expectedF1 = ColumnVector.fromBoxedLongs(100L);
+         ColumnVector expectedF3 = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedF1, expectedF3);
+         // Decode only f1 (field_number=1) and f3 (field_number=3), skip f2
+         // With the unified API, we only include the fields we want in the schema
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 3},  // field numbers for f1 and f3
+             new int[]{DType.INT64.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testSchemaProjectionDecodeNone() {
+    // Decode no fields - all should be null
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(100)),
+        box(tag(2, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row0}).build();
+         // With no fields in the schema, the GPU returns an empty struct
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{},  // no field numbers
+             new int[]{},  // no types
+             new int[]{})) {  // no encodings
+      assertNotNull(actualStruct);
+      assertEquals(DType.STRUCT, actualStruct.getType());
+    }
+  }
+
+  // ============================================================================
+  // Varint Boundary Tests
+  // ============================================================================
+
+  @Test
+  void testVarintMaxUint64() {
+    // Max uint64 = 0xFFFFFFFFFFFFFFFF = 18446744073709551615
+    // Encoded as 10 bytes: FF FF FF FF FF FF FF FF FF 01
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        new Byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                   (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0x01});
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.UINT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      try (ColumnVector expectedU64 = ColumnVector.fromBoxedLongs(-1L);  // -1 as unsigned = max
+           ColumnVector expectedU64Correct = expectedU64.castTo(DType.UINT64);
+           ColumnVector expectedStruct = ColumnVector.makeStruct(expectedU64Correct)) {
+        AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+      }
+    }
+  }
+
   // ============================================================================
   // Output shape tests — verify the stub produces correctly typed struct columns
   // ============================================================================
@@ -90,6 +488,23 @@ public class ProtobufTest {
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(1, result.getRowCount());
       assertEquals(0, result.getNumChildren());
+    }
+  }
+
+  @Test
+  void testVarintZero() {
+    // Zero encoded as single byte: 0x00
+    Byte[] row = concat(box(tag(1, WT_VARINT)), new Byte[]{0x00});
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(0L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
 
@@ -109,6 +524,1756 @@ public class ProtobufTest {
       assertEquals(DType.INT64, result.getChildColumnView(0).getType());
     }
   }
+
+  @Test
+  void testVarintOverEncodedZero() {
+    // Zero over-encoded as 10 bytes (all continuation bits except last)
+    // This is valid per protobuf spec - parsers must accept non-canonical varints
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        new Byte[]{(byte)0x80, (byte)0x80, (byte)0x80, (byte)0x80, (byte)0x80,
+                   (byte)0x80, (byte)0x80, (byte)0x80, (byte)0x80, (byte)0x00});
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(0L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testVarint10thByteInvalid() {
+    // 10th byte with more than 1 significant bit is invalid
+    // (uint64 can only hold 64 bits: 9*7=63 bits + 1 bit from 10th byte)
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        new Byte[]{(byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                   (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0x02});  // 0x02 has 2nd bit set
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             false)) {
+      try (ColumnVector expected = ColumnVector.fromBoxedLongs((Long)null);
+           ColumnVector expectedStruct = ColumnVector.makeStruct(expected)) {
+        AssertUtils.assertStructColumnsAreEqual(expectedStruct, result);
+      }
+    }
+  }
+
+  // ============================================================================
+  // ZigZag Boundary Tests
+  // ============================================================================
+
+  @Test
+  void testZigzagInt32Min() {
+    // int32 min = -2147483648
+    // zigzag encoded = 4294967295 = 0xFFFFFFFF
+    int minInt32 = Integer.MIN_VALUE;
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(zigzagEncode32(minInt32))));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(minInt32);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_ZIGZAG})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testZigzagInt32Max() {
+    // int32 max = 2147483647
+    // zigzag encoded = 4294967294 = 0xFFFFFFFE
+    int maxInt32 = Integer.MAX_VALUE;
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(zigzagEncode32(maxInt32))));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(maxInt32);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_ZIGZAG})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testZigzagInt64Min() {
+    // int64 min = -9223372036854775808
+    long minInt64 = Long.MIN_VALUE;
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(zigzagEncode64(minInt64))));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedLong = ColumnVector.fromBoxedLongs(minInt64);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_ZIGZAG})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testZigzagInt64Max() {
+    long maxInt64 = Long.MAX_VALUE;
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(zigzagEncode64(maxInt64))));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedLong = ColumnVector.fromBoxedLongs(maxInt64);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_ZIGZAG})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testZigzagNegativeOne() {
+    // -1 zigzag encoded = 1
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(zigzagEncode64(-1L))));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedLong = ColumnVector.fromBoxedLongs(-1L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_ZIGZAG})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Truncated/Malformed Data Tests
+  // ============================================================================
+
+  @Test
+  void testMalformedVarint() {
+    // Varint that never terminates (all continuation bits set, 11 bytes)
+    Byte[] malformed = new Byte[]{(byte)0x08, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                                   (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                                   (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{malformed}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{0},
+             false)) {
+      assertSingleNullStructRow(result, "Malformed varint should null the struct row");
+    }
+  }
+
+  @Test
+  void testTruncatedVarint() {
+    // Single byte with continuation bit set but no following byte
+    Byte[] truncated = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte)0x80});
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{0},
+             false)) {
+      assertSingleNullStructRow(result, "Truncated varint should null the struct row");
+    }
+  }
+
+  @Test
+  void testTruncatedLengthDelimited() {
+    // String field with length=5 but no actual data
+    Byte[] truncated = concat(box(tag(2, WT_LEN)), box(encodeVarint(5)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{2},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{0},
+             false)) {
+      assertSingleNullStructRow(result,
+          "Truncated length-delimited field should null the struct row");
+    }
+  }
+
+  @Test
+  void testTruncatedFixed32() {
+    // Fixed32 needs 4 bytes but only 3 provided
+    Byte[] truncated = concat(box(tag(1, WT_32BIT)), new Byte[]{0x01, 0x02, 0x03});
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_FIXED},
+             false)) {
+      assertSingleNullStructRow(result, "Truncated fixed32 should null the struct row");
+    }
+  }
+
+  @Test
+  void testTruncatedFixed64() {
+    // Fixed64 needs 8 bytes but only 7 provided
+    Byte[] truncated = concat(box(tag(1, WT_64BIT)), 
+        new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_FIXED},
+             false)) {
+      assertSingleNullStructRow(result, "Truncated fixed64 should null the struct row");
+    }
+  }
+
+  @Test
+  void testPartialLengthDelimitedData() {
+    // Length says 10 bytes but only 5 provided
+    Byte[] partial = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(10)),
+        box("hello".getBytes()));  // only 5 bytes
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{partial}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{0},
+             false)) {
+      assertSingleNullStructRow(result,
+          "Partial length-delimited payload should null the struct row");
+    }
+  }
+
+  // ============================================================================
+  // Wrong Wire Type Tests
+  // ============================================================================
+
+  @Test
+  void testWrongWireType() {
+    // Expect varint (wire type 0) but provide fixed32 (wire type 5)
+    Byte[] wrongType = concat(
+        box(tag(1, WT_32BIT)),  // wire type 5 instead of 0
+        box(encodeFixed32(100)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{wrongType}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},  // expects varint
+             new int[]{Protobuf.ENC_DEFAULT},
+             false)) {
+      assertSingleNullStructRow(result, "Wrong wire type should null the struct row");
+    }
+  }
+
+  @Test
+  void testWrongWireTypeForString() {
+    // Expect length-delimited (wire type 2) but provide varint (wire type 0)
+    Byte[] wrongType = concat(
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(12345)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{wrongType}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},  // expects LEN
+             new int[]{Protobuf.ENC_DEFAULT},
+             false)) {
+      assertSingleNullStructRow(result, "Wrong wire type for string should null the struct row");
+    }
+  }
+
+  // ============================================================================
+  // Unknown Field Skip Tests
+  // ============================================================================
+
+  @Test
+  void testSkipUnknownVarintField() {
+    // Unknown field 99 with varint, followed by known field 1
+    Byte[] row = concat(
+        box(tag(99, WT_VARINT)),
+        box(encodeVarint(12345)),  // unknown field to skip
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(42)));    // known field
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testSkipUnknownFixed64Field() {
+    // Unknown field 99 with fixed64, followed by known field 1
+    Byte[] row = concat(
+        box(tag(99, WT_64BIT)),
+        box(encodeFixed64(0x123456789ABCDEF0L)),  // unknown field to skip
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(42)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testSkipUnknownLengthDelimitedField() {
+    // Unknown field 99 with length-delimited data, followed by known field 1
+    Byte[] row = concat(
+        box(tag(99, WT_LEN)),
+        box(encodeVarint(5)),
+        box("hello".getBytes()),  // unknown field to skip
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(42)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testSkipUnknownFixed32Field() {
+    // Unknown field 99 with fixed32, followed by known field 1
+    Byte[] row = concat(
+        box(tag(99, WT_32BIT)),
+        box(encodeFixed32(12345)),  // unknown field to skip
+        box(tag(1, WT_VARINT)),
+        box(encodeVarint(42)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Last One Wins (Repeated Scalar Field) Tests
+  // ============================================================================
+
+  @Test
+  void testLastOneWins() {
+    // Same field appears multiple times - last value should win
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(100)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(200)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(300)));  // this should win
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs(300L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testLastOneWinsForString() {
+    // Same string field appears multiple times
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(5)), box("first".getBytes()),
+        box(tag(1, WT_LEN)), box(encodeVarint(6)), box("second".getBytes()),
+        box(tag(1, WT_LEN)), box(encodeVarint(4)), box("last".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedStr = ColumnVector.fromStrings("last");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Error Handling Tests
+  // ============================================================================
+
+  @Test
+  void testFailOnErrorsTrue() {
+    Byte[] malformed = new Byte[]{(byte)0x08, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                                   (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                                   (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{malformed}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{0},
+             true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFieldNumberZeroInvalid() {
+    // Field number 0 is reserved and invalid
+    Byte[] invalid = concat(box(tag(0, WT_VARINT)), box(encodeVarint(123)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{invalid}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{0},
+             false)) {
+      assertSingleNullStructRow(result, "Field number zero should null the struct row");
+    }
+  }
+
+  @Test
+  void testEmptyMessage() {
+    // Empty message should result in null/default values for all fields
+    Byte[] empty = new Byte[0];
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{empty}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedLongs((Long)null);
+         ColumnVector expectedStr = ColumnVector.fromStrings((String)null);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt, expectedStr);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{0, 0})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Float/Double Special Values Tests
+  // ============================================================================
+
+  @Test
+  void testFloatSpecialValues() {
+    Byte[] rowInf = concat(box(tag(1, WT_32BIT)), box(encodeFloat(Float.POSITIVE_INFINITY)));
+    Byte[] rowNegInf = concat(box(tag(1, WT_32BIT)), box(encodeFloat(Float.NEGATIVE_INFINITY)));
+    Byte[] rowNaN = concat(box(tag(1, WT_32BIT)), box(encodeFloat(Float.NaN)));
+    Byte[] rowMin = concat(box(tag(1, WT_32BIT)), box(encodeFloat(Float.MIN_VALUE)));
+    Byte[] rowMax = concat(box(tag(1, WT_32BIT)), box(encodeFloat(Float.MAX_VALUE)));
+
+    try (Table input = new Table.TestBuilder().column(rowInf, rowNegInf, rowNaN, rowMin, rowMax).build();
+         ColumnVector expectedFloat = ColumnVector.fromBoxedFloats(
+             Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN, 
+             Float.MIN_VALUE, Float.MAX_VALUE);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedFloat);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.FLOAT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDoubleSpecialValues() {
+    Byte[] rowInf = concat(box(tag(1, WT_64BIT)), box(encodeDouble(Double.POSITIVE_INFINITY)));
+    Byte[] rowNegInf = concat(box(tag(1, WT_64BIT)), box(encodeDouble(Double.NEGATIVE_INFINITY)));
+    Byte[] rowNaN = concat(box(tag(1, WT_64BIT)), box(encodeDouble(Double.NaN)));
+    Byte[] rowMin = concat(box(tag(1, WT_64BIT)), box(encodeDouble(Double.MIN_VALUE)));
+    Byte[] rowMax = concat(box(tag(1, WT_64BIT)), box(encodeDouble(Double.MAX_VALUE)));
+
+    try (Table input = new Table.TestBuilder().column(rowInf, rowNegInf, rowNaN, rowMin, rowMax).build();
+         ColumnVector expectedDouble = ColumnVector.fromBoxedDoubles(
+             Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN,
+             Double.MIN_VALUE, Double.MAX_VALUE);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedDouble);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.FLOAT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Enum Tests (enums.as.ints=true semantics)
+  // ============================================================================
+
+  @Test
+  void testEnumAsInt() {
+    // message Msg { enum Color { RED=0; GREEN=1; BLUE=2; } Color c = 1; }
+    // c = GREEN (value 1) - encoded as varint
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(1);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumZeroValue() {
+    // Enum with value 0 (first/default enum value)
+    // c = RED (value 0)
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(0)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(0);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumUnknownValue() {
+    // Protobuf allows unknown enum values - they should still be decoded as integers
+    // c = 999 (unknown value not in enum definition)
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(999);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumNegativeValue() {
+    // Negative enum values are valid in protobuf (stored as unsigned varint)
+    // c = -1 (represented as 0xFFFFFFFF in protobuf wire format)
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(-1L & 0xFFFFFFFFL)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(-1);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumMultipleFields() {
+    // message Msg { enum Status { OK=0; ERROR=1; } Status s1 = 1; int32 count = 2; Status s2 = 3; }
+    // s1 = ERROR (1), count = 42, s2 = OK (0)
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),   // s1 = ERROR
+        box(tag(2, WT_VARINT)), box(encodeVarint(42)),  // count = 42
+        box(tag(3, WT_VARINT)), box(encodeVarint(0)));  // s2 = OK
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedS1 = ColumnVector.fromBoxedInts(1);
+         ColumnVector expectedCount = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedS2 = ColumnVector.fromBoxedInts(0);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedS1, expectedCount, expectedS2);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2, 3},
+             new int[]{DType.INT32.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumMissingField() {
+    // Enum field not present in message - should be null
+    Byte[] row = concat(box(tag(2, WT_VARINT)), box(encodeVarint(42)));  // only count field
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedEnum = ColumnVector.fromBoxedInts((Integer) null);
+         ColumnVector expectedCount = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedEnum, expectedCount);
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT})) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Required Field Tests
+  // ============================================================================
+
+  @Test
+  void testRequiredFieldPresent() {
+    // message Msg { required int64 id = 1; optional string name = 2; }
+    // Both fields present - should decode successfully
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(42)),
+        box(tag(2, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedId = ColumnVector.fromBoxedLongs(42L);
+         ColumnVector expectedName = ColumnVector.fromStrings("hello");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedId, expectedName);
+         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{true, false},  // id is required, name is optional
+             true)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testRequiredFieldMissing_Permissive() {
+    // Required field missing in permissive mode - should null the whole row without exception
+    // message Msg { required int64 id = 1; optional string name = 2; }
+    // Only name field present, required id is missing
+    Byte[] row = concat(
+        box(tag(2, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{true, false},  // id is required, name is optional
+             false)) {  // permissive mode - don't fail on errors
+      assertSingleNullStructRow(actualStruct,
+          "Missing top-level required field should null the row in PERMISSIVE mode");
+    }
+  }
+
+  @Test
+  void testRequiredFieldMissing_Failfast() {
+    // Required field missing in failfast mode - should throw exception
+    // message Msg { required int64 id = 1; optional string name = 2; }
+    // Only name field present, required id is missing
+    Byte[] row = concat(
+        box(tag(2, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFieldsWithRequired(
+            input.getColumn(0),
+            new int[]{1, 2},
+            new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+            new boolean[]{true, false},  // id is required, name is optional
+            true)) {  // failfast mode - should throw
+        }
+      });
+    }
+  }
+
+  @Test
+  void testMultipleRequiredFields_AllPresent() {
+    // message Msg { required int32 a = 1; required int64 b = 2; required string c = 3; }
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(10)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(20)),
+        box(tag(3, WT_LEN)), box(encodeVarint(3)), box("abc".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(10);
+         ColumnVector expectedB = ColumnVector.fromBoxedLongs(20L);
+         ColumnVector expectedC = ColumnVector.fromStrings("abc");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB, expectedC);
+         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+             input.getColumn(0),
+             new int[]{1, 2, 3},
+             new int[]{DType.INT32.getTypeId().getNativeId(),
+                       DType.INT64.getTypeId().getNativeId(),
+                       DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{true, true, true},  // all required
+             true)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testMultipleRequiredFields_SomeMissing_Failfast() {
+    // message Msg { required int32 a = 1; required int64 b = 2; required string c = 3; }
+    // Only field a is present, b and c are missing
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(10)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFieldsWithRequired(
+            input.getColumn(0),
+            new int[]{1, 2, 3},
+            new int[]{DType.INT32.getTypeId().getNativeId(),
+                      DType.INT64.getTypeId().getNativeId(),
+                      DType.STRING.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+            new boolean[]{true, true, true},  // all required
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testOptionalFieldsOnly_NoValidation() {
+    // All fields optional - missing fields should not cause error
+    // message Msg { optional int32 a = 1; optional int64 b = 2; }
+    Byte[] row = new Byte[0];  // empty message
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts((Integer) null);
+         ColumnVector expectedB = ColumnVector.fromBoxedLongs((Long) null);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
+         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},  // all optional
+             true)) {  // even with failOnErrors=true, should succeed since all fields are optional
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testRequiredFieldWithMultipleRows() {
+    // Test required field validation across multiple rows
+    // Row 0: required field present
+    // Row 1: required field missing (should cause error in failfast mode)
+    Byte[] row0 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(42)));
+    Byte[] row1 = new Byte[0];  // empty - required field missing
+
+    try (Table input = new Table.TestBuilder().column(row0, row1).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFieldsWithRequired(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT},
+            new boolean[]{true},  // required
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testRequiredFieldIgnoresNullInputRow_Failfast() {
+    Byte[] row0 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(42)));
+    Byte[] row1 = null;
+
+    try (Table input = new Table.TestBuilder().column(row0, row1).build();
+         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             true);
+         ColumnVector idCol = actualStruct.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostStruct = actualStruct.copyToHost();
+         HostColumnVector hostId = idCol.copyToHost()) {
+      assertEquals(0, actualStruct.getNullCount(), "Null input rows keep the top-level struct row");
+      assertFalse(hostStruct.isNull(0), "Present required field should keep row 0 valid");
+      assertFalse(hostStruct.isNull(1), "Null input row should not trigger required-field failure");
+      assertEquals(1, idCol.getNullCount(), "The required child value should be null on the null input row");
+      assertTrue(hostId.isNull(1), "Null input row should produce a null child value, not ERR_REQUIRED");
+    }
+  }
+
+  // ============================================================================
+  // Default Value Tests (API accepts parameters, CUDA fill not yet implemented)
+  // ============================================================================
+
+  /**
+   * Helper method for tests with default value support.
+   */
+  private static ColumnVector decodeAllFieldsWithDefaults(ColumnView binaryInput,
+                                                          int[] fieldNumbers,
+                                                          int[] typeIds,
+                                                          int[] encodings,
+                                                          boolean[] isRequired,
+                                                          boolean[] hasDefaultValue,
+                                                          long[] defaultInts,
+                                                          double[] defaultFloats,
+                                                          boolean[] defaultBools,
+                                                          byte[][] defaultStrings,
+                                                          boolean failOnErrors) {
+    int numFields = fieldNumbers.length;
+    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
+        isRequired, hasDefaultValue, defaultInts, defaultFloats, defaultBools,
+        defaultStrings, new int[numFields][], failOnErrors);
+  }
+
+  @Test
+  void testDefaultValueForMissingFields() {
+    // Test that missing fields with default values return the defaults
+    Byte[] row = new Byte[0];  // empty message
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         // With default values set, missing fields should return the default values
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedB = ColumnVector.fromBoxedLongs(100L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},  // not required
+             new boolean[]{true, true},    // has default value
+             new long[]{42, 100},          // default int values (42, 100)
+             new double[]{0.0, 0.0},       // default float values (unused for int fields)
+             new boolean[]{false, false},  // default bool values (unused)
+             new byte[][]{null, null},     // default string values (unused)
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultValueFieldPresent_OverridesDefault() {
+    // When field is present, use the actual value (not the default)
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(99)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(200)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(99);
+         ColumnVector expectedB = ColumnVector.fromBoxedLongs(200L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},  // not required
+             new boolean[]{true, true},    // has default value
+             new long[]{42, 100},          // default values - NOT used since field is present
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             false)) {
+      // Actual values should be used, not defaults
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultIntValue() {
+    // optional int32 count = 1 [default = 42];
+    // Empty message should return the default value
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},   // not required
+             new boolean[]{true},    // has default
+             new long[]{42},         // default = 42
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultBoolValue() {
+    // optional bool flag = 1 [default = true];
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedBool = ColumnVector.fromBoxedBooleans(true);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedBool);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.BOOL8.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{true},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{true},  // default = true
+             new byte[][]{null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultFloatValue() {
+    // optional double rate = 1 [default = 3.14];
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedDouble = ColumnVector.fromBoxedDoubles(3.14);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedDouble);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.FLOAT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{true},
+             new long[]{0},
+             new double[]{3.14},  // default = 3.14
+             new boolean[]{false},
+             new byte[][]{null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultInt64Value() {
+    // optional int64 big_num = 1 [default = 9876543210];
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedLong = ColumnVector.fromBoxedLongs(9876543210L);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{true},
+             new long[]{9876543210L},  // default = 9876543210
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testMixedDefaultAndNonDefaultFields() {
+    // optional int32 a = 1 [default = 42];
+    // optional int64 b = 2; (no default)
+    // optional bool c = 3 [default = true];
+    // Empty message: a=42, b=null, c=true
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedB = ColumnVector.fromBoxedLongs((Long) null);  // no default
+         ColumnVector expectedC = ColumnVector.fromBoxedBooleans(true);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB, expectedC);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1, 2, 3},
+             new int[]{DType.INT32.getTypeId().getNativeId(),
+                       DType.INT64.getTypeId().getNativeId(),
+                       DType.BOOL8.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false, false},  // not required
+             new boolean[]{true, false, true},    // a and c have defaults, b doesn't
+             new long[]{42, 0, 0},                // default for a
+             new double[]{0.0, 0.0, 0.0},
+             new boolean[]{false, false, true},   // default for c
+             new byte[][]{null, null, null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultValueWithPartialMessage() {
+    // optional int32 a = 1 [default = 42];
+    // optional int64 b = 2 [default = 100];
+    // Message has only field b set, a should use default
+    Byte[] row = concat(
+        box(tag(2, WT_VARINT)), box(encodeVarint(999)));  // b = 999
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(42);  // default
+         ColumnVector expectedB = ColumnVector.fromBoxedLongs(999L);  // actual value
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},  // not required
+             new boolean[]{true, true},    // both have defaults
+             new long[]{42, 100},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultStringValue() {
+    // optional string name = 1 [default = "hello"];
+    // Empty message should return the default string
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedStr = ColumnVector.fromStrings("hello");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},   // not required
+             new boolean[]{true},    // has default
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{"hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultStringValueEmpty() {
+    // optional string name = 1 [default = ""];
+    // Empty message with empty default string
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedStr = ColumnVector.fromStrings("");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{true},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{new byte[0]},  // empty default string
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultStringValueWithPresent() {
+    // optional string name = 1 [default = "default"];
+    // Message has actual value, should override default
+    byte[] strBytesRaw = "actual".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(strBytesRaw.length)),
+        box(strBytesRaw));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedStr = ColumnVector.fromStrings("actual");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{true},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{"default".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultStringWithMixedFields() {
+    // optional int32 count = 1 [default = 42];
+    // optional string name = 2 [default = "test"];
+    // Empty message should return both defaults
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedInt = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedStr = ColumnVector.fromStrings("test");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt, expectedStr);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},
+             new boolean[]{true, true},
+             new long[]{42, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, "test".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testDefaultStringMultipleRows() {
+    // optional string name = 1 [default = "default"];
+    // Multiple rows: empty, has value, empty
+    Byte[] row1 = new Byte[0];  // will use default
+    byte[] strBytesRaw = "row2val".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    Byte[] row2 = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(strBytesRaw.length)),
+        box(strBytesRaw));
+    Byte[] row3 = new Byte[0];  // will use default
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row1, row2, row3}).build();
+         ColumnVector expectedStr = ColumnVector.fromStrings("default", "row2val", "default");
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
+         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{true},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{"default".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Tests for Nested and Repeated Fields (Phase 1-3 Implementation)
+  // ============================================================================
+
+  /** Helper: concatenate byte arrays */
+  private static byte[] concatBytes(byte[]... arrays) {
+    int len = 0;
+    for (byte[] a : arrays) len += a.length;
+    byte[] out = new byte[len];
+    int pos = 0;
+    for (byte[] a : arrays) {
+      System.arraycopy(a, 0, out, pos, a.length);
+      pos += a.length;
+    }
+    return out;
+  }
+
+  @Test
+  void testNestedMessage() {
+    // message Inner { int32 x = 1; }
+    // message Outer { Inner inner = 1; }
+    // Outer with inner.x = 42
+    Byte[] innerMessage = concat(box(tag(1, WT_VARINT)), box(encodeVarint(42)));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(innerMessage.length)),
+        innerMessage);
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      // Flattened schema:
+      // [0] inner: STRUCT, field_number=1, parent=-1, depth=0
+      // [1] inner.x: INT32, field_number=1, parent=0, depth=1
+      try (ColumnVector result = decodeRaw(
+          input.getColumn(0),
+          new int[]{1, 1},                 // fieldNumbers
+          new int[]{-1, 0},                // parentIndices
+          new int[]{0, 1},                 // depthLevels
+          new int[]{Protobuf.WT_LEN, Protobuf.WT_VARINT},  // wireTypes
+          new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+          new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+          new boolean[]{false, false},     // isRepeated
+          new boolean[]{false, false},     // isRequired
+          new boolean[]{false, false},     // hasDefaultValue
+          new long[]{0, 0},
+          new double[]{0.0, 0.0},
+          new boolean[]{false, false},
+          new byte[][]{null, null},
+          new int[][]{null, null},
+          false)) {
+        assertNotNull(result);
+        assertEquals(DType.STRUCT, result.getType());
+      }
+    }
+  }
+
+  // ============================================================================
+  // FAILFAST Mode Tests (failOnErrors = true)
+  // ============================================================================
+
+  @Test
+  void testFailfastMalformedVarint() {
+    // Varint that never terminates (all continuation bits set)
+    Byte[] malformed = new Byte[]{(byte)0x08, (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                                   (byte)0xFF, (byte)0xFF, (byte)0xFF,
+                                   (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{malformed}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{0},
+            true)) {  // failOnErrors = true
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastTruncatedVarint() {
+    // Single byte with continuation bit set but no following byte
+    Byte[] truncated = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte)0x80});
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{0},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastTruncatedString() {
+    // String field with length=5 but no actual data
+    Byte[] truncated = concat(box(tag(2, WT_LEN)), box(encodeVarint(5)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{2},
+            new int[]{DType.STRING.getTypeId().getNativeId()},
+            new int[]{0},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastTruncatedFixed32() {
+    // Fixed32 needs 4 bytes but only 3 provided
+    Byte[] truncated = concat(box(tag(1, WT_32BIT)), new Byte[]{0x01, 0x02, 0x03});
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT32.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_FIXED},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastTruncatedFixed64() {
+    // Fixed64 needs 8 bytes but only 5 provided
+    Byte[] truncated = concat(box(tag(1, WT_64BIT)), new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_FIXED},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastWrongWireType() {
+    // Field 1 with wire type 2 (length-delimited), but we request varint
+    Byte[] row = concat(box(tag(1, WT_LEN)), box(encodeVarint(3)), box("abc".getBytes()));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastFieldNumberZero() {
+    // Field number 0 is invalid in protobuf
+    Byte[] row = concat(box(tag(0, WT_VARINT)), box(encodeVarint(42)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{0},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testFailfastFieldNumberAboveSpecLimit() {
+    // Protobuf field numbers must be <= 2^29 - 1.
+    Byte[] row = concat(box(tag(1 << 29, WT_VARINT)), box(encodeVarint(42)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = decodeAllFields(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testUnknownEndGroupWireTypeNullsMalformedRow() {
+    Byte[] row = concat(
+        box(tag(5, 4)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(42)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             false)) {
+      assertSingleNullStructRow(actual, "Unknown end-group wire type should null the struct row");
+    }
+  }
+
+  @Test
+  void testFailfastValidDataDoesNotThrow() {
+    // Valid protobuf should not throw even with failOnErrors = true
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(42)));
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT64.getTypeId().getNativeId()},
+             new int[]{0},
+             true)) {
+      try (ColumnVector expected = ColumnVector.fromBoxedLongs(42L);
+           ColumnVector expectedStruct = ColumnVector.makeStruct(expected)) {
+        AssertUtils.assertStructColumnsAreEqual(expectedStruct, result);
+      }
+    }
+  }
+
+  // ============================================================================
+  // Performance Benchmark Tests (Multi-field)
+  // ============================================================================
+
+  @Test
+  void testMultiFieldPerformance() {
+    // Test with 6 fields to verify fused kernel efficiency
+    // message Msg { bool f1=1; int32 f2=2; int64 f3=3; float f4=4; double f5=5; string f6=6; }
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), new Byte[]{0x01},
+        box(tag(2, WT_VARINT)), box(encodeVarint(12345)),
+        box(tag(3, WT_VARINT)), box(encodeVarint(9876543210L)),
+        box(tag(4, WT_32BIT)), box(encodeFloat(3.14f)),
+        box(tag(5, WT_64BIT)), box(encodeDouble(2.71828)),
+        box(tag(6, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actualStruct = decodeAllFields(
+             input.getColumn(0),
+             new int[]{1, 2, 3, 4, 5, 6},
+             new int[]{
+                 DType.BOOL8.getTypeId().getNativeId(),
+                 DType.INT32.getTypeId().getNativeId(),
+                 DType.INT64.getTypeId().getNativeId(),
+                 DType.FLOAT32.getTypeId().getNativeId(),
+                 DType.FLOAT64.getTypeId().getNativeId(),
+                 DType.STRING.getTypeId().getNativeId()},
+             new int[]{0, 0, 0, 0, 0, 0})) {
+      try (ColumnVector expectedBool = ColumnVector.fromBoxedBooleans(true);
+           ColumnVector expectedInt = ColumnVector.fromBoxedInts(12345);
+           ColumnVector expectedLong = ColumnVector.fromBoxedLongs(9876543210L);
+           ColumnVector expectedFloat = ColumnVector.fromBoxedFloats(3.14f);
+           ColumnVector expectedDouble = ColumnVector.fromBoxedDoubles(2.71828);
+           ColumnVector expectedString = ColumnVector.fromStrings("hello");
+           ColumnVector expectedStruct = ColumnVector.makeStruct(
+               expectedBool, expectedInt, expectedLong, expectedFloat, expectedDouble, expectedString)) {
+        AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+      }
+    }
+  }
+
+  // ============================================================================
+  // Enum Validation Tests
+  // ============================================================================
+
+  /**
+   * Helper method that wraps decodeToStruct with enum validation support.
+   */
+  private static ColumnVector decodeAllFieldsWithEnums(ColumnView binaryInput,
+                                                        int[] fieldNumbers,
+                                                        int[] typeIds,
+                                                        int[] encodings,
+                                                        int[][] enumValidValues,
+                                                        boolean failOnErrors) {
+    int numFields = fieldNumbers.length;
+    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
+        new boolean[numFields], new boolean[numFields], new long[numFields],
+        new double[numFields], new boolean[numFields], new byte[numFields][],
+        enumValidValues, failOnErrors);
+  }
+
+  /**
+   * Helper that enables enum-as-string decoding by passing enum name mappings.
+   */
+  private static ColumnVector decodeAllFieldsWithEnumStrings(ColumnView binaryInput,
+                                                             int[] fieldNumbers,
+                                                             int[][] enumValidValues,
+                                                             byte[][][] enumNames,
+                                                             boolean failOnErrors) {
+    int numFields = fieldNumbers.length;
+    int[] typeIds = new int[numFields];
+    int[] encodings = new int[numFields];
+    for (int i = 0; i < numFields; i++) {
+      typeIds[i] = DType.STRING.getTypeId().getNativeId();
+      encodings[i] = Protobuf.ENC_ENUM_STRING;
+    }
+    int[] parentIndices = new int[numFields];
+    int[] depthLevels = new int[numFields];
+    int[] wireTypes = new int[numFields];
+    boolean[] isRepeated = new boolean[numFields];
+    java.util.Arrays.fill(parentIndices, -1);
+    java.util.Arrays.fill(wireTypes, Protobuf.WT_VARINT);
+    return Protobuf.decodeToStruct(binaryInput,
+        new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
+            wireTypes, typeIds, encodings, isRepeated,
+            new boolean[numFields], new boolean[numFields], new long[numFields],
+            new double[numFields], new boolean[numFields], new byte[numFields][],
+            enumValidValues, enumNames),
+        failOnErrors);
+  }
+
+  @Test
+  void testEnumAsStringValidValue() {
+    // enum Color { RED=0; GREEN=1; BLUE=2; }
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));  // GREEN
+
+    byte[][][] enumNames = new byte[][][] {
+        new byte[][] {
+            "RED".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "GREEN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BLUE".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedField = ColumnVector.fromStrings("GREEN");
+         ColumnVector expected = ColumnVector.makeStruct(expectedField);
+         ColumnVector actual = decodeAllFieldsWithEnumStrings(
+             input.getColumn(0),
+             new int[]{1},
+             new int[][]{{0, 1, 2}},
+             enumNames,
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expected, actual);
+    }
+  }
+
+  @Test
+  void testEnumAsStringUnknownValueReturnsNullRow() {
+    // Unknown enum value should null the entire struct row (PERMISSIVE behavior).
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));
+
+    byte[][][] enumNames = new byte[][][] {
+        new byte[][] {
+            "RED".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "GREEN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BLUE".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeAllFieldsWithEnumStrings(
+             input.getColumn(0),
+             new int[]{1},
+             new int[][]{{0, 1, 2}},
+             enumNames,
+             false);
+         HostColumnVector hostStruct = actual.copyToHost()) {
+      assertEquals(1, actual.getNullCount(), "Struct row should be null for unknown enum value");
+      assertTrue(hostStruct.isNull(0), "Row 0 should be null");
+    }
+  }
+
+  @Test
+  void testEnumAsStringMixedValidAndUnknown() {
+    Byte[] row0 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(0)));    // RED
+    Byte[] row1 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));  // unknown
+    Byte[] row2 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(2)));    // BLUE
+
+    byte[][][] enumNames = new byte[][][] {
+        new byte[][] {
+            "RED".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "GREEN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BLUE".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+    try (Table input = new Table.TestBuilder().column(row0, row1, row2).build();
+         ColumnVector actual = decodeAllFieldsWithEnumStrings(
+             input.getColumn(0),
+             new int[]{1},
+             new int[][]{{0, 1, 2}},
+             enumNames,
+             false);
+         HostColumnVector hostStruct = actual.copyToHost()) {
+      assertEquals(1, actual.getNullCount(), "Only the unknown enum row should be null");
+      assertTrue(!hostStruct.isNull(0), "Row 0 should be valid");
+      assertTrue(hostStruct.isNull(1), "Row 1 should be null");
+      assertTrue(!hostStruct.isNull(2), "Row 2 should be valid");
+    }
+  }
+
+  @Test
+  void testEnumValidValue() {
+    // enum Color { RED=0; GREEN=1; BLUE=2; }
+    // message Msg { Color color = 1; }
+    // Test with valid enum value (GREEN = 1)
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedColor = ColumnVector.fromBoxedInts(1);  // GREEN
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedColor);
+         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new int[][]{{0, 1, 2}},  // valid enum values: RED=0, GREEN=1, BLUE=2
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumUnknownValueReturnsNullRow() {
+    // enum Color { RED=0; GREEN=1; BLUE=2; }
+    // message Msg { Color color = 1; }
+    // Test with unknown enum value (999 is not defined)
+    // The entire struct row should be null (matching Spark CPU PERMISSIVE mode)
+    Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new int[][]{{0, 1, 2}},  // valid enum values: RED=0, GREEN=1, BLUE=2
+             false);
+         HostColumnVector hostStruct = actualStruct.copyToHost()) {
+      // The struct itself should be null (not just the field)
+      assertEquals(1, actualStruct.getNullCount(), "Struct row should be null for unknown enum");
+      assertTrue(hostStruct.isNull(0), "Row 0 should be null");
+    }
+  }
+
+  @Test
+  void testEnumMixedValidAndUnknown() {
+    // Test multiple rows with mix of valid and unknown enum values
+    // Rows with unknown enum values should have null struct (not just null field)
+    Byte[] row0 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(0)));    // RED (valid) -> struct valid
+    Byte[] row1 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));  // unknown -> struct null
+    Byte[] row2 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(2)));    // BLUE (valid) -> struct valid
+    Byte[] row3 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(-1)));   // negative (unknown) -> struct null
+
+    try (Table input = new Table.TestBuilder().column(row0, row1, row2, row3).build();
+         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new int[][]{{0, 1, 2}},  // valid enum values
+             false);
+         HostColumnVector hostStruct = actualStruct.copyToHost()) {
+      // Check struct-level nulls
+      assertEquals(2, actualStruct.getNullCount(), "Should have 2 null rows (rows 1 and 3)");
+      assertTrue(!hostStruct.isNull(0), "Row 0 should be valid");
+      assertTrue(hostStruct.isNull(1), "Row 1 should be null (unknown enum 999)");
+      assertTrue(!hostStruct.isNull(2), "Row 2 should be valid");
+      assertTrue(hostStruct.isNull(3), "Row 3 should be null (unknown enum -1)");
+    }
+  }
+
+  @Test
+  void testEnumWithOtherFields_NullsEntireRow() {
+    // message Msg { Color color = 1; int32 count = 2; }
+    // Test that unknown enum value nulls the ENTIRE struct row (not just the enum field)
+    // This matches Spark CPU PERMISSIVE mode behavior
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(999)),  // unknown enum value
+        box(tag(2, WT_VARINT)), box(encodeVarint(42)));  // count = 42
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new int[][]{{0, 1, 2}, null},  // first field is enum, second is regular int (no validation)
+             false);
+         HostColumnVector hostStruct = actualStruct.copyToHost()) {
+      // The entire struct row should be null
+      assertEquals(1, actualStruct.getNullCount(), "Struct row should be null");
+      assertTrue(hostStruct.isNull(0), "Row 0 should be null due to unknown enum");
+    }
+  }
+
+  @Test
+  void testEnumMissingFieldDoesNotNullRow() {
+    // Missing enum field should return null for the field, but NOT null the entire row
+    // Only unknown enum values (present but invalid) trigger row-level null
+    Byte[] row = new Byte[0];  // empty message
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedColor = ColumnVector.fromBoxedInts((Integer) null);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedColor);
+         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new int[][]{{0, 1, 2}},  // valid enum values
+             false)) {
+      // Struct row should be valid (not null), only the field is null
+      assertEquals(0, actualStruct.getNullCount(), "Struct row should NOT be null for missing field");
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testEnumValidWithOtherFields() {
+    // message Msg { Color color = 1; int32 count = 2; }
+    // Test that valid enum value works correctly with other fields
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),    // GREEN (valid)
+        box(tag(2, WT_VARINT)), box(encodeVarint(42)));  // count = 42
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedColor = ColumnVector.fromBoxedInts(1);
+         ColumnVector expectedCount = ColumnVector.fromBoxedInts(42);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedColor, expectedCount);
+         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+             input.getColumn(0),
+             new int[]{1, 2},
+             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new int[][]{{0, 1, 2}, null},  // first field is enum, second is regular int
+             false)) {
+      // Struct row should be valid with correct values
+      assertEquals(0, actualStruct.getNullCount(), "Struct row should be valid");
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  // ============================================================================
+  // Repeated Enum-as-String Tests
+  // ============================================================================
+
+  // ============================================================================
+  // Edge case and boundary tests
+  // ============================================================================
 
   @Test
   void testMultiFieldOutputShape() {
@@ -188,6 +2353,100 @@ public class ProtobufTest {
     }
   }
 
+  @Test
+  void testLargeFieldNumber() {
+    int maxFieldNumber = (1 << 29) - 1;
+    Byte[] row = concat(
+        box(tag(maxFieldNumber, WT_VARINT)),
+        box(encodeVarint(42)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{maxFieldNumber},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{false},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      assertNotNull(result);
+      assertEquals(DType.STRUCT, result.getType());
+      try (ColumnVector child = result.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostChild = child.copyToHost()) {
+        assertEquals(42, hostChild.getInt(0));
+      }
+    }
+  }
+
+  private void verifyDeepNesting(int numLevels) {
+    int numFields = 2 * numLevels - 1;
+
+    byte[] current = concatBytes(tag(1, WT_VARINT), encodeVarint(1));
+    for (int level = numLevels - 2; level >= 0; level--) {
+      current = concatBytes(
+          tag(1, WT_VARINT), encodeVarint(1),
+          tag(2, WT_LEN), encodeVarint(current.length), current);
+    }
+    Byte[] row = box(current);
+
+    int[] fieldNumbers = new int[numFields];
+    int[] parentIndices = new int[numFields];
+    int[] depthLevels = new int[numFields];
+    int[] wireTypes = new int[numFields];
+    int[] outputTypeIds = new int[numFields];
+    int[] encodings = new int[numFields];
+    boolean[] isRepeated = new boolean[numFields];
+    boolean[] isRequired = new boolean[numFields];
+    boolean[] hasDefaultValue = new boolean[numFields];
+    long[] defaultInts = new long[numFields];
+    double[] defaultFloats = new double[numFields];
+    boolean[] defaultBools = new boolean[numFields];
+    byte[][] defaultStrings = new byte[numFields][];
+    int[][] enumValidValues = new int[numFields][];
+
+    for (int level = 0; level < numLevels; level++) {
+      int intIdx = 2 * level;
+      int parentIdx = level == 0 ? -1 : 2 * (level - 1) + 1;
+
+      fieldNumbers[intIdx] = 1;
+      parentIndices[intIdx] = parentIdx;
+      depthLevels[intIdx] = level;
+      wireTypes[intIdx] = WT_VARINT;
+      outputTypeIds[intIdx] = DType.INT32.getTypeId().getNativeId();
+      encodings[intIdx] = Protobuf.ENC_DEFAULT;
+
+      if (level < numLevels - 1) {
+        int structIdx = 2 * level + 1;
+        fieldNumbers[structIdx] = 2;
+        parentIndices[structIdx] = parentIdx;
+        depthLevels[structIdx] = level;
+        wireTypes[structIdx] = WT_LEN;
+        outputTypeIds[structIdx] = DType.STRUCT.getTypeId().getNativeId();
+        encodings[structIdx] = Protobuf.ENC_DEFAULT;
+      }
+    }
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             fieldNumbers, parentIndices, depthLevels, wireTypes,
+             outputTypeIds, encodings, isRepeated, isRequired,
+             hasDefaultValue, defaultInts, defaultFloats, defaultBools,
+             defaultStrings, enumValidValues, false)) {
+      assertNotNull(result);
+      assertEquals(DType.STRUCT, result.getType());
+    }
+  }
+
   // ============================================================================
   // Empty-row (0 rows) handling
   // ============================================================================
@@ -250,6 +2509,35 @@ public class ProtobufTest {
   }
 
   @Test
+  void testZeroLengthNestedMessage() {
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(0)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, null},
+             false)) {
+      assertNotNull(result);
+      assertEquals(DType.STRUCT, result.getType());
+    }
+  }
+
+  @Test
   void testRepeatedFieldOutputShape() {
     // Schema: message Msg { repeated int32 values = 1; }
     int intType = DType.INT32.getTypeId().getNativeId();
@@ -278,6 +2566,35 @@ public class ProtobufTest {
       assertEquals(1, result.getRowCount());
       assertEquals(1, result.getNumChildren());
       assertEquals(DType.LIST, result.getChildColumnView(0).getType());
+    }
+  }
+
+  @Test
+  void testEmptyPackedRepeated() {
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(0)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      assertNotNull(result);
+      assertEquals(DType.STRUCT, result.getType());
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -322,7 +322,24 @@ public class ProtobufTest {
              new int[]{1, 2},
              new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
              new int[]{0, 0})) {
-      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+      // Row 2 is a null input row — the output struct row should also be null.
+      assertEquals(3, actualStruct.getRowCount());
+      assertEquals(1, actualStruct.getNullCount());
+      try (HostColumnVector hcv = actualStruct.copyToHost()) {
+        assertFalse(hcv.isNull(0));
+        assertFalse(hcv.isNull(1));
+        assertTrue(hcv.isNull(2), "Null input row should produce null struct row");
+      }
+      // Children for non-null rows should still match
+      try (ColumnVector childId = actualStruct.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostId = childId.copyToHost();
+           ColumnVector childName = actualStruct.getChildColumnView(1).copyToColumnVector();
+           HostColumnVector hostName = childName.copyToHost()) {
+        assertEquals(100L, hostId.getLong(0));
+        assertEquals(200L, hostId.getLong(1));
+        assertEquals("alice", hostName.getJavaString(0));
+        assertTrue(hostName.isNull(1));
+      }
     }
   }
 
@@ -1346,9 +1363,9 @@ public class ProtobufTest {
          ColumnVector idCol = actualStruct.getChildColumnView(0).copyToColumnVector();
          HostColumnVector hostStruct = actualStruct.copyToHost();
          HostColumnVector hostId = idCol.copyToHost()) {
-      assertEquals(0, actualStruct.getNullCount(), "Null input rows keep the top-level struct row");
+      assertEquals(1, actualStruct.getNullCount(), "Null input row should be null in output struct");
       assertFalse(hostStruct.isNull(0), "Present required field should keep row 0 valid");
-      assertFalse(hostStruct.isNull(1), "Null input row should not trigger required-field failure");
+      assertTrue(hostStruct.isNull(1), "Null input row should produce null struct row");
       assertEquals(1, idCol.getNullCount(), "The required child value should be null on the null input row");
       assertTrue(hostId.isNull(1), "Null input row should produce a null child value, not ERR_REQUIRED");
     }


### PR DESCRIPTION
## `from_protobuf` kernel (part1): scalar field decoding [2/4]

Part 1 of https://github.com/NVIDIA/spark-rapids-jni/pull/4107

### Summary

Second PR in the series. Replaces the all-null stub from part0 with actual GPU decoding of flat (non-nested, non-repeated) scalar protobuf fields. After this PR, `decode_protobuf_to_struct` can decode messages with scalar fields end-to-end; repeated and nested fields still produce null columns.

### What is included

**Scan kernel** (`protobuf_kernels.cu`):
- `scan_all_fields_kernel`: one-thread-per-row parser that scans each protobuf message and records `(offset, length)` for all top-level fields. Supports "last one wins" semantics, unknown field skipping, and malformed-row detection.
- Real `check_required_fields_kernel` replacing the part0 stub.
- `validate_enum_values_kernel` with binary-search validation.
- `compute_enum_string_lengths_kernel` / `copy_enum_string_chars_kernel` for enum-as-string decoding.

**Decode pipeline** (`protobuf.cu`):
- Field classification into scalar / repeated / nested categories.
- Batched scalar extraction in 12 type groups (varint int32/uint32/int64/uint64/bool/zigzag32/zigzag64, fixed32/fixed64, float32/float64, fallback).
- Per-field extraction for STRING, BYTES (LIST\<UINT8\>), and enum-as-string fields.
- Required field validation (proto2 semantics).
- Input null mask propagation: null input rows produce null output struct rows (combined with PERMISSIVE-mode row invalidation).
- Repeated / nested fields fall through to `make_null_column_with_schema`.

**Enum builders** (`protobuf_builders.cu`):
- `build_enum_string_column`: validates enum values and converts to UTF-8 name strings.

### Test coverage (98 tests)

- Scalar types: varint, zigzag, fixed32/64, float/double special values, bool, string, bytes
- Default values: int, float, bool, string, mixed present/absent
- Required fields: present, missing (permissive + failfast), multiple fields, null input rows
- Enum: as-int, as-string, unknown values, mixed valid/unknown, row nulling in PERMISSIVE mode
- Error handling: malformed varint, truncated fields, wrong wire type, field number validation
- Unknown field skipping: varint, fixed64, length-delimited, fixed32
- Schema projection, last-one-wins, empty message, zero-row, null propagation

### Follow-up PRs

3. **Repeated + nested** — count/scan/build for repeated fields and recursive nested message decode
4. **Benchmarks + cleanup**