### PR TITLE
Fix bytesToHex to accept LIST<UINT8> for BinaryType

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -299,8 +299,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_bytesToHex(
       switch (col.type().id()) {
         case cudf::type_id::LIST: {
           auto const lv = cudf::lists_column_view(col);
-          CUDF_EXPECTS(lv.child().type().id() == cudf::type_id::INT8,
-                       "bytesToHex: LIST child must be INT8 (BinaryType)");
+          CUDF_EXPECTS(lv.child().type().id() == cudf::type_id::UINT8,
+                       "bytesToHex: LIST child must be UINT8 (BinaryType)");
           return cudf::column_view(cudf::data_type{cudf::type_id::STRING},
                                    col.size(),
                                    lv.child().head<char>(),

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -438,7 +438,7 @@ public class CastStringsTest {
   void bytesToHexBinaryTest() {
     try (
       ColumnVector input = ColumnVector.fromLists(
-        new HostColumnVector.ListType(true, new HostColumnVector.BasicType(true, DType.INT8)),
+        new HostColumnVector.ListType(true, new HostColumnVector.BasicType(true, DType.UINT8)),
         Arrays.asList((byte)0x41, (byte)0x42),
         Arrays.asList((byte)0x00, (byte)0xFF),
         null,


### PR DESCRIPTION
## Summary
- spark-rapids represents BinaryType as `LIST<UINT8>` (see `GpuColumnVector.java`), but the type assertion in `bytesToHex` checked for `INT8`, rejecting all valid binary columns.
- Fixes CI failure in spark-rapids#14575.

## Test plan
- [ ] Existing `test_hex_binary` integration test passes (was failing before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)