### PR TITLE
Refactor: add more check for RapidsInputFile.readVectored

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -72,8 +72,14 @@ public interface RapidsInputFile {
     if (copyRanges.isEmpty()) {
       return;
     }
+    long outputLength = output.getLength();
     for (CopyRange copyRange : copyRanges) {
       Objects.requireNonNull(copyRange, "copyRange can't be null");
+      long end = copyRange.getOutputOffset() + copyRange.getLength();
+      if (end > outputLength) {
+        throw new IllegalArgumentException(
+            "Output buffer length " + outputLength + " is smaller than requested end " + end);
+      }
     }
 
     try (SeekableInputStream input = open()) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -76,7 +76,7 @@ public interface RapidsInputFile {
     for (CopyRange copyRange : copyRanges) {
       Objects.requireNonNull(copyRange, "copyRange can't be null");
       long end = copyRange.getOutputOffset() + copyRange.getLength();
-      if (end > outputLength) {
+      if (end < 0 || end > outputLength) {
         throw new IllegalArgumentException(
             "Output buffer length " + outputLength + " is smaller than requested end " + end);
       }

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -67,6 +67,20 @@ public class RapidsInputFileTest {
   }
 
   @Test
+  public void readVectoredRejectsRangeExceedingOutputBeforeOpeningStream() throws IOException {
+    TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
+      assertThrows(IllegalArgumentException.class,
+          () -> inputFile.readVectored(output,
+              Collections.singletonList(new RapidsInputFile.CopyRange(0, 4, 0))));
+      assertThrows(IllegalArgumentException.class,
+          () -> inputFile.readVectored(output,
+              Collections.singletonList(new RapidsInputFile.CopyRange(0, 2, 2))));
+    }
+    assertEquals(0, inputFile.getOpenCount());
+  }
+
+  @Test
   public void readTailUsesSeekableStreamFallback() throws IOException {
     RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
     try (HostMemoryBuffer output = HostMemoryBuffer.allocate(4)) {


### PR DESCRIPTION
## Summary
- Add an output-buffer capacity check to the default `readVectored` on `RapidsInputFile`: throw `IllegalArgumentException` when any `CopyRange`'s `outputOffset + length` exceeds `output.getLength()`, before opening the stream.
- `CopyRange`'s constructor already rejects negative offsets and non-positive lengths, so those guards don't need to be duplicated.
- Motivation: spark-rapids subclasses (`HadoopInputFile`, `IcebergInputFile`) override `readVectored` almost entirely to add this one check. With the check here, those overrides can be deleted.

## Test plan
- [ ] `mvn test -Dtest=RapidsInputFileTest` — new `readVectoredRejectsRangeExceedingOutputBeforeOpeningStream` asserts `IllegalArgumentException` and `getOpenCount() == 0` (fail-fast before `open()`).
- [ ] Existing `RapidsInputFileTest` cases continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)