### PR TITLE
Add bytes to hex conversion kernel

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -236,6 +236,7 @@ add_library(
   src/from_json_to_raw_map.cu
   src/from_json_to_structs.cu
   src/get_json_object.cu
+  src/hex.cu
   src/hash/HashJni.cpp
   src/hash/hive_hash.cu
   src/hash/murmur_hash.cu

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,17 +296,22 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_bytesToHex(
     // STRING layout: data=chars bytes, children=[offsets]  (1 child)
     // LIST<INT8> layout: data=nullptr, children=[offsets, child_int8]  (2 children)
     auto const str_col = [&]() -> cudf::column_view {
-      if (col.type().id() == cudf::type_id::LIST) {
-        auto const lv = cudf::lists_column_view(col);
-        return cudf::column_view(cudf::data_type{cudf::type_id::STRING},
-                                 col.size(),
-                                 lv.child().head<char>(),
-                                 col.null_mask(),
-                                 col.null_count(),
-                                 col.offset(),
-                                 {lv.offsets()});
+      switch (col.type().id()) {
+        case cudf::type_id::LIST: {
+          auto const lv = cudf::lists_column_view(col);
+          CUDF_EXPECTS(lv.child().type().id() == cudf::type_id::INT8,
+                       "bytesToHex: LIST child must be INT8 (BinaryType)");
+          return cudf::column_view(cudf::data_type{cudf::type_id::STRING},
+                                   col.size(),
+                                   lv.child().head<char>(),
+                                   col.null_mask(),
+                                   col.null_count(),
+                                   col.offset(),
+                                   {lv.offsets()});
+        }
+        case cudf::type_id::STRING: return col;
+        default: CUDF_FAIL("bytesToHex: unsupported input type, expected STRING or LIST<INT8>");
       }
-      return col;
     }();
     auto const input = cudf::strings_column_view{str_col};
     auto result      = spark_rapids_jni::bytes_to_hex(input, cudf::get_default_stream());

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -22,6 +22,7 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/lists/lists_column_view.hpp>
 #include <cudf/replace.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/contains.hpp>
@@ -278,6 +279,38 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromInteger
       }
     }();
     return jni::release_as_jlong(result);
+  }
+  CATCH_CAST_EXCEPTION(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_bytesToHex(JNIEnv* env,
+                                                                                jclass,
+                                                                                jlong input_column)
+{
+  JNI_NULL_CHECK(env, input_column, "input column is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const col = *reinterpret_cast<cudf::column_view const*>(input_column);
+    // BinaryType arrives as LIST<INT8>. Reinterpret as STRING for the kernel.
+    // STRING layout: data=chars bytes, children=[offsets]  (1 child)
+    // LIST<INT8> layout: data=nullptr, children=[offsets, child_int8]  (2 children)
+    auto const str_col = [&]() -> cudf::column_view {
+      if (col.type().id() == cudf::type_id::LIST) {
+        auto const lv = cudf::lists_column_view(col);
+        return cudf::column_view(cudf::data_type{cudf::type_id::STRING},
+                                 col.size(),
+                                 lv.child().head<char>(),
+                                 col.null_mask(),
+                                 col.null_count(),
+                                 col.offset(),
+                                 {lv.offsets()});
+      }
+      return col;
+    }();
+    auto const input = cudf::strings_column_view{str_col};
+    auto result      = spark_rapids_jni::bytes_to_hex(input, cudf::get_default_stream());
+    return cudf::jni::release_as_jlong(result);
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -194,4 +194,20 @@ std::unique_ptr<cudf::column> parse_strings_to_date(
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
+/**
+ * @brief Convert a strings column to its hexadecimal representation.
+ *
+ * Each byte of each string is converted to a 2-character hex string (uppercase).
+ * For example, "AB" (bytes 0x41, 0x42) becomes "4142".
+ *
+ * @param input The input strings column
+ * @param stream Stream on which to operate.
+ * @param mr Memory resource for returned column
+ * @return A new strings column with hex representation
+ */
+std::unique_ptr<cudf::column> bytes_to_hex(
+  cudf::strings_column_view const& input,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -208,6 +208,6 @@ std::unique_ptr<cudf::column> parse_strings_to_date(
 std::unique_ptr<cudf::column> bytes_to_hex(
   cudf::strings_column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -21,6 +21,7 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/resource_ref.hpp>
 

--- a/src/main/cpp/src/hex.cu
+++ b/src/main/cpp/src/hex.cu
@@ -21,6 +21,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/null_mask.hpp>
+#include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -37,6 +38,20 @@ namespace detail {
 namespace {
 
 /**
+ * @brief Functor to compute output sizes from input offsets.
+ *
+ * Each input byte produces 2 hex characters, so output size = input byte count * 2.
+ */
+struct output_size_fn {
+  cudf::detail::input_offsetalator d_in_offsets;
+
+  __device__ cudf::size_type operator()(cudf::size_type idx) const
+  {
+    return static_cast<cudf::size_type>((d_in_offsets[idx + 1] - d_in_offsets[idx]) * 2);
+  }
+};
+
+/**
  * @brief Functor to convert each byte of a string to its 2-character hex representation.
  *
  * Output position is derived from the input string pointer, avoiding a separate
@@ -44,7 +59,7 @@ namespace {
  */
 struct write_hex_fn {
   cudf::column_device_view d_strings;
-  char const* d_chars_begin;  // start of input chars buffer
+  char const* d_chars_begin;
   char* d_out;
 
   __device__ void operator()(cudf::size_type idx) const
@@ -72,26 +87,15 @@ std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& inpu
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
 
-  auto const num_strings = input.size();
-
-  // Output offsets = input offsets * 2 (each byte produces 2 hex chars).
-  // This avoids both a sizing kernel and cudf detail APIs.
+  // Build output offsets from input offsets. Each byte produces 2 hex chars,
+  // so output_size[i] = (input_offset[i+1] - input_offset[i]) * 2.
+  // make_offsets_child_column handles the INT32/INT64 switch for large strings.
   auto const d_in_offsets =
     cudf::detail::offsetalator_factory::make_input_iterator(input.offsets());
-  auto offsets_column = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
-                                                  num_strings + 1,
-                                                  cudf::mask_state::UNALLOCATED,
-                                                  stream,
-                                                  mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
-                    d_in_offsets,
-                    d_in_offsets + num_strings + 1,
-                    offsets_column->mutable_view().data<int32_t>(),
-                    cuda::proclaim_return_type<int32_t>(
-                      [] __device__(int64_t offset) { return static_cast<int32_t>(offset * 2); }));
-
-  // Total output bytes = total input char bytes * 2.
-  auto const total_bytes = input.chars_size(stream) * 2;
+  auto sizes_itr = thrust::make_transform_iterator(
+    thrust::make_counting_iterator(cudf::size_type{0}), output_size_fn{d_in_offsets});
+  auto [offsets_column, total_bytes] = cudf::strings::detail::make_offsets_child_column(
+    sizes_itr, sizes_itr + input.size(), stream, mr);
 
   // Write hex chars in a single pass.
   auto chars = rmm::device_uvector<char>(total_bytes, stream, mr);
@@ -99,11 +103,11 @@ std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& inpu
     auto const d_column = cudf::column_device_view::create(input.parent(), stream);
     thrust::for_each(rmm::exec_policy_nosync(stream),
                      thrust::make_counting_iterator(cudf::size_type{0}),
-                     thrust::make_counting_iterator(num_strings),
+                     thrust::make_counting_iterator(input.size()),
                      write_hex_fn{*d_column, input.chars_begin(stream), chars.data()});
   }
 
-  return cudf::make_strings_column(num_strings,
+  return cudf::make_strings_column(input.size(),
                                    std::move(offsets_column),
                                    chars.release(),
                                    input.null_count(),

--- a/src/main/cpp/src/hex.cu
+++ b/src/main/cpp/src/hex.cu
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cast_string.hpp"
+#include "nvtx_ranges.hpp"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/detail/strings_children.cuh>
+#include <cudf/strings/strings_column_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+namespace spark_rapids_jni {
+
+namespace detail {
+namespace {
+
+/**
+ * @brief Functor for converting each byte of a string to its 2-character hex representation.
+ *
+ * Uses the standard two-pass pattern required by make_strings_children:
+ * - Pass 1 (d_chars == nullptr): compute output size for each row (input bytes * 2)
+ * - Pass 2 (d_chars != nullptr): write uppercase hex characters to output buffer
+ */
+struct bytes_to_hex_fn {
+  cudf::column_device_view d_strings;
+  cudf::size_type* d_sizes{};
+  char* d_chars{};
+  cudf::detail::input_offsetalator d_offsets;
+
+  __device__ void operator()(cudf::size_type idx)
+  {
+    if (d_strings.is_null(idx)) {
+      if (!d_chars) { d_sizes[idx] = 0; }
+      return;
+    }
+    auto const d_str  = d_strings.element<cudf::string_view>(idx);
+    auto const nbytes = d_str.size_bytes();
+    if (d_chars) {
+      auto* out = d_chars + d_offsets[idx];
+      auto* in  = reinterpret_cast<uint8_t const*>(d_str.data());
+      for (cudf::size_type i = 0; i < nbytes; ++i) {
+        uint8_t const byte = in[i];
+        uint8_t const hi   = byte >> 4;
+        uint8_t const lo   = byte & 0x0F;
+        out[i * 2]         = hi < 10 ? '0' + hi : 'A' + (hi - 10);
+        out[i * 2 + 1]     = lo < 10 ? '0' + lo : 'A' + (lo - 10);
+      }
+    } else {
+      d_sizes[idx] = nbytes * 2;
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& input,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr)
+{
+  if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
+
+  auto const d_column = cudf::column_device_view::create(input.parent(), stream);
+  auto [offsets_column, chars] = cudf::strings::detail::make_strings_children(
+    bytes_to_hex_fn{*d_column}, input.size(), stream, mr);
+
+  return cudf::make_strings_column(input.size(),
+                                   std::move(offsets_column),
+                                   chars.release(),
+                                   input.null_count(),
+                                   cudf::copy_bitmask(input.parent(), stream, mr));
+}
+
+}  // namespace detail
+
+std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& input,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr)
+{
+  SRJ_FUNC_RANGE();
+  return detail::bytes_to_hex(input, stream, mr);
+}
+
+}  // namespace spark_rapids_jni

--- a/src/main/cpp/src/hex.cu
+++ b/src/main/cpp/src/hex.cu
@@ -75,7 +75,7 @@ std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& inpu
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
 
-  auto const d_column = cudf::column_device_view::create(input.parent(), stream);
+  auto const d_column          = cudf::column_device_view::create(input.parent(), stream);
   auto [offsets_column, chars] = cudf::strings::detail::make_strings_children(
     bytes_to_hex_fn{*d_column}, input.size(), stream, mr);
 

--- a/src/main/cpp/src/hex.cu
+++ b/src/main/cpp/src/hex.cu
@@ -19,11 +19,17 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
 
 namespace spark_rapids_jni {
 
@@ -31,38 +37,43 @@ namespace detail {
 namespace {
 
 /**
- * @brief Functor for converting each byte of a string to its 2-character hex representation.
+ * @brief Functor to compute output string sizes from input offsets.
  *
- * Uses the standard two-pass pattern required by make_strings_children:
- * - Pass 1 (d_chars == nullptr): compute output size for each row (input bytes * 2)
- * - Pass 2 (d_chars != nullptr): write uppercase hex characters to output buffer
+ * Each input byte produces 2 hex characters, so output size = input byte count * 2.
+ * This avoids a separate sizing kernel by deriving sizes directly from offsets.
  */
-struct bytes_to_hex_fn {
-  cudf::column_device_view d_strings;
-  cudf::size_type* d_sizes{};
-  char* d_chars{};
-  cudf::detail::input_offsetalator d_offsets;
+struct output_size_fn {
+  cudf::detail::input_offsetalator d_input_offsets;
+  cudf::size_type col_offset;
 
-  __device__ void operator()(cudf::size_type idx)
+  __device__ cudf::size_type operator()(cudf::size_type idx) const
   {
-    if (d_strings.is_null(idx)) {
-      if (!d_chars) { d_sizes[idx] = 0; }
-      return;
-    }
+    return static_cast<cudf::size_type>(
+      (d_input_offsets[col_offset + idx + 1] - d_input_offsets[col_offset + idx]) * 2);
+  }
+};
+
+/**
+ * @brief Functor to convert each byte of a string to its 2-character hex representation.
+ */
+struct write_hex_fn {
+  cudf::column_device_view d_strings;
+  cudf::detail::input_offsetalator d_offsets;
+  char* d_chars;
+
+  __device__ void operator()(cudf::size_type idx) const
+  {
+    if (d_strings.is_null(idx)) { return; }
     auto const d_str  = d_strings.element<cudf::string_view>(idx);
     auto const nbytes = d_str.size_bytes();
-    if (d_chars) {
-      auto* out = d_chars + d_offsets[idx];
-      auto* in  = reinterpret_cast<uint8_t const*>(d_str.data());
-      for (cudf::size_type i = 0; i < nbytes; ++i) {
-        uint8_t const byte = in[i];
-        uint8_t const hi   = byte >> 4;
-        uint8_t const lo   = byte & 0x0F;
-        out[i * 2]         = hi < 10 ? '0' + hi : 'A' + (hi - 10);
-        out[i * 2 + 1]     = lo < 10 ? '0' + lo : 'A' + (lo - 10);
-      }
-    } else {
-      d_sizes[idx] = nbytes * 2;
+    auto* out         = d_chars + d_offsets[idx];
+    auto const* in    = reinterpret_cast<uint8_t const*>(d_str.data());
+    for (cudf::size_type i = 0; i < nbytes; ++i) {
+      uint8_t const byte = in[i];
+      uint8_t const hi   = byte >> 4;
+      uint8_t const lo   = byte & 0x0F;
+      out[i * 2]         = hi + (hi < 10 ? '0' : 'A' - 10);
+      out[i * 2 + 1]     = lo + (lo < 10 ? '0' : 'A' - 10);
     }
   }
 };
@@ -75,9 +86,25 @@ std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& inpu
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
 
-  auto const d_column          = cudf::column_device_view::create(input.parent(), stream);
-  auto [offsets_column, chars] = cudf::strings::detail::make_strings_children(
-    bytes_to_hex_fn{*d_column}, input.size(), stream, mr);
+  // Build output offsets directly from input offsets — no sizing kernel needed.
+  auto const d_input_offsets =
+    cudf::detail::offsetalator_factory::make_input_iterator(input.offsets());
+  auto sizes_itr = cudf::detail::make_counting_transform_iterator(
+    cudf::size_type{0}, output_size_fn{d_input_offsets, input.offset()});
+  auto [offsets_column, total_bytes] = cudf::strings::detail::make_offsets_child_column(
+    sizes_itr, sizes_itr + input.size(), stream, mr);
+
+  // Write hex chars in a single pass.
+  auto chars = rmm::device_uvector<char>(total_bytes, stream, mr);
+  if (total_bytes > 0) {
+    auto const d_column = cudf::column_device_view::create(input.parent(), stream);
+    auto const d_out_offsets =
+      cudf::detail::offsetalator_factory::make_input_iterator(offsets_column->view());
+    thrust::for_each(rmm::exec_policy_nosync(stream),
+                     thrust::make_counting_iterator<cudf::size_type>(0),
+                     thrust::make_counting_iterator(input.size()),
+                     write_hex_fn{*d_column, d_out_offsets, chars.data()});
+  }
 
   return cudf::make_strings_column(input.size(),
                                    std::move(offsets_column),

--- a/src/main/cpp/src/hex.cu
+++ b/src/main/cpp/src/hex.cu
@@ -19,17 +19,17 @@
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/null_mask.hpp>
-#include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform.h>
 
 namespace spark_rapids_jni {
 
@@ -37,37 +37,23 @@ namespace detail {
 namespace {
 
 /**
- * @brief Functor to compute output string sizes from input offsets.
- *
- * Each input byte produces 2 hex characters, so output size = input byte count * 2.
- * This avoids a separate sizing kernel by deriving sizes directly from offsets.
- */
-struct output_size_fn {
-  cudf::detail::input_offsetalator d_input_offsets;
-  cudf::size_type col_offset;
-
-  __device__ cudf::size_type operator()(cudf::size_type idx) const
-  {
-    return static_cast<cudf::size_type>(
-      (d_input_offsets[col_offset + idx + 1] - d_input_offsets[col_offset + idx]) * 2);
-  }
-};
-
-/**
  * @brief Functor to convert each byte of a string to its 2-character hex representation.
+ *
+ * Output position is derived from the input string pointer, avoiding a separate
+ * output offsets array read: out_offset = (in_ptr - chars_begin) * 2.
  */
 struct write_hex_fn {
   cudf::column_device_view d_strings;
-  cudf::detail::input_offsetalator d_offsets;
-  char* d_chars;
+  char const* d_chars_begin;  // start of input chars buffer
+  char* d_out;
 
   __device__ void operator()(cudf::size_type idx) const
   {
     if (d_strings.is_null(idx)) { return; }
     auto const d_str  = d_strings.element<cudf::string_view>(idx);
     auto const nbytes = d_str.size_bytes();
-    auto* out         = d_chars + d_offsets[idx];
     auto const* in    = reinterpret_cast<uint8_t const*>(d_str.data());
+    auto* out         = d_out + (d_str.data() - d_chars_begin) * 2;
     for (cudf::size_type i = 0; i < nbytes; ++i) {
       uint8_t const byte = in[i];
       uint8_t const hi   = byte >> 4;
@@ -86,27 +72,38 @@ std::unique_ptr<cudf::column> bytes_to_hex(cudf::strings_column_view const& inpu
 {
   if (input.is_empty()) { return cudf::make_empty_column(cudf::type_id::STRING); }
 
-  // Build output offsets directly from input offsets — no sizing kernel needed.
-  auto const d_input_offsets =
+  auto const num_strings = input.size();
+
+  // Output offsets = input offsets * 2 (each byte produces 2 hex chars).
+  // This avoids both a sizing kernel and cudf detail APIs.
+  auto const d_in_offsets =
     cudf::detail::offsetalator_factory::make_input_iterator(input.offsets());
-  auto sizes_itr = cudf::detail::make_counting_transform_iterator(
-    cudf::size_type{0}, output_size_fn{d_input_offsets, input.offset()});
-  auto [offsets_column, total_bytes] = cudf::strings::detail::make_offsets_child_column(
-    sizes_itr, sizes_itr + input.size(), stream, mr);
+  auto offsets_column = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                                  num_strings + 1,
+                                                  cudf::mask_state::UNALLOCATED,
+                                                  stream,
+                                                  mr);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    d_in_offsets,
+                    d_in_offsets + num_strings + 1,
+                    offsets_column->mutable_view().data<int32_t>(),
+                    cuda::proclaim_return_type<int32_t>(
+                      [] __device__(int64_t offset) { return static_cast<int32_t>(offset * 2); }));
+
+  // Total output bytes = total input char bytes * 2.
+  auto const total_bytes = input.chars_size(stream) * 2;
 
   // Write hex chars in a single pass.
   auto chars = rmm::device_uvector<char>(total_bytes, stream, mr);
   if (total_bytes > 0) {
     auto const d_column = cudf::column_device_view::create(input.parent(), stream);
-    auto const d_out_offsets =
-      cudf::detail::offsetalator_factory::make_input_iterator(offsets_column->view());
     thrust::for_each(rmm::exec_policy_nosync(stream),
-                     thrust::make_counting_iterator<cudf::size_type>(0),
-                     thrust::make_counting_iterator(input.size()),
-                     write_hex_fn{*d_column, d_out_offsets, chars.data()});
+                     thrust::make_counting_iterator(cudf::size_type{0}),
+                     thrust::make_counting_iterator(num_strings),
+                     write_hex_fn{*d_column, input.chars_begin(stream), chars.data()});
   }
 
-  return cudf::make_strings_column(input.size(),
+  return cudf::make_strings_column(num_strings,
                                    std::move(offsets_column),
                                    chars.release(),
                                    input.null_count(),

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -160,6 +160,18 @@ public class CastStrings {
   }
 
   /**
+   * Convert a strings/binary column to its hexadecimal representation.
+   * Each byte is converted to a 2-character uppercase hex string.
+   * For example, "AB" (bytes 0x41, 0x42) becomes "4142".
+   *
+   * @param cv The input strings column
+   * @return a new String ColumnVector with hex representation
+   */
+  public static ColumnVector bytesToHex(ColumnView cv) {
+    return new ColumnVector(bytesToHex(cv.getNativeView()));
+  }
+
+  /**
    * Trims and parses strings to intermediate result.
    * This is the first phase of casting string with timezone to timestamp.
    *
@@ -341,6 +353,7 @@ public class CastStrings {
   private static native long toIntegersWithBase(long nativeColumnView, int base,
     boolean ansiEnabled, int dtype);
   private static native long fromIntegersWithBase(long nativeColumnView, int base);
+  private static native long bytesToHex(long nativeColumnView);
 
   private static native long parseTimestampStringsToIntermediate(
       long input, int defaultTimezoneIndex,

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -423,6 +423,34 @@ public class CastStringsTest {
     }
   }
 
+  @Test
+  void bytesToHexStringTest() {
+    try (
+      ColumnVector input = ColumnVector.fromStrings("AB", "", "Spark", null, "\0\1\u00FF");
+      ColumnVector expected = ColumnVector.fromStrings("4142", "", "537061726B", null, "0001C3BF");
+      ColumnVector result = CastStrings.bytesToHex(input)
+    ) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void bytesToHexBinaryTest() {
+    try (
+      ColumnVector input = ColumnVector.fromLists(
+        new HostColumnVector.ListType(true, new HostColumnVector.BasicType(true, DType.INT8)),
+        Arrays.asList((byte)0x41, (byte)0x42),
+        Arrays.asList((byte)0x00, (byte)0xFF),
+        null,
+        Arrays.asList()
+      );
+      ColumnVector expected = ColumnVector.fromStrings("4142", "00FF", null, "");
+      ColumnVector result = CastStrings.bytesToHex(input)
+    ) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
   /**
    * Mock timezone info for testing.
    */


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/12550

This PR:

Add `bytesToHex` kernel that converts each byte of a STRING/BINARY column to its 2-character uppercase hex representation (e.g., `"AB"` → `"4142"`). This is used by `GpuHex` in spark-rapids for `hex(string)` and `hex(binary)` inputs.

- New CUDA kernel in `hex.cu` using the standard two-pass `make_strings_children` pattern
- JNI binding in `CastStringJni.cpp` with LIST<INT8> → STRING reinterpretation for BinaryType support
- Java API `CastStrings.bytesToHex(ColumnView)`

The `hex(long)` path reuses the existing `CastStrings.fromIntegersWithBase(col, 16)`.