### PR TITLE
Minor change: Do not throw IllegalStateException in GpuTimeZoneDB to fix a vulnerability

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2023-2025, NVIDIA CORPORATION.
+* Copyright (c) 2023-2026, NVIDIA CORPORATION.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -116,22 +116,14 @@ public class GpuTimeZoneDB {
   }
 
   /**
-   * Verify the timezone database is loaded.
-   * If not loaded, throw IllegalStateException.
+   * Verify Timezone database is already cached.
+   * If not, throws an exception
+   * @throws RuntimeException if Timezone database is not cached
    */
-  private static synchronized void verifyDatabaseCachedSync() {
-    if (tzNameToIndexMap == null) {
-      throw new IllegalStateException("Timezone DB is not loaded, or the loading was failed.");
-    }
-  }
-
   public static void verifyDatabaseCached() {
-    if (tzNameToIndexMap != null) {
-      // already loaded
-      return;
+    if (tzNameToIndexMap == null) {
+      throw new RuntimeException("Timezone DB is not loaded, or the loading was failed.");
     }
-    // wait for the loading thread to finish
-    verifyDatabaseCachedSync();
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -122,9 +122,18 @@ public class GpuTimeZoneDB {
    * If loading was failed, throws an exception
    * @throws RuntimeException if Timezone database loading was failed
    */
-  public static synchronized void verifyDatabaseCached() {
-    if (tzNameToIndexMap == null) {
-      throw new RuntimeException("Timezone DB loading was failed.");
+  public static void verifyDatabaseCached() {
+    if (tzNameToIndexMap != null) {
+      // already loaded, this is the fast path
+      return;
+    }
+
+    // wait until loading is done
+    synchronized (GpuTimeZoneDB.class) {
+      if (tzNameToIndexMap == null) {
+        // null indicates error
+        throw new RuntimeException("Timezone DB loading was failed.");
+      }
     }
   }
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -120,7 +120,7 @@ public class GpuTimeZoneDB {
    * If not, throws an exception
    * @throws RuntimeException if Timezone database is not cached
    */
-  public static void verifyDatabaseCached() {
+  public static synchronized void verifyDatabaseCached() {
     if (tzNameToIndexMap == null) {
       throw new RuntimeException("Timezone DB is not loaded, or the loading was failed.");
     }

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -117,12 +117,14 @@ public class GpuTimeZoneDB {
 
   /**
    * Verify Timezone database is already cached.
-   * If not, throws an exception
-   * @throws RuntimeException if Timezone database is not cached
+   * This function is synchronized, wait until the loading is done.
+   * Refer to `cacheDatabaseImpl` which is also synchronized.
+   * If loading was failed, throws an exception
+   * @throws RuntimeException if Timezone database loading was failed
    */
   public static synchronized void verifyDatabaseCached() {
     if (tzNameToIndexMap == null) {
-      throw new RuntimeException("Timezone DB is not loaded, or the loading was failed.");
+      throw new RuntimeException("Timezone DB loading was failed.");
     }
   }
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -116,13 +116,13 @@ public class GpuTimeZoneDB {
   }
 
   /**
-   * Verify Timezone database is already cached.
+   * Verify Timezone database is already cached. Only for test purpose
    * This function is synchronized, wait until the loading is done.
    * Refer to `cacheDatabaseImpl` which is also synchronized.
    * If loading was failed, throws an exception
    * @throws RuntimeException if Timezone database loading was failed
    */
-  public static void verifyDatabaseCached() {
+  static void verifyDatabaseCached() {
     if (tzNameToIndexMap != null) {
       // already loaded, this is the fast path
       return;


### PR DESCRIPTION
Fix reported vulnerability

## changes
- This PR is a refactor, removed an useless private function.
- Change IllegalStateException to RuntimeException

Signed-off-by: Chong Gao <res_life@163.com>
