### PR TITLE
Provide default tail read and vector read implementation.

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -20,8 +20,6 @@ import ai.rapids.cudf.HostMemoryBuffer;
 
 import java.io.EOFException;
 import java.io.IOException;
-
-import java.util.List;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalLong;
@@ -74,10 +72,12 @@ public interface RapidsInputFile {
     if (copyRanges.isEmpty()) {
       return;
     }
+    for (CopyRange copyRange : copyRanges) {
+      Objects.requireNonNull(copyRange, "copyRange can't be null");
+    }
 
     try (SeekableInputStream input = open()) {
       for (CopyRange copyRange : copyRanges) {
-        Objects.requireNonNull(copyRange, "copyRange can't be null");
         input.seek(copyRange.getInputOffset());
         output.copyFromStream(copyRange.getOutputOffset(), input, copyRange.getLength());
       }
@@ -92,6 +92,10 @@ public interface RapidsInputFile {
    *
    * <p>Data is written starting at offset 0 of the output buffer. The output buffer must have
    * capacity for at least {@code length} bytes.</p>
+   *
+   * <p>This default implementation computes the tail offset using {@link #getLength()} before
+   * calling {@link #open()}. If the file is truncated between those calls, the read may still
+   * fail with an I/O error.</p>
    *
    * @param length the number of bytes to read from the tail
    * @param output the buffer to read data into

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -18,7 +18,10 @@ package com.nvidia.spark.rapids.jni.fileio;
 
 import ai.rapids.cudf.HostMemoryBuffer;
 
+import ai.rapids.cudf.HostMemoryBuffer;
+
 import java.io.IOException;
+import java.util.List;
 import java.util.List;
 import java.util.OptionalLong;
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -18,11 +18,12 @@ package com.nvidia.spark.rapids.jni.fileio;
 
 import ai.rapids.cudf.HostMemoryBuffer;
 
-import ai.rapids.cudf.HostMemoryBuffer;
-
+import java.io.EOFException;
 import java.io.IOException;
+
 import java.util.List;
 import java.util.List;
+import java.util.Objects;
 import java.util.OptionalLong;
 
 /**
@@ -68,8 +69,19 @@ public interface RapidsInputFile {
    */
   default void readVectored(HostMemoryBuffer output, List<CopyRange> copyRanges)
       throws IOException {
-    throw new UnsupportedOperationException(
-        "readVectored is not supported for " + getClass().getName());
+    Objects.requireNonNull(output, "output can't be null");
+    Objects.requireNonNull(copyRanges, "copyRanges can't be null");
+    if (copyRanges.isEmpty()) {
+      return;
+    }
+
+    try (SeekableInputStream input = open()) {
+      for (CopyRange copyRange : copyRanges) {
+        Objects.requireNonNull(copyRange, "copyRange can't be null");
+        input.seek(copyRange.getInputOffset());
+        output.copyFromStream(copyRange.getOutputOffset(), input, copyRange.getLength());
+      }
+    }
   }
 
   /**
@@ -86,8 +98,24 @@ public interface RapidsInputFile {
    * @throws IOException if an I/O error occurs during reading
    */
   default void readTail(long length, HostMemoryBuffer output) throws IOException {
-    throw new UnsupportedOperationException(
-        "readTail is not supported for " + getClass().getName());
+    Objects.requireNonNull(output, "output can't be null");
+    if (length < 0) {
+      throw new IllegalArgumentException("length must be non-negative");
+    }
+    if (length == 0) {
+      return;
+    }
+
+    long fileLength = getLength();
+    if (length > fileLength) {
+      throw new EOFException(
+          "Cannot read tail of length " + length + " from file of length " + fileLength);
+    }
+
+    try (SeekableInputStream input = open()) {
+      input.seek(fileLength - length);
+      output.copyFromStream(0, input, length);
+    }
   }
 
   /**

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RapidsInputFileTest {
@@ -53,6 +54,19 @@ public class RapidsInputFileTest {
   }
 
   @Test
+  public void readVectoredRejectsNullRangesBeforeOpeningStream() throws IOException {
+    TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
+      assertThrows(NullPointerException.class,
+          () -> inputFile.readVectored(output, Arrays.asList(
+              new RapidsInputFile.CopyRange(0, 1, 0),
+              null,
+              new RapidsInputFile.CopyRange(1, 1, 1))));
+    }
+    assertEquals(0, inputFile.getOpenCount());
+  }
+
+  @Test
   public void readTailUsesSeekableStreamFallback() throws IOException {
     RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
     try (HostMemoryBuffer output = HostMemoryBuffer.allocate(4)) {
@@ -77,9 +91,11 @@ public class RapidsInputFileTest {
 
   private static final class TestRapidsInputFile implements RapidsInputFile {
     private final byte[] data;
+    private int openCount;
 
     private TestRapidsInputFile(byte[] data) {
       this.data = data;
+      this.openCount = 0;
     }
 
     @Override
@@ -87,8 +103,13 @@ public class RapidsInputFileTest {
       return data.length;
     }
 
+    private int getOpenCount() {
+      return openCount;
+    }
+
     @Override
     public SeekableInputStream open() {
+      openCount++;
       return new ArraySeekableInputStream(data);
     }
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni.fileio;
+
+import ai.rapids.cudf.HostMemoryBuffer;
+import org.junit.jupiter.api.Test;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RapidsInputFileTest {
+  private static final byte[] FILE_DATA = "abcdefghijklmnop".getBytes(StandardCharsets.UTF_8);
+
+  @Test
+  public void readVectoredUsesSeekableStreamFallback() throws IOException {
+    RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(5)) {
+      inputFile.readVectored(output, Arrays.asList(
+          new RapidsInputFile.CopyRange(2, 3, 0),
+          new RapidsInputFile.CopyRange(10, 2, 3)));
+      assertArrayEquals("cdekl".getBytes(StandardCharsets.UTF_8), readBytes(output));
+    }
+  }
+
+  @Test
+  public void readVectoredThrowsOnShortRead() throws IOException {
+    RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
+      assertThrows(EOFException.class,
+          () -> inputFile.readVectored(output,
+              Collections.singletonList(new RapidsInputFile.CopyRange(14, 3, 0))));
+    }
+  }
+
+  @Test
+  public void readTailUsesSeekableStreamFallback() throws IOException {
+    RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(4)) {
+      inputFile.readTail(4, output);
+      assertArrayEquals("mnop".getBytes(StandardCharsets.UTF_8), readBytes(output));
+    }
+  }
+
+  @Test
+  public void readTailThrowsWhenTailExceedsFileLength() throws IOException {
+    RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(FILE_DATA.length + 1L)) {
+      assertThrows(EOFException.class, () -> inputFile.readTail(FILE_DATA.length + 1L, output));
+    }
+  }
+
+  private static byte[] readBytes(HostMemoryBuffer buffer) {
+    byte[] bytes = new byte[Math.toIntExact(buffer.getLength())];
+    buffer.getBytes(bytes, 0, 0, bytes.length);
+    return bytes;
+  }
+
+  private static final class TestRapidsInputFile implements RapidsInputFile {
+    private final byte[] data;
+
+    private TestRapidsInputFile(byte[] data) {
+      this.data = data;
+    }
+
+    @Override
+    public long getLength() {
+      return data.length;
+    }
+
+    @Override
+    public SeekableInputStream open() {
+      return new ArraySeekableInputStream(data);
+    }
+  }
+
+  private static final class ArraySeekableInputStream extends SeekableInputStream {
+    private final byte[] data;
+    private int position;
+
+    private ArraySeekableInputStream(byte[] data) {
+      this.data = data;
+      this.position = 0;
+    }
+
+    @Override
+    public long getPos() {
+      return position;
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      if (newPos < 0 || newPos > data.length) {
+        throw new EOFException("Cannot seek to position " + newPos);
+      }
+      position = Math.toIntExact(newPos);
+    }
+
+    @Override
+    public int read() {
+      if (position >= data.length) {
+        return -1;
+      }
+      return data[position++] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) {
+      if (b == null) {
+        throw new NullPointerException("b can't be null");
+      }
+      if (off < 0 || len < 0 || len > b.length - off) {
+        throw new IndexOutOfBoundsException("Invalid off/len for destination buffer");
+      }
+      if (len == 0) {
+        return 0;
+      }
+      if (position >= data.length) {
+        return -1;
+      }
+
+      int amountToRead = Math.min(len, data.length - position);
+      System.arraycopy(data, position, b, off, amountToRead);
+      position += amountToRead;
+      return amountToRead;
+    }
+  }
+}


### PR DESCRIPTION
Related to https://github.com/nvidia/spark-rapids/issues/13305.

This pr provide default tailRead and vectorRead implementation using SeekableInputStream. This is to be compatible with normal path.