### PR TITLE
from_protobuf kernel (part 2): Repeated fields + nested messages

### DIFF
--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -21,6 +21,7 @@
 
 #include <thrust/binary_search.h>
 
+#include <limits>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -356,7 +357,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                        enum_valid_values,
                                        enum_names,
                                        &enum_lookup_cache};
-  bool fail_on_errors           = context.fail_on_errors;
+  bool fail_on_errors = context.fail_on_errors;
   CUDF_EXPECTS(binary_input.type().id() == cudf::type_id::LIST,
                "binary_input must be a LIST<INT8/UINT8> column");
   cudf::lists_column_view const in_list(binary_input);
@@ -409,8 +410,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   // Stage list_offsets[0] through pinned host memory so the D2H stays truly async (pageable
   // destinations turn small cudaMemcpyAsync calls into synchronous bounce-buffer copies).
-  auto h_base_offset =
-    cudf::detail::make_pinned_vector_async<cudf::size_type>(1, stream);
+  auto h_base_offset = cudf::detail::make_pinned_vector_async<cudf::size_type>(1, stream);
   CUDF_CUDA_TRY(cudaMemcpyAsync(h_base_offset.data(),
                                 list_offsets,
                                 sizeof(cudf::size_type),
@@ -507,8 +507,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   rmm::device_uvector<int> d_repeated_indices(
     num_repeated > 0 ? num_repeated : 1, stream, scratch_mr);
-  rmm::device_uvector<int> d_nested_indices(
-    num_nested > 0 ? num_nested : 1, stream, scratch_mr);
+  rmm::device_uvector<int> d_nested_indices(num_nested > 0 ? num_nested : 1, stream, scratch_mr);
 
   if (num_repeated > 0) {
     CUDF_CUDA_TRY(cudaMemcpyAsync(d_repeated_indices.data(),
@@ -979,11 +978,6 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     std::vector<std::unique_ptr<repeated_field_work>> rep_work;
     rep_work.reserve(num_repeated);
 
-    // Stage all per-field totals into a pinned host buffer with a single synchronize at the end,
-    // so the per-iteration D2H copies stay truly async (pageable destinations would force the
-    // driver into a synchronous bounce path on every copy).
-    auto h_total_counts = cudf::detail::make_pinned_vector_async<int32_t>(num_repeated, stream);
-
     for (int ri = 0; ri < num_repeated; ri++) {
       int schema_idx = repeated_field_indices[ri];
       auto& w        = *rep_work.emplace_back(
@@ -995,27 +989,25 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                         w.counts.data(),
                         extract_strided_count{d_repeated_info.data(), ri, num_repeated});
 
-      // exclusive_scan writes offsets[0..num_rows-1] (the leading 0 falls out for free, no memset
-      // needed); the trailing offsets[num_rows] = total is written by a single-element transform
-      // computing offsets[num_rows-1] + counts[num_rows-1] on the same stream.
-      thrust::exclusive_scan(
-        rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), w.offsets.begin(), 0);
-      auto* d_total = w.offsets.data() + num_rows;
-      thrust::transform(rmm::exec_policy_nosync(stream),
-                        w.counts.end() - 1,
-                        w.counts.end(),
-                        w.offsets.data() + (num_rows - 1),
-                        d_total,
-                        thrust::plus<int32_t>{});
+      // Reduce in int64 to detect overflow before truncating to int32 (cudf list offsets are
+      // int32). Mirrors the guard already used in `build_repeated_child_list_column`.
+      // `thrust::reduce` syncs the stream by returning the value, so subsequent host code can
+      // safely consume `w.total_count` without a separate stream.synchronize() per field.
+      int64_t total_64 = thrust::reduce(
+        rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), int64_t{0});
+      CUDF_EXPECTS(total_64 <= std::numeric_limits<int32_t>::max(),
+                   "Top-level repeated field total element count exceeds 2^31-1");
+      w.total_count = static_cast<int32_t>(total_64);
 
-      CUDF_CUDA_TRY(cudaMemcpyAsync(h_total_counts.data() + ri,
-                                    d_total,
-                                    sizeof(int32_t),
-                                    cudaMemcpyDeviceToHost,
-                                    stream.value()));
+      if (num_rows > 0) {
+        // offsets[0] must start at 0; inclusive scan into offsets+1 fills offsets[1..num_rows].
+        // Empty input (num_rows == 0) has w.counts.begin() == w.counts.end() and offsets size 1,
+        // so we skip both writes — the offsets buffer goes unused on the no-row path.
+        CUDF_CUDA_TRY(cudaMemsetAsync(w.offsets.data(), 0, sizeof(int32_t), stream.value()));
+        thrust::inclusive_scan(
+          rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), w.offsets.data() + 1);
+      }
     }
-    stream.synchronize();
-    for (int ri = 0; ri < num_repeated; ri++) { rep_work[ri]->total_count = h_total_counts[ri]; }
 
     // Phase B: Allocate occurrence buffers and launch ONE combined scan kernel.
     std::vector<repeated_field_scan_desc> h_scan_descs;

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -343,6 +343,19 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   auto const& default_strings   = context.default_strings;
   auto const& enum_valid_values = context.enum_valid_values;
   auto const& enum_names        = context.enum_names;
+  // Per-decode cache keyed by schema index for enum-as-string lookup tables. Reusing the
+  // device buffers across recursive call sites (each `build_repeated_child_list_column`
+  // invocation that hits the same enum field) avoids re-uploading the same metadata.
+  enum_string_lookup_cache enum_lookup_cache;
+  // Bundle defaults + enum metadata into a single view so the recursive nested/repeated
+  // builders take one parameter instead of six identical references.
+  schema_context_view const schema_ctx{default_ints,
+                                       default_floats,
+                                       default_bools,
+                                       default_strings,
+                                       enum_valid_values,
+                                       enum_names,
+                                       &enum_lookup_cache};
   bool fail_on_errors           = context.fail_on_errors;
   CUDF_EXPECTS(binary_input.type().id() == cudf::type_id::LIST,
                "binary_input must be a LIST<INT8/UINT8> column");
@@ -394,10 +407,21 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   auto const message_data_size = static_cast<cudf::size_type>(in_list_view.child().size());
   auto const* list_offsets     = in_list_view.offsets().data<cudf::size_type>();
 
-  cudf::size_type base_offset = 0;
-  CUDF_CUDA_TRY(cudaMemcpyAsync(
-    &base_offset, list_offsets, sizeof(cudf::size_type), cudaMemcpyDeviceToHost, stream.value()));
+  // Stage list_offsets[0] through pinned host memory so the D2H stays truly async (pageable
+  // destinations turn small cudaMemcpyAsync calls into synchronous bounce-buffer copies).
+  auto h_base_offset =
+    cudf::detail::make_pinned_vector_async<cudf::size_type>(1, stream);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(h_base_offset.data(),
+                                list_offsets,
+                                sizeof(cudf::size_type),
+                                cudaMemcpyDeviceToHost,
+                                stream.value()));
   stream.synchronize();
+  cudf::size_type base_offset = h_base_offset[0];
+
+  // Scratch allocations consumed inside this function go through the current device resource;
+  // only buffers that flow into the returned column should use the caller-supplied `mr`.
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
 
   // Copy schema to device
   std::vector<device_nested_field_descriptor> h_device_schema(num_fields);
@@ -405,7 +429,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     h_device_schema[i] = device_nested_field_descriptor{schema[i]};
   }
 
-  rmm::device_uvector<device_nested_field_descriptor> d_schema(num_fields, stream, mr);
+  rmm::device_uvector<device_nested_field_descriptor> d_schema(num_fields, stream, scratch_mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_schema.data(),
                                 h_device_schema.data(),
                                 num_fields * sizeof(device_nested_field_descriptor),
@@ -451,7 +475,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       case ERR_REQUIRED: return "Protobuf decode error: missing required field";
       case ERR_SCHEMA_TOO_LARGE:
         return "Protobuf decode error: schema exceeds maximum supported repeated fields per kernel "
-               "(128)";
+               "(32)";
       case ERR_MISSING_ENUM_META:
         return "Protobuf decode error: missing or mismatched enum metadata for enum-as-string "
                "field";
@@ -477,12 +501,14 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   // Allocate for counting repeated fields
   rmm::device_uvector<repeated_field_info> d_repeated_info(
-    num_repeated > 0 ? static_cast<size_t>(num_rows) * num_repeated : 1, stream, mr);
+    num_repeated > 0 ? static_cast<size_t>(num_rows) * num_repeated : 1, stream, scratch_mr);
   rmm::device_uvector<field_location> d_nested_locations(
-    num_nested > 0 ? static_cast<size_t>(num_rows) * num_nested : 1, stream, mr);
+    num_nested > 0 ? static_cast<size_t>(num_rows) * num_nested : 1, stream, scratch_mr);
 
-  rmm::device_uvector<int> d_repeated_indices(num_repeated > 0 ? num_repeated : 1, stream, mr);
-  rmm::device_uvector<int> d_nested_indices(num_nested > 0 ? num_nested : 1, stream, mr);
+  rmm::device_uvector<int> d_repeated_indices(
+    num_repeated > 0 ? num_repeated : 1, stream, scratch_mr);
+  rmm::device_uvector<int> d_nested_indices(
+    num_nested > 0 ? num_nested : 1, stream, scratch_mr);
 
   if (num_repeated > 0) {
     CUDF_CUDA_TRY(cudaMemcpyAsync(d_repeated_indices.data(),
@@ -500,8 +526,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   }
 
   // Count repeated fields at depth 0 (with O(1) field_number lookup tables)
-  rmm::device_uvector<int> d_fn_to_rep(0, stream, mr);
-  rmm::device_uvector<int> d_fn_to_nested(0, stream, mr);
+  rmm::device_uvector<int> d_fn_to_rep(0, stream, scratch_mr);
+  rmm::device_uvector<int> d_fn_to_nested(0, stream, scratch_mr);
 
   if (num_repeated > 0 || num_nested > 0) {
     auto h_fn_to_rep =
@@ -510,7 +536,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested);
 
     if (!h_fn_to_rep.empty()) {
-      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, mr);
+      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_rep.data(),
                                     h_fn_to_rep.data(),
                                     h_fn_to_rep.size() * sizeof(int),
@@ -518,7 +544,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                     stream.value()));
     }
     if (!h_fn_to_nested.empty()) {
-      d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, mr);
+      d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_nested.data(),
                                     h_fn_to_nested.data(),
                                     h_fn_to_nested.size() * sizeof(int),
@@ -702,7 +728,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           int si                  = scalar_field_indices[idxs[j]];
           auto dt                 = cudf::data_type{schema[si].output_type};
           auto& bp                = *bufs[j];
-          auto [mask, null_count] = make_null_mask_from_valid(bp.valid, stream, mr);
+          auto [mask, null_count] = make_null_mask_from_valid(bp.valid, num_rows, stream, mr);
           column_map[si]          = std::make_unique<cudf::column>(
             dt, num_rows, bp.out_bytes.release(), std::move(mask), null_count);
         }
@@ -953,10 +979,15 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     std::vector<std::unique_ptr<repeated_field_work>> rep_work;
     rep_work.reserve(num_repeated);
 
+    // Stage all per-field totals into a pinned host buffer with a single synchronize at the end,
+    // so the per-iteration D2H copies stay truly async (pageable destinations would force the
+    // driver into a synchronous bounce path on every copy).
+    auto h_total_counts = cudf::detail::make_pinned_vector_async<int32_t>(num_repeated, stream);
+
     for (int ri = 0; ri < num_repeated; ri++) {
       int schema_idx = repeated_field_indices[ri];
       auto& w        = *rep_work.emplace_back(
-        std::make_unique<repeated_field_work>(schema_idx, num_rows, stream, mr));
+        std::make_unique<repeated_field_work>(schema_idx, num_rows, stream, scratch_mr));
 
       thrust::transform(rmm::exec_policy_nosync(stream),
                         thrust::make_counting_iterator(0),
@@ -964,17 +995,27 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                         w.counts.data(),
                         extract_strided_count{d_repeated_info.data(), ri, num_repeated});
 
-      CUDF_CUDA_TRY(cudaMemsetAsync(w.offsets.data(), 0, sizeof(int32_t), stream.value()));
-      thrust::inclusive_scan(
-        rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), w.offsets.data() + 1);
+      // exclusive_scan writes offsets[0..num_rows-1] (the leading 0 falls out for free, no memset
+      // needed); the trailing offsets[num_rows] = total is written by a single-element transform
+      // computing offsets[num_rows-1] + counts[num_rows-1] on the same stream.
+      thrust::exclusive_scan(
+        rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), w.offsets.begin(), 0);
+      auto* d_total = w.offsets.data() + num_rows;
+      thrust::transform(rmm::exec_policy_nosync(stream),
+                        w.counts.end() - 1,
+                        w.counts.end(),
+                        w.offsets.data() + (num_rows - 1),
+                        d_total,
+                        thrust::plus<int32_t>{});
 
-      CUDF_CUDA_TRY(cudaMemcpyAsync(&w.total_count,
-                                    w.offsets.data() + num_rows,
+      CUDF_CUDA_TRY(cudaMemcpyAsync(h_total_counts.data() + ri,
+                                    d_total,
                                     sizeof(int32_t),
                                     cudaMemcpyDeviceToHost,
                                     stream.value()));
     }
     stream.synchronize();
+    for (int ri = 0; ri < num_repeated; ri++) { rep_work[ri]->total_count = h_total_counts[ri]; }
 
     // Phase B: Allocate occurrence buffers and launch ONE combined scan kernel.
     std::vector<repeated_field_scan_desc> h_scan_descs;
@@ -982,8 +1023,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     for (auto& wp : rep_work) {
       if (wp->total_count > 0) {
-        wp->occurrences =
-          std::make_unique<rmm::device_uvector<repeated_occurrence>>(wp->total_count, stream, mr);
+        wp->occurrences = std::make_unique<rmm::device_uvector<repeated_occurrence>>(
+          wp->total_count, stream, scratch_mr);
         h_scan_descs.push_back({schema[wp->schema_idx].field_number,
                                 static_cast<int>(schema[wp->schema_idx].wire_type),
                                 wp->offsets.data(),
@@ -992,7 +1033,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     }
 
     if (!h_scan_descs.empty()) {
-      rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(h_scan_descs.size(), stream, mr);
+      rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
+        h_scan_descs.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudaMemcpyAsync(d_scan_descs.data(),
                                     h_scan_descs.data(),
                                     h_scan_descs.size() * sizeof(h_scan_descs[0]),
@@ -1004,14 +1046,14 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       for (auto const& sd : h_scan_descs) {
         max_scan_fn = std::max(max_scan_fn, sd.field_number);
       }
-      rmm::device_uvector<int> d_fn_to_scan(0, stream, mr);
+      rmm::device_uvector<int> d_fn_to_scan(0, stream, scratch_mr);
       int fn_to_scan_size = 0;
       if (max_scan_fn <= FIELD_LOOKUP_TABLE_MAX) {
         std::vector<int> h_fn_to_scan(max_scan_fn + 1, -1);
         for (int i = 0; i < static_cast<int>(h_scan_descs.size()); i++) {
           h_fn_to_scan[h_scan_descs[i].field_number] = i;
         }
-        d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, mr);
+        d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
         CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_scan.data(),
                                       h_fn_to_scan.data(),
                                       h_fn_to_scan.size() * sizeof(int),
@@ -1231,13 +1273,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                                                     num_rows,
                                                                     h_device_schema,
                                                                     child_field_indices,
-                                                                    default_ints,
-                                                                    default_floats,
-                                                                    default_bools,
-                                                                    default_strings,
                                                                     schema,
-                                                                    enum_valid_values,
-                                                                    enum_names,
+                                                                    schema_ctx,
                                                                     d_row_force_null,
                                                                     d_error,
                                                                     stream,
@@ -1305,7 +1342,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       }
 
       // Extract parent locations for this nested field directly on GPU
-      rmm::device_uvector<field_location> d_parent_locs(num_rows, stream, mr);
+      rmm::device_uvector<field_location> d_parent_locs(num_rows, stream, scratch_mr);
       launch_extract_strided_locations(
         d_nested_locations.data(), ni, num_nested, d_parent_locs.data(), num_rows, stream);
 
@@ -1317,12 +1354,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                                                  child_field_indices,
                                                                  schema,
                                                                  num_fields,
-                                                                 default_ints,
-                                                                 default_floats,
-                                                                 default_bools,
-                                                                 default_strings,
-                                                                 enum_valid_values,
-                                                                 enum_names,
+                                                                 schema_ctx,
                                                                  d_row_force_null,
                                                                  d_error,
                                                                  num_rows,

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -340,6 +340,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   auto const& default_ints      = context.default_ints;
   auto const& default_floats    = context.default_floats;
   auto const& default_bools     = context.default_bools;
+  auto const& default_strings   = context.default_strings;
   auto const& enum_valid_values = context.enum_valid_values;
   auto const& enum_names        = context.enum_names;
   bool fail_on_errors           = context.fail_on_errors;
@@ -390,12 +391,26 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   // Extract shared input data pointers (used by scalar, repeated, and nested sections)
   cudf::lists_column_view const in_list_view(binary_input);
   auto const* message_data = reinterpret_cast<uint8_t const*>(in_list_view.child().data<int8_t>());
-  auto const* list_offsets = in_list_view.offsets().data<cudf::size_type>();
+  auto const message_data_size = static_cast<cudf::size_type>(in_list_view.child().size());
+  auto const* list_offsets     = in_list_view.offsets().data<cudf::size_type>();
 
   cudf::size_type base_offset = 0;
   CUDF_CUDA_TRY(cudaMemcpyAsync(
     &base_offset, list_offsets, sizeof(cudf::size_type), cudaMemcpyDeviceToHost, stream.value()));
   stream.synchronize();
+
+  // Copy schema to device
+  std::vector<device_nested_field_descriptor> h_device_schema(num_fields);
+  for (int i = 0; i < num_fields; i++) {
+    h_device_schema[i] = device_nested_field_descriptor{schema[i]};
+  }
+
+  rmm::device_uvector<device_nested_field_descriptor> d_schema(num_fields, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_schema.data(),
+                                h_device_schema.data(),
+                                num_fields * sizeof(device_nested_field_descriptor),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
 
   auto d_in = cudf::column_device_view::create(binary_input, stream);
   // Identify repeated and nested fields at depth 0
@@ -415,7 +430,9 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     }
   }
 
-  int num_scalar = static_cast<int>(scalar_field_indices.size());
+  int num_repeated = static_cast<int>(repeated_field_indices.size());
+  int num_nested   = static_cast<int>(nested_field_indices.size());
+  int num_scalar   = static_cast<int>(scalar_field_indices.size());
 
   // Error flag
   rmm::device_uvector<int> d_error(1, stream, cudf::get_current_device_resource_ref());
@@ -457,6 +474,76 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   auto const threads = THREADS_PER_BLOCK;
   auto const blocks  = static_cast<int>((num_rows + threads - 1u) / threads);
+
+  // Allocate for counting repeated fields
+  rmm::device_uvector<repeated_field_info> d_repeated_info(
+    num_repeated > 0 ? static_cast<size_t>(num_rows) * num_repeated : 1, stream, mr);
+  rmm::device_uvector<field_location> d_nested_locations(
+    num_nested > 0 ? static_cast<size_t>(num_rows) * num_nested : 1, stream, mr);
+
+  rmm::device_uvector<int> d_repeated_indices(num_repeated > 0 ? num_repeated : 1, stream, mr);
+  rmm::device_uvector<int> d_nested_indices(num_nested > 0 ? num_nested : 1, stream, mr);
+
+  if (num_repeated > 0) {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(d_repeated_indices.data(),
+                                  repeated_field_indices.data(),
+                                  num_repeated * sizeof(int),
+                                  cudaMemcpyHostToDevice,
+                                  stream.value()));
+  }
+  if (num_nested > 0) {
+    CUDF_CUDA_TRY(cudaMemcpyAsync(d_nested_indices.data(),
+                                  nested_field_indices.data(),
+                                  num_nested * sizeof(int),
+                                  cudaMemcpyHostToDevice,
+                                  stream.value()));
+  }
+
+  // Count repeated fields at depth 0 (with O(1) field_number lookup tables)
+  rmm::device_uvector<int> d_fn_to_rep(0, stream, mr);
+  rmm::device_uvector<int> d_fn_to_nested(0, stream, mr);
+
+  if (num_repeated > 0 || num_nested > 0) {
+    auto h_fn_to_rep =
+      build_index_lookup_table(schema.data(), repeated_field_indices.data(), num_repeated);
+    auto h_fn_to_nested =
+      build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested);
+
+    if (!h_fn_to_rep.empty()) {
+      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, mr);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_rep.data(),
+                                    h_fn_to_rep.data(),
+                                    h_fn_to_rep.size() * sizeof(int),
+                                    cudaMemcpyHostToDevice,
+                                    stream.value()));
+    }
+    if (!h_fn_to_nested.empty()) {
+      d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, mr);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_nested.data(),
+                                    h_fn_to_nested.data(),
+                                    h_fn_to_nested.size() * sizeof(int),
+                                    cudaMemcpyHostToDevice,
+                                    stream.value()));
+    }
+
+    launch_count_repeated_fields(*d_in,
+                                 d_schema.data(),
+                                 num_fields,
+                                 0,
+                                 d_repeated_info.data(),
+                                 num_repeated,
+                                 d_repeated_indices.data(),
+                                 d_nested_locations.data(),
+                                 num_nested,
+                                 d_nested_indices.data(),
+                                 d_error.data(),
+                                 d_fn_to_rep.data(),
+                                 static_cast<int>(d_fn_to_rep.size()),
+                                 d_fn_to_nested.data(),
+                                 static_cast<int>(d_fn_to_nested.size()),
+                                 num_rows,
+                                 stream);
+  }
 
   // Store decoded columns by schema index for ordered assembly at the end.
   std::vector<std::unique_ptr<cudf::column>> column_map(num_fields);
@@ -827,6 +914,423 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           column_map[schema_idx] = make_null_column(dt, num_rows, stream, mr);
           break;
       }
+    }
+  }
+
+  // Required top-level nested messages are tracked in d_nested_locations during the scan/count
+  // pass.
+  maybe_check_required_fields(d_nested_locations.data(),
+                              nested_field_indices,
+                              schema,
+                              num_rows,
+                              binary_input.null_count() > 0 ? binary_input.null_mask() : nullptr,
+                              binary_input.offset(),
+                              nullptr,
+                              track_permissive_null_rows ? d_row_force_null.data() : nullptr,
+                              nullptr,
+                              d_error.data(),
+                              stream);
+
+  // Process repeated fields (three-phase: offsets → combined scan → build columns)
+  if (num_repeated > 0) {
+    // Phase A: Compute per-row offsets for each repeated field.
+    struct repeated_field_work {
+      int schema_idx;
+      int32_t total_count{0};
+      rmm::device_uvector<int32_t> counts;
+      rmm::device_uvector<int32_t> offsets;
+      std::unique_ptr<rmm::device_uvector<repeated_occurrence>> occurrences;
+
+      repeated_field_work(int si,
+                          cudf::size_type n,
+                          rmm::cuda_stream_view s,
+                          rmm::device_async_resource_ref m)
+        : schema_idx(si), counts(n, s, m), offsets(n + 1, s, m)
+      {
+      }
+    };
+
+    std::vector<std::unique_ptr<repeated_field_work>> rep_work;
+    rep_work.reserve(num_repeated);
+
+    for (int ri = 0; ri < num_repeated; ri++) {
+      int schema_idx = repeated_field_indices[ri];
+      auto& w        = *rep_work.emplace_back(
+        std::make_unique<repeated_field_work>(schema_idx, num_rows, stream, mr));
+
+      thrust::transform(rmm::exec_policy_nosync(stream),
+                        thrust::make_counting_iterator(0),
+                        thrust::make_counting_iterator(num_rows),
+                        w.counts.data(),
+                        extract_strided_count{d_repeated_info.data(), ri, num_repeated});
+
+      CUDF_CUDA_TRY(cudaMemsetAsync(w.offsets.data(), 0, sizeof(int32_t), stream.value()));
+      thrust::inclusive_scan(
+        rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), w.offsets.data() + 1);
+
+      CUDF_CUDA_TRY(cudaMemcpyAsync(&w.total_count,
+                                    w.offsets.data() + num_rows,
+                                    sizeof(int32_t),
+                                    cudaMemcpyDeviceToHost,
+                                    stream.value()));
+    }
+    stream.synchronize();
+
+    // Phase B: Allocate occurrence buffers and launch ONE combined scan kernel.
+    std::vector<repeated_field_scan_desc> h_scan_descs;
+    h_scan_descs.reserve(num_repeated);
+
+    for (auto& wp : rep_work) {
+      if (wp->total_count > 0) {
+        wp->occurrences =
+          std::make_unique<rmm::device_uvector<repeated_occurrence>>(wp->total_count, stream, mr);
+        h_scan_descs.push_back({schema[wp->schema_idx].field_number,
+                                static_cast<int>(schema[wp->schema_idx].wire_type),
+                                wp->offsets.data(),
+                                wp->occurrences->data()});
+      }
+    }
+
+    if (!h_scan_descs.empty()) {
+      rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(h_scan_descs.size(), stream, mr);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(d_scan_descs.data(),
+                                    h_scan_descs.data(),
+                                    h_scan_descs.size() * sizeof(h_scan_descs[0]),
+                                    cudaMemcpyHostToDevice,
+                                    stream.value()));
+
+      // Build field_number -> scan_desc_index lookup for the combined kernel
+      int max_scan_fn = 0;
+      for (auto const& sd : h_scan_descs) {
+        max_scan_fn = std::max(max_scan_fn, sd.field_number);
+      }
+      rmm::device_uvector<int> d_fn_to_scan(0, stream, mr);
+      int fn_to_scan_size = 0;
+      if (max_scan_fn <= FIELD_LOOKUP_TABLE_MAX) {
+        std::vector<int> h_fn_to_scan(max_scan_fn + 1, -1);
+        for (int i = 0; i < static_cast<int>(h_scan_descs.size()); i++) {
+          h_fn_to_scan[h_scan_descs[i].field_number] = i;
+        }
+        d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, mr);
+        CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_scan.data(),
+                                      h_fn_to_scan.data(),
+                                      h_fn_to_scan.size() * sizeof(int),
+                                      cudaMemcpyHostToDevice,
+                                      stream.value()));
+        fn_to_scan_size = static_cast<int>(h_fn_to_scan.size());
+      }
+
+      launch_scan_all_repeated_occurrences(*d_in,
+                                           d_scan_descs.data(),
+                                           static_cast<int>(h_scan_descs.size()),
+                                           d_error.data(),
+                                           fn_to_scan_size > 0 ? d_fn_to_scan.data() : nullptr,
+                                           fn_to_scan_size,
+                                           num_rows,
+                                           stream);
+    }
+
+    // Phase C: Build columns per field.
+    for (int ri = 0; ri < num_repeated; ri++) {
+      auto& w              = *rep_work[ri];
+      int schema_idx       = w.schema_idx;
+      auto element_type    = cudf::data_type{schema[schema_idx].output_type};
+      int32_t total_count  = w.total_count;
+      auto& d_field_counts = w.counts;
+
+      if (total_count > 0) {
+        auto& d_occurrences = *w.occurrences;
+
+        // Build the appropriate column type based on element type
+        auto child_type_id = static_cast<cudf::type_id>(h_device_schema[schema_idx].output_type_id);
+
+        // The output_type in schema is the LIST type, but we need element type
+        // For repeated int32, output_type should indicate the element is INT32
+        switch (child_type_id) {
+          case cudf::type_id::INT32:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<int32_t>(binary_input,
+                                                    message_data,
+                                                    list_offsets,
+                                                    base_offset,
+                                                    h_device_schema[schema_idx],
+                                                    d_field_counts,
+                                                    d_occurrences,
+                                                    total_count,
+                                                    num_rows,
+                                                    d_error,
+                                                    stream,
+                                                    mr);
+            break;
+          case cudf::type_id::INT64:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<int64_t>(binary_input,
+                                                    message_data,
+                                                    list_offsets,
+                                                    base_offset,
+                                                    h_device_schema[schema_idx],
+                                                    d_field_counts,
+                                                    d_occurrences,
+                                                    total_count,
+                                                    num_rows,
+                                                    d_error,
+                                                    stream,
+                                                    mr);
+            break;
+          case cudf::type_id::UINT32:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<uint32_t>(binary_input,
+                                                     message_data,
+                                                     list_offsets,
+                                                     base_offset,
+                                                     h_device_schema[schema_idx],
+                                                     d_field_counts,
+                                                     d_occurrences,
+                                                     total_count,
+                                                     num_rows,
+                                                     d_error,
+                                                     stream,
+                                                     mr);
+            break;
+          case cudf::type_id::UINT64:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<uint64_t>(binary_input,
+                                                     message_data,
+                                                     list_offsets,
+                                                     base_offset,
+                                                     h_device_schema[schema_idx],
+                                                     d_field_counts,
+                                                     d_occurrences,
+                                                     total_count,
+                                                     num_rows,
+                                                     d_error,
+                                                     stream,
+                                                     mr);
+            break;
+          case cudf::type_id::FLOAT32:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<float>(binary_input,
+                                                  message_data,
+                                                  list_offsets,
+                                                  base_offset,
+                                                  h_device_schema[schema_idx],
+                                                  d_field_counts,
+                                                  d_occurrences,
+                                                  total_count,
+                                                  num_rows,
+                                                  d_error,
+                                                  stream,
+                                                  mr);
+            break;
+          case cudf::type_id::FLOAT64:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<double>(binary_input,
+                                                   message_data,
+                                                   list_offsets,
+                                                   base_offset,
+                                                   h_device_schema[schema_idx],
+                                                   d_field_counts,
+                                                   d_occurrences,
+                                                   total_count,
+                                                   num_rows,
+                                                   d_error,
+                                                   stream,
+                                                   mr);
+            break;
+          case cudf::type_id::BOOL8:
+            column_map[schema_idx] =
+              build_repeated_scalar_column<uint8_t>(binary_input,
+                                                    message_data,
+                                                    list_offsets,
+                                                    base_offset,
+                                                    h_device_schema[schema_idx],
+                                                    d_field_counts,
+                                                    d_occurrences,
+                                                    total_count,
+                                                    num_rows,
+                                                    d_error,
+                                                    stream,
+                                                    mr);
+            break;
+          case cudf::type_id::STRING: {
+            auto const field_meta = make_field_meta_view(context, schema_idx);
+            auto enc              = field_meta.schema.encoding;
+            if (enc == proto_encoding::ENUM_STRING) {
+              if (!field_meta.enum_valid_values.empty() &&
+                  field_meta.enum_valid_values.size() == field_meta.enum_names.size()) {
+                column_map[schema_idx] =
+                  build_repeated_enum_string_column(binary_input,
+                                                    message_data,
+                                                    list_offsets,
+                                                    base_offset,
+                                                    d_field_counts,
+                                                    d_occurrences,
+                                                    total_count,
+                                                    num_rows,
+                                                    field_meta.enum_valid_values,
+                                                    field_meta.enum_names,
+                                                    d_row_force_null,
+                                                    d_error,
+                                                    stream,
+                                                    mr);
+              } else {
+                set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+                column_map[schema_idx] = make_null_column(
+                  cudf::data_type{schema[schema_idx].output_type}, num_rows, stream, mr);
+              }
+            } else {
+              column_map[schema_idx] = build_repeated_string_column(binary_input,
+                                                                    message_data,
+                                                                    list_offsets,
+                                                                    base_offset,
+                                                                    h_device_schema[schema_idx],
+                                                                    d_field_counts,
+                                                                    d_occurrences,
+                                                                    total_count,
+                                                                    num_rows,
+                                                                    false,
+                                                                    d_error,
+                                                                    stream,
+                                                                    mr);
+            }
+            break;
+          }
+          case cudf::type_id::LIST:  // bytes as LIST<INT8>
+            column_map[schema_idx] = build_repeated_string_column(binary_input,
+                                                                  message_data,
+                                                                  list_offsets,
+                                                                  base_offset,
+                                                                  h_device_schema[schema_idx],
+                                                                  d_field_counts,
+                                                                  d_occurrences,
+                                                                  total_count,
+                                                                  num_rows,
+                                                                  true,
+                                                                  d_error,
+                                                                  stream,
+                                                                  mr);
+            break;
+          case cudf::type_id::STRUCT: {
+            // Repeated message field - ArrayType(StructType)
+            auto child_field_indices = find_child_field_indices(schema, num_fields, schema_idx);
+            if (child_field_indices.empty()) {
+              auto empty_struct_child =
+                make_empty_struct_column_with_schema(schema, schema_idx, num_fields, stream, mr);
+              column_map[schema_idx] = make_null_list_column_with_child(
+                std::move(empty_struct_child), num_rows, stream, mr);
+            } else {
+              column_map[schema_idx] = build_repeated_struct_column(binary_input,
+                                                                    message_data,
+                                                                    message_data_size,
+                                                                    list_offsets,
+                                                                    base_offset,
+                                                                    h_device_schema[schema_idx],
+                                                                    d_field_counts,
+                                                                    d_occurrences,
+                                                                    total_count,
+                                                                    num_rows,
+                                                                    h_device_schema,
+                                                                    child_field_indices,
+                                                                    default_ints,
+                                                                    default_floats,
+                                                                    default_bools,
+                                                                    default_strings,
+                                                                    schema,
+                                                                    enum_valid_values,
+                                                                    enum_names,
+                                                                    d_row_force_null,
+                                                                    d_error,
+                                                                    stream,
+                                                                    mr);
+            }
+            break;
+          }
+          default:
+            // Unsupported element type - create null column
+            column_map[schema_idx] = make_null_list_column_with_child(
+              make_empty_column_safe(element_type, stream, mr), num_rows, stream, mr);
+            break;
+        }
+      } else {
+        // All rows have count=0 - create list of empty elements
+        rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
+        thrust::fill(rmm::exec_policy_nosync(stream), offsets.begin(), offsets.end(), 0);
+        auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                          num_rows + 1,
+                                                          offsets.release(),
+                                                          rmm::device_buffer{},
+                                                          0);
+
+        // Build appropriate empty child column
+        std::unique_ptr<cudf::column> child_col;
+        auto child_type_id = static_cast<cudf::type_id>(h_device_schema[schema_idx].output_type_id);
+        if (child_type_id == cudf::type_id::STRUCT) {
+          // Use helper to build empty struct with proper nested structure
+          child_col =
+            make_empty_struct_column_with_schema(schema, schema_idx, num_fields, stream, mr);
+        } else {
+          child_col =
+            make_empty_column_safe(cudf::data_type{schema[schema_idx].output_type}, stream, mr);
+        }
+
+        auto const input_null_count = binary_input.null_count();
+        if (input_null_count > 0) {
+          auto null_mask         = cudf::copy_bitmask(binary_input, stream, mr);
+          column_map[schema_idx] = cudf::make_lists_column(num_rows,
+                                                           std::move(offsets_col),
+                                                           std::move(child_col),
+                                                           input_null_count,
+                                                           std::move(null_mask));
+        } else {
+          column_map[schema_idx] = cudf::make_lists_column(
+            num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+        }
+      }
+    }
+  }
+
+  // Process nested struct fields (Phase 2)
+  if (num_nested > 0) {
+    for (int ni = 0; ni < num_nested; ni++) {
+      int parent_schema_idx = nested_field_indices[ni];
+
+      // Find child fields of this nested message
+      auto child_field_indices = find_child_field_indices(schema, num_fields, parent_schema_idx);
+
+      if (child_field_indices.empty()) {
+        // No child fields - create empty struct
+        column_map[parent_schema_idx] = make_null_column(
+          cudf::data_type{schema[parent_schema_idx].output_type}, num_rows, stream, mr);
+        continue;
+      }
+
+      // Extract parent locations for this nested field directly on GPU
+      rmm::device_uvector<field_location> d_parent_locs(num_rows, stream, mr);
+      launch_extract_strided_locations(
+        d_nested_locations.data(), ni, num_nested, d_parent_locs.data(), num_rows, stream);
+
+      column_map[parent_schema_idx] = build_nested_struct_column(message_data,
+                                                                 message_data_size,
+                                                                 list_offsets,
+                                                                 base_offset,
+                                                                 d_parent_locs,
+                                                                 child_field_indices,
+                                                                 schema,
+                                                                 num_fields,
+                                                                 default_ints,
+                                                                 default_floats,
+                                                                 default_bools,
+                                                                 default_strings,
+                                                                 enum_valid_values,
+                                                                 enum_names,
+                                                                 d_row_force_null,
+                                                                 d_error,
+                                                                 num_rows,
+                                                                 stream,
+                                                                 mr,
+                                                                 nullptr,
+                                                                 0,
+                                                                 false);
     }
   }
 

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -991,8 +991,14 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
       // Reduce in int64 to detect overflow before truncating to int32 (cudf list offsets are
       // int32). Mirrors the guard already used in `build_repeated_child_list_column`.
-      // `thrust::reduce` syncs the stream by returning the value, so subsequent host code can
-      // safely consume `w.total_count` without a separate stream.synchronize() per field.
+      //
+      // NOTE: `thrust::reduce` returns the value to the host, which implicitly syncs the stream
+      // once per repeated field — i.e. Phase A is O(num_repeated) syncs. We accept this for
+      // correctness: an async device-side reduce (e.g. `cub::DeviceReduce::Sum` writing to a
+      // device buffer + a single batched D2H) would let us keep one synchronize per decode call,
+      // but requires a transform-iterator promotion to int64 to keep the accumulator wide. With
+      // typical schemas carrying <16 top-level repeated fields the saved syncs are µs-scale and
+      // not worth the extra complexity at this point. Revisit alongside benchmarks in part 4.
       int64_t total_64 = thrust::reduce(
         rmm::exec_policy_nosync(stream), w.counts.begin(), w.counts.end(), int64_t{0});
       CUDF_EXPECTS(total_64 <= std::numeric_limits<int32_t>::max(),

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -38,8 +38,10 @@ inline rmm::device_uvector<int32_t> make_list_offsets_from_counts(
   rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
   thrust::exclusive_scan(
     rmm::exec_policy_nosync(stream), counts.begin(), counts.end(), offsets.begin(), 0);
-  thrust::fill_n(
-    rmm::exec_policy_nosync(stream), offsets.data() + num_rows, 1, static_cast<int32_t>(total_count));
+  thrust::fill_n(rmm::exec_policy_nosync(stream),
+                 offsets.data() + num_rows,
+                 1,
+                 static_cast<int32_t>(total_count));
   return offsets;
 }
 
@@ -96,8 +98,8 @@ make_single_repeated_schema(int child_schema_idx,
 
   int const zero = 0;
   rmm::device_uvector<int> d_indices(1, stream, mr);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(
-    d_indices.data(), &zero, sizeof(int), cudaMemcpyHostToDevice, stream.value()));
+  CUDF_CUDA_TRY(
+    cudaMemcpyAsync(d_indices.data(), &zero, sizeof(int), cudaMemcpyHostToDevice, stream.value()));
   return {std::move(d_schema), std::move(d_indices)};
 }
 
@@ -600,7 +602,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
     build_enum_string_values_column(enum_ints, elem_valid, lookup, total_count, stream, mr);
 
   // Build the final LIST<STRING> column from the per-row counts and decoded child strings.
-  auto lo            = make_list_offsets_from_counts(d_field_counts, total_count, num_rows, stream, mr);
+  auto lo = make_list_offsets_from_counts(d_field_counts, total_count, num_rows, stream, mr);
   auto list_offs_col = std::make_unique<cudf::column>(
     cudf::data_type{cudf::type_id::INT32}, num_rows + 1, lo.release(), rmm::device_buffer{}, 0);
 
@@ -851,8 +853,7 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
   auto h_lookup_vec = build_field_lookup_table(h_child_descs.data(), num_child_fields);
   rmm::device_uvector<int> d_child_lookup(0, stream, scratch_mr);
   if (!h_lookup_vec.empty()) {
-    auto h_child_lookup =
-      cudf::detail::make_pinned_vector_async<int>(h_lookup_vec.size(), stream);
+    auto h_child_lookup = cudf::detail::make_pinned_vector_async<int>(h_lookup_vec.size(), stream);
     std::copy(h_lookup_vec.begin(), h_lookup_vec.end(), h_child_lookup.begin());
     d_child_lookup = rmm::device_uvector<int>(h_child_lookup.size(), stream, scratch_mr);
     CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_lookup.data(),

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -21,6 +21,115 @@
 
 namespace spark_rapids_jni::protobuf::detail {
 
+std::unique_ptr<cudf::column> build_repeated_msg_child_varlen_column(
+  uint8_t const* message_data,
+  rmm::device_uvector<cudf::size_type> const& d_msg_row_offsets,
+  rmm::device_uvector<field_location> const& d_msg_locs,
+  rmm::device_uvector<field_location> const& d_child_locs,
+  int child_idx,
+  int num_child_fields,
+  int total_count,
+  rmm::device_uvector<int>& d_error,
+  bool as_bytes,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  if (total_count == 0) {
+    if (as_bytes) return make_empty_column_safe(cudf::data_type{cudf::type_id::LIST}, stream, mr);
+    return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
+  }
+
+  rmm::device_uvector<int32_t> d_lengths(total_count, stream, mr);
+  thrust::transform(
+    rmm::exec_policy_nosync(stream),
+    thrust::make_counting_iterator(0),
+    thrust::make_counting_iterator(total_count),
+    d_lengths.data(),
+    [child_locs = d_child_locs.data(), ci = child_idx, ncf = num_child_fields] __device__(int idx) {
+      auto const& loc = child_locs[flat_index(
+        static_cast<size_t>(idx), static_cast<size_t>(ncf), static_cast<size_t>(ci))];
+      return loc.offset >= 0 ? loc.length : 0;
+    });
+
+  auto [offsets_col, total_data] = cudf::strings::detail::make_offsets_child_column(
+    d_lengths.begin(), d_lengths.end(), stream, mr);
+
+  rmm::device_uvector<char> d_data(total_data, stream, mr);
+  rmm::device_uvector<bool> d_valid((total_count > 0 ? total_count : 1), stream, mr);
+
+  thrust::transform(
+    rmm::exec_policy_nosync(stream),
+    thrust::make_counting_iterator(0),
+    thrust::make_counting_iterator(total_count),
+    d_valid.data(),
+    [child_locs = d_child_locs.data(), ci = child_idx, ncf = num_child_fields] __device__(int idx) {
+      return child_locs[flat_index(static_cast<size_t>(idx),
+                                   static_cast<size_t>(ncf),
+                                   static_cast<size_t>(ci))]
+               .offset >= 0;
+    });
+
+  if (total_data > 0) {
+    repeated_msg_child_location_provider loc_provider{d_msg_row_offsets.data(),
+                                                      0,
+                                                      d_msg_locs.data(),
+                                                      d_child_locs.data(),
+                                                      child_idx,
+                                                      num_child_fields};
+    auto const* offsets_data = offsets_col->view().data<cudf::size_type>();
+    auto* chars_ptr          = d_data.data();
+
+    auto src_iter = cudf::detail::make_counting_transform_iterator(
+      0,
+      cuda::proclaim_return_type<void const*>(
+        [message_data, loc_provider] __device__(int idx) -> void const* {
+          int32_t data_offset = 0;
+          auto loc            = loc_provider.get(idx, data_offset);
+          if (loc.offset < 0) return nullptr;
+          return static_cast<void const*>(message_data + data_offset);
+        }));
+    auto dst_iter = cudf::detail::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<void*>([chars_ptr, offsets_data] __device__(int idx) -> void* {
+        return static_cast<void*>(chars_ptr + offsets_data[idx]);
+      }));
+    auto size_iter = cudf::detail::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<size_t>([loc_provider] __device__(int idx) -> size_t {
+        int32_t data_offset = 0;
+        auto loc            = loc_provider.get(idx, data_offset);
+        if (loc.offset < 0) return 0;
+        return static_cast<size_t>(loc.length);
+      }));
+
+    size_t temp_storage_bytes = 0;
+    cub::DeviceMemcpy::Batched(
+      nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, total_count, stream.value());
+    rmm::device_buffer temp_storage(temp_storage_bytes, stream, mr);
+    cub::DeviceMemcpy::Batched(temp_storage.data(),
+                               temp_storage_bytes,
+                               src_iter,
+                               dst_iter,
+                               size_iter,
+                               total_count,
+                               stream.value());
+  }
+
+  auto [mask, null_count] = make_null_mask_from_valid(d_valid, stream, mr);
+
+  if (as_bytes) {
+    auto bytes_child =
+      std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
+                                     total_data,
+                                     rmm::device_buffer(d_data.data(), total_data, stream, mr),
+                                     rmm::device_buffer{},
+                                     0);
+    return cudf::make_lists_column(
+      total_count, std::move(offsets_col), std::move(bytes_child), null_count, std::move(mask));
+  }
+
+  return cudf::make_strings_column(
+    total_count, std::move(offsets_col), d_data.release(), null_count, std::move(mask));
+}
+
 std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
                                                cudf::size_type num_rows,
                                                rmm::cuda_stream_view stream,
@@ -250,6 +359,1355 @@ std::unique_ptr<cudf::column> build_enum_string_column(
                                        propagate_invalid_rows,
                                        stream);
   return build_enum_string_values_column(enum_values, valid, lookup, num_rows, stream, mr);
+}
+
+std::unique_ptr<cudf::column> build_repeated_msg_child_enum_string_column(
+  uint8_t const* message_data,
+  rmm::device_uvector<cudf::size_type> const& d_msg_row_offsets,
+  rmm::device_uvector<field_location> const& d_msg_locs,
+  rmm::device_uvector<field_location> const& d_child_locs,
+  int child_idx,
+  int num_child_fields,
+  int total_count,
+  cudf::detail::host_vector<int32_t> const& valid_enums,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  rmm::device_uvector<bool>& d_row_force_null,
+  int32_t const* top_row_indices,
+  bool propagate_invalid_rows,
+  rmm::device_uvector<int>& d_error,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const threads = THREADS_PER_BLOCK;
+  auto const blocks  = static_cast<int>((total_count + threads - 1u) / threads);
+  auto lookup        = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+
+  rmm::device_uvector<int32_t> enum_values(total_count, stream, mr);
+  rmm::device_uvector<bool> valid((total_count > 0 ? total_count : 1), stream, mr);
+  repeated_msg_child_location_provider loc_provider{d_msg_row_offsets.data(),
+                                                    0,
+                                                    d_msg_locs.data(),
+                                                    d_child_locs.data(),
+                                                    child_idx,
+                                                    num_child_fields};
+  extract_varint_kernel<int32_t, false, repeated_msg_child_location_provider>
+    <<<blocks, threads, 0, stream.value()>>>(message_data,
+                                             loc_provider,
+                                             total_count,
+                                             enum_values.data(),
+                                             valid.data(),
+                                             d_error.data(),
+                                             false,
+                                             0);
+
+  rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, mr);
+  thrust::fill(rmm::exec_policy_nosync(stream),
+               d_elem_has_invalid_enum.begin(),
+               d_elem_has_invalid_enum.end(),
+               false);
+  launch_validate_enum_values(enum_values.data(),
+                              valid.data(),
+                              d_elem_has_invalid_enum.data(),
+                              lookup.d_valid_enums.data(),
+                              static_cast<int>(valid_enums.size()),
+                              total_count,
+                              stream);
+  propagate_invalid_enum_flags_to_rows(d_elem_has_invalid_enum,
+                                       d_row_force_null,
+                                       total_count,
+                                       top_row_indices,
+                                       propagate_invalid_rows,
+                                       stream);
+  return build_enum_string_values_column(enum_values, valid, lookup, total_count, stream, mr);
+}
+
+std::unique_ptr<cudf::column> build_repeated_enum_string_column(
+  cudf::column_view const& binary_input,
+  uint8_t const* message_data,
+  cudf::size_type const* list_offsets,
+  cudf::size_type base_offset,
+  rmm::device_uvector<int32_t> const& d_field_counts,
+  rmm::device_uvector<repeated_occurrence>& d_occurrences,
+  int total_count,
+  int num_rows,
+  cudf::detail::host_vector<int32_t> const& valid_enums,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  rmm::device_uvector<bool>& d_row_force_null,
+  rmm::device_uvector<int>& d_error,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const rep_blocks =
+    static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  auto lookup = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+
+  // 1. Extract enum integer values from occurrences
+  rmm::device_uvector<int32_t> enum_ints(total_count, stream, mr);
+  rmm::device_uvector<bool> elem_valid(total_count, stream, mr);
+  repeated_location_provider rep_loc{list_offsets, base_offset, d_occurrences.data()};
+  extract_varint_kernel<int32_t, false>
+    <<<rep_blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(message_data,
+                                                           rep_loc,
+                                                           total_count,
+                                                           enum_ints.data(),
+                                                           elem_valid.data(),
+                                                           d_error.data(),
+                                                           false,
+                                                           0);
+
+  // 2. Validate enum values — mark invalid as false in elem_valid
+  // (elem_valid was already populated by extract_varint_kernel: true for success, false for
+  // failure)
+  rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, mr);
+  thrust::fill(rmm::exec_policy_nosync(stream),
+               d_elem_has_invalid_enum.begin(),
+               d_elem_has_invalid_enum.end(),
+               false);
+  launch_validate_enum_values(enum_ints.data(),
+                              elem_valid.data(),
+                              d_elem_has_invalid_enum.data(),
+                              lookup.d_valid_enums.data(),
+                              static_cast<int>(valid_enums.size()),
+                              total_count,
+                              stream);
+
+  rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, mr);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    d_occurrences.begin(),
+                    d_occurrences.end(),
+                    d_top_row_indices.begin(),
+                    [] __device__(repeated_occurrence const& occ) { return occ.row_idx; });
+  propagate_invalid_enum_flags_to_rows(
+    d_elem_has_invalid_enum, d_row_force_null, total_count, d_top_row_indices.data(), true, stream);
+
+  auto child_col =
+    build_enum_string_values_column(enum_ints, elem_valid, lookup, total_count, stream, mr);
+
+  // Build the final LIST<STRING> column from the per-row counts and decoded child strings.
+  rmm::device_uvector<int32_t> lo(num_rows + 1, stream, mr);
+  thrust::exclusive_scan(
+    rmm::exec_policy_nosync(stream), d_field_counts.begin(), d_field_counts.end(), lo.begin(), 0);
+  int32_t tc_i32 = static_cast<int32_t>(total_count);
+  thrust::fill_n(rmm::exec_policy_nosync(stream), lo.data() + num_rows, 1, tc_i32);
+
+  auto list_offs_col = std::make_unique<cudf::column>(
+    cudf::data_type{cudf::type_id::INT32}, num_rows + 1, lo.release(), rmm::device_buffer{}, 0);
+
+  auto input_null_count = binary_input.null_count();
+  if (input_null_count > 0) {
+    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
+    return cudf::make_lists_column(num_rows,
+                                   std::move(list_offs_col),
+                                   std::move(child_col),
+                                   input_null_count,
+                                   std::move(null_mask));
+  }
+  return cudf::make_lists_column(
+    num_rows, std::move(list_offs_col), std::move(child_col), 0, rmm::device_buffer{});
+}
+
+std::unique_ptr<cudf::column> build_repeated_string_column(
+  cudf::column_view const& binary_input,
+  uint8_t const* message_data,
+  cudf::size_type const* list_offsets,
+  cudf::size_type base_offset,
+  device_nested_field_descriptor const& field_desc,
+  rmm::device_uvector<int32_t> const& d_field_counts,
+  rmm::device_uvector<repeated_occurrence>& d_occurrences,
+  int total_count,
+  int num_rows,
+  bool is_bytes,
+  rmm::device_uvector<int>& d_error,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const input_null_count = binary_input.null_count();
+
+  if (total_count == 0) {
+    // All rows have count=0, but we still need to check input nulls
+    rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
+    thrust::fill(rmm::exec_policy_nosync(stream), offsets.begin(), offsets.end(), 0);
+    auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                      num_rows + 1,
+                                                      offsets.release(),
+                                                      rmm::device_buffer{},
+                                                      0);
+    auto child_col   = is_bytes ? make_empty_column_safe(
+                                  cudf::data_type{cudf::type_id::LIST}, stream, mr)  // LIST<UINT8>
+                                : cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
+
+    if (input_null_count > 0) {
+      // Copy input null mask - only input nulls produce output nulls
+      auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
+      return cudf::make_lists_column(num_rows,
+                                     std::move(offsets_col),
+                                     std::move(child_col),
+                                     input_null_count,
+                                     std::move(null_mask));
+    } else {
+      // No input nulls, all rows get empty arrays []
+      return cudf::make_lists_column(
+        num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+    }
+  }
+
+  rmm::device_uvector<int32_t> list_offs(num_rows + 1, stream, mr);
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+                         d_field_counts.begin(),
+                         d_field_counts.end(),
+                         list_offs.begin(),
+                         0);
+
+  int32_t total_count_i32 = static_cast<int32_t>(total_count);
+  thrust::fill_n(rmm::exec_policy_nosync(stream), list_offs.data() + num_rows, 1, total_count_i32);
+
+  // Extract string lengths from occurrences
+  rmm::device_uvector<int32_t> str_lengths(total_count, stream, mr);
+  auto const threads = THREADS_PER_BLOCK;
+  auto const blocks  = static_cast<int>((total_count + threads - 1u) / threads);
+  repeated_location_provider loc_provider{list_offsets, base_offset, d_occurrences.data()};
+  extract_lengths_kernel<repeated_location_provider>
+    <<<blocks, threads, 0, stream.value()>>>(loc_provider, total_count, str_lengths.data());
+
+  auto [str_offsets_col, total_chars] = cudf::strings::detail::make_offsets_child_column(
+    str_lengths.begin(), str_lengths.end(), stream, mr);
+
+  rmm::device_uvector<char> chars(total_chars, stream, mr);
+  if (total_chars > 0) {
+    repeated_location_provider copy_provider{list_offsets, base_offset, d_occurrences.data()};
+    auto const* offsets_data = str_offsets_col->view().data<cudf::size_type>();
+    auto* chars_ptr          = chars.data();
+
+    auto src_iter = cudf::detail::make_counting_transform_iterator(
+      0,
+      cuda::proclaim_return_type<void const*>(
+        [message_data, copy_provider] __device__(int idx) -> void const* {
+          int32_t data_offset = 0;
+          auto loc            = copy_provider.get(idx, data_offset);
+          if (loc.offset < 0) return nullptr;
+          return static_cast<void const*>(message_data + data_offset);
+        }));
+    auto dst_iter = cudf::detail::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<void*>([chars_ptr, offsets_data] __device__(int idx) -> void* {
+        return static_cast<void*>(chars_ptr + offsets_data[idx]);
+      }));
+    auto size_iter = cudf::detail::make_counting_transform_iterator(
+      0, cuda::proclaim_return_type<size_t>([copy_provider] __device__(int idx) -> size_t {
+        int32_t data_offset = 0;
+        auto loc            = copy_provider.get(idx, data_offset);
+        if (loc.offset < 0) return 0;
+        return static_cast<size_t>(loc.length);
+      }));
+
+    size_t temp_storage_bytes = 0;
+    cub::DeviceMemcpy::Batched(
+      nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, total_count, stream.value());
+    rmm::device_buffer temp_storage(temp_storage_bytes, stream, mr);
+    cub::DeviceMemcpy::Batched(temp_storage.data(),
+                               temp_storage_bytes,
+                               src_iter,
+                               dst_iter,
+                               size_iter,
+                               total_count,
+                               stream.value());
+  }
+
+  std::unique_ptr<cudf::column> child_col;
+  if (is_bytes) {
+    auto bytes_child =
+      std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
+                                     total_chars,
+                                     rmm::device_buffer(chars.data(), total_chars, stream, mr),
+                                     rmm::device_buffer{},
+                                     0);
+    child_col = cudf::make_lists_column(
+      total_count, std::move(str_offsets_col), std::move(bytes_child), 0, rmm::device_buffer{});
+  } else {
+    child_col = cudf::make_strings_column(
+      total_count, std::move(str_offsets_col), chars.release(), 0, rmm::device_buffer{});
+  }
+
+  auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                    num_rows + 1,
+                                                    list_offs.release(),
+                                                    rmm::device_buffer{},
+                                                    0);
+
+  // Only rows where INPUT is null should produce null output
+  // Rows with valid input but count=0 should produce empty array []
+  if (input_null_count > 0) {
+    // Copy input null mask - only input nulls produce output nulls
+    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
+    return cudf::make_lists_column(num_rows,
+                                   std::move(offsets_col),
+                                   std::move(child_col),
+                                   input_null_count,
+                                   std::move(null_mask));
+  }
+
+  return cudf::make_lists_column(
+    num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+}
+
+// Forward declaration -- build_nested_struct_column is defined after build_repeated_struct_column
+// but the latter's STRUCT-child case needs to call it.
+std::unique_ptr<cudf::column> build_nested_struct_column(
+  uint8_t const* message_data,
+  cudf::size_type message_data_size,
+  cudf::size_type const* list_offsets,
+  cudf::size_type base_offset,
+  rmm::device_uvector<field_location> const& d_parent_locs,
+  std::vector<int> const& child_field_indices,
+  std::vector<nested_field_descriptor> const& schema,
+  int num_fields,
+  std::vector<int64_t> const& default_ints,
+  std::vector<double> const& default_floats,
+  std::vector<bool> const& default_bools,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
+  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
+  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  rmm::device_uvector<bool>& d_row_force_null,
+  rmm::device_uvector<int>& d_error,
+  int num_rows,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr,
+  int32_t const* top_row_indices,
+  int depth,
+  bool propagate_invalid_rows);
+
+// Forward declaration -- build_repeated_child_list_column is defined after
+// build_nested_struct_column but both build_repeated_struct_column and build_nested_struct_column
+// need to call it.
+std::unique_ptr<cudf::column> build_repeated_child_list_column(
+  uint8_t const* message_data,
+  cudf::size_type message_data_size,
+  cudf::size_type const* row_offsets,
+  cudf::size_type base_offset,
+  field_location const* parent_locs,
+  int num_parent_rows,
+  int child_schema_idx,
+  std::vector<nested_field_descriptor> const& schema,
+  int num_fields,
+  std::vector<int64_t> const& default_ints,
+  std::vector<double> const& default_floats,
+  std::vector<bool> const& default_bools,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
+  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
+  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  rmm::device_uvector<bool>& d_row_force_null,
+  rmm::device_uvector<int>& d_error,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr,
+  int32_t const* top_row_indices,
+  int depth,
+  bool propagate_invalid_rows);
+
+std::unique_ptr<cudf::column> build_repeated_struct_column(
+  cudf::column_view const& binary_input,
+  uint8_t const* message_data,
+  cudf::size_type message_data_size,
+  cudf::size_type const* list_offsets,
+  cudf::size_type base_offset,
+  device_nested_field_descriptor const& field_desc,
+  rmm::device_uvector<int32_t> const& d_field_counts,
+  rmm::device_uvector<repeated_occurrence>& d_occurrences,
+  int total_count,
+  int num_rows,
+  std::vector<device_nested_field_descriptor> const& h_device_schema,
+  std::vector<int> const& child_field_indices,
+  std::vector<int64_t> const& default_ints,
+  std::vector<double> const& default_floats,
+  std::vector<bool> const& default_bools,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
+  std::vector<nested_field_descriptor> const& schema,
+  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
+  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  rmm::device_uvector<bool>& d_row_force_null,
+  rmm::device_uvector<int>& d_error_top,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const input_null_count = binary_input.null_count();
+  int num_child_fields        = static_cast<int>(child_field_indices.size());
+
+  if (total_count == 0 || num_child_fields == 0) {
+    // All rows have count=0 or no child fields - return list of empty structs
+    rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
+    thrust::fill(rmm::exec_policy_nosync(stream), offsets.begin(), offsets.end(), 0);
+    auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                      num_rows + 1,
+                                                      offsets.release(),
+                                                      rmm::device_buffer{},
+                                                      0);
+
+    // Build empty struct child column with proper nested structure
+    int num_schema_fields = static_cast<int>(h_device_schema.size());
+    std::vector<std::unique_ptr<cudf::column>> empty_struct_children;
+    for (int child_schema_idx : child_field_indices) {
+      auto child_type = cudf::data_type{schema[child_schema_idx].output_type};
+      std::unique_ptr<cudf::column> child_col;
+      if (child_type.id() == cudf::type_id::STRUCT) {
+        child_col = make_empty_struct_column_with_schema(
+          h_device_schema, child_schema_idx, num_schema_fields, stream, mr);
+      } else {
+        child_col = make_empty_column_safe(child_type, stream, mr);
+      }
+      if (h_device_schema[child_schema_idx].is_repeated) {
+        child_col = make_empty_list_column(std::move(child_col), stream, mr);
+      }
+      empty_struct_children.push_back(std::move(child_col));
+    }
+    auto empty_struct = cudf::make_structs_column(
+      0, std::move(empty_struct_children), 0, rmm::device_buffer{}, stream, mr);
+
+    if (input_null_count > 0) {
+      auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
+      return cudf::make_lists_column(num_rows,
+                                     std::move(offsets_col),
+                                     std::move(empty_struct),
+                                     input_null_count,
+                                     std::move(null_mask));
+    } else {
+      return cudf::make_lists_column(
+        num_rows, std::move(offsets_col), std::move(empty_struct), 0, rmm::device_buffer{});
+    }
+  }
+
+  rmm::device_uvector<int32_t> list_offs(num_rows + 1, stream, mr);
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+                         d_field_counts.begin(),
+                         d_field_counts.end(),
+                         list_offs.begin(),
+                         0);
+
+  int32_t total_count_i32 = static_cast<int32_t>(total_count);
+  thrust::fill_n(rmm::exec_policy_nosync(stream), list_offs.data() + num_rows, 1, total_count_i32);
+
+  // Build child field descriptors for scanning within each message occurrence
+  std::vector<field_descriptor> h_child_descs(num_child_fields);
+  for (int ci = 0; ci < num_child_fields; ci++) {
+    int child_schema_idx                 = child_field_indices[ci];
+    h_child_descs[ci].field_number       = h_device_schema[child_schema_idx].field_number;
+    h_child_descs[ci].expected_wire_type = h_device_schema[child_schema_idx].wire_type;
+    h_child_descs[ci].is_repeated        = h_device_schema[child_schema_idx].is_repeated;
+  }
+  rmm::device_uvector<field_descriptor> d_child_descs(num_child_fields, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_descs.data(),
+                                h_child_descs.data(),
+                                num_child_fields * sizeof(field_descriptor),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+  auto h_child_lookup = build_field_lookup_table(h_child_descs.data(), num_child_fields);
+  rmm::device_uvector<int> d_child_lookup(0, stream, mr);
+  if (!h_child_lookup.empty()) {
+    d_child_lookup = rmm::device_uvector<int>(h_child_lookup.size(), stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_lookup.data(),
+                                  h_child_lookup.data(),
+                                  h_child_lookup.size() * sizeof(int),
+                                  cudaMemcpyHostToDevice,
+                                  stream.value()));
+  }
+
+  // For each occurrence, we need to scan for child fields
+  // Create "virtual" parent locations from the occurrences using GPU kernel
+  // This replaces the host-side loop with D->H->D copy pattern (critical performance fix!)
+  rmm::device_uvector<field_location> d_msg_locs(total_count, stream, mr);
+  rmm::device_uvector<cudf::size_type> d_msg_row_offsets(total_count, stream, mr);
+  launch_compute_msg_locations_from_occurrences(d_occurrences.data(),
+                                                list_offsets,
+                                                base_offset,
+                                                d_msg_locs.data(),
+                                                d_msg_row_offsets.data(),
+                                                total_count,
+                                                d_error_top.data(),
+                                                stream);
+  rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, mr);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    d_occurrences.data(),
+                    d_occurrences.end(),
+                    d_top_row_indices.data(),
+                    [] __device__(repeated_occurrence const& occ) { return occ.row_idx; });
+
+  // Scan for child fields within each message occurrence
+  rmm::device_uvector<field_location> d_child_locs(total_count * num_child_fields, stream, mr);
+  // Reuse top-level error flag so failfast can observe nested repeated-message failures.
+  auto& d_error = d_error_top;
+
+  auto const threads = THREADS_PER_BLOCK;
+  auto const blocks  = static_cast<int>((total_count + threads - 1u) / threads);
+
+  // Use a custom kernel to scan child fields within message occurrences
+  // This is similar to scan_nested_message_fields_kernel but operates on occurrences
+  launch_scan_repeated_message_children(message_data,
+                                        message_data_size,
+                                        d_msg_row_offsets.data(),
+                                        d_msg_locs.data(),
+                                        total_count,
+                                        d_child_descs.data(),
+                                        num_child_fields,
+                                        d_child_locs.data(),
+                                        d_error.data(),
+                                        h_child_lookup.empty() ? nullptr : d_child_lookup.data(),
+                                        static_cast<int>(d_child_lookup.size()),
+                                        stream);
+
+  // Enforce proto2 required semantics for fields inside each repeated message occurrence.
+  maybe_check_required_fields(d_child_locs.data(),
+                              child_field_indices,
+                              schema,
+                              total_count,
+                              nullptr,
+                              0,
+                              nullptr,
+                              d_row_force_null.size() > 0 ? d_row_force_null.data() : nullptr,
+                              d_top_row_indices.data(),
+                              d_error.data(),
+                              stream);
+
+  // Note: We no longer need to copy child_locs to host because:
+  // 1. All scalar extraction kernels access d_child_locs directly on device
+  // 2. String extraction uses GPU kernels
+  // 3. Nested struct locations are computed on GPU via compute_nested_struct_locations_kernel
+
+  // Extract child field values - build one column per child field
+  std::vector<std::unique_ptr<cudf::column>> struct_children;
+  int num_schema_fields = static_cast<int>(h_device_schema.size());
+  for (int ci = 0; ci < num_child_fields; ci++) {
+    int child_schema_idx   = child_field_indices[ci];
+    auto const dt          = cudf::data_type{schema[child_schema_idx].output_type};
+    auto const enc         = h_device_schema[child_schema_idx].encoding;
+    bool has_def           = h_device_schema[child_schema_idx].has_default_value;
+    bool child_is_repeated = h_device_schema[child_schema_idx].is_repeated;
+
+    if (child_is_repeated) {
+      struct_children.push_back(build_repeated_child_list_column(message_data,
+                                                                 message_data_size,
+                                                                 d_msg_row_offsets.data(),
+                                                                 0,
+                                                                 d_msg_locs.data(),
+                                                                 total_count,
+                                                                 child_schema_idx,
+                                                                 schema,
+                                                                 num_schema_fields,
+                                                                 default_ints,
+                                                                 default_floats,
+                                                                 default_bools,
+                                                                 default_strings,
+                                                                 enum_valid_values,
+                                                                 enum_names,
+                                                                 d_row_force_null,
+                                                                 d_error_top,
+                                                                 stream,
+                                                                 mr,
+                                                                 d_top_row_indices.data(),
+                                                                 1,
+                                                                 false));
+      continue;
+    }
+
+    switch (dt.id()) {
+      case cudf::type_id::BOOL8:
+      case cudf::type_id::INT32:
+      case cudf::type_id::UINT32:
+      case cudf::type_id::INT64:
+      case cudf::type_id::UINT64:
+      case cudf::type_id::FLOAT32:
+      case cudf::type_id::FLOAT64: {
+        repeated_msg_child_location_provider loc_provider{d_msg_row_offsets.data(),
+                                                          0,
+                                                          d_msg_locs.data(),
+                                                          d_child_locs.data(),
+                                                          ci,
+                                                          num_child_fields};
+        struct_children.push_back(
+          extract_typed_column(dt,
+                               enc,
+                               message_data,
+                               loc_provider,
+                               total_count,
+                               blocks,
+                               threads,
+                               has_def,
+                               has_def ? default_ints[child_schema_idx] : 0,
+                               has_def ? default_floats[child_schema_idx] : 0.0,
+                               has_def ? default_bools[child_schema_idx] : false,
+                               default_strings[child_schema_idx],
+                               child_schema_idx,
+                               enum_valid_values,
+                               enum_names,
+                               d_row_force_null,
+                               d_error,
+                               stream,
+                               mr,
+                               d_top_row_indices.data(),
+                               false));
+        break;
+      }
+      case cudf::type_id::STRING: {
+        if (enc == encoding_value(proto_encoding::ENUM_STRING)) {
+          if (child_schema_idx < static_cast<int>(enum_valid_values.size()) &&
+              child_schema_idx < static_cast<int>(enum_names.size()) &&
+              !enum_valid_values[child_schema_idx].empty() &&
+              enum_valid_values[child_schema_idx].size() == enum_names[child_schema_idx].size()) {
+            struct_children.push_back(
+              build_repeated_msg_child_enum_string_column(message_data,
+                                                          d_msg_row_offsets,
+                                                          d_msg_locs,
+                                                          d_child_locs,
+                                                          ci,
+                                                          num_child_fields,
+                                                          total_count,
+                                                          enum_valid_values[child_schema_idx],
+                                                          enum_names[child_schema_idx],
+                                                          d_row_force_null,
+                                                          d_top_row_indices.data(),
+                                                          false,
+                                                          d_error,
+                                                          stream,
+                                                          mr));
+          } else {
+            set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+            struct_children.push_back(make_null_column(dt, total_count, stream, mr));
+          }
+        } else {
+          struct_children.push_back(build_repeated_msg_child_varlen_column(message_data,
+                                                                           d_msg_row_offsets,
+                                                                           d_msg_locs,
+                                                                           d_child_locs,
+                                                                           ci,
+                                                                           num_child_fields,
+                                                                           total_count,
+                                                                           d_error,
+                                                                           false,
+                                                                           stream,
+                                                                           mr));
+        }
+        break;
+      }
+      case cudf::type_id::LIST: {
+        struct_children.push_back(build_repeated_msg_child_varlen_column(message_data,
+                                                                         d_msg_row_offsets,
+                                                                         d_msg_locs,
+                                                                         d_child_locs,
+                                                                         ci,
+                                                                         num_child_fields,
+                                                                         total_count,
+                                                                         d_error,
+                                                                         true,
+                                                                         stream,
+                                                                         mr));
+        break;
+      }
+      case cudf::type_id::STRUCT: {
+        // Nested struct inside repeated message - use recursive build_nested_struct_column
+        int num_schema_fields = static_cast<int>(h_device_schema.size());
+        auto grandchild_indices =
+          find_child_field_indices(h_device_schema, num_schema_fields, child_schema_idx);
+
+        if (grandchild_indices.empty()) {
+          struct_children.push_back(
+            cudf::make_structs_column(total_count,
+                                      std::vector<std::unique_ptr<cudf::column>>{},
+                                      0,
+                                      rmm::device_buffer{},
+                                      stream,
+                                      mr));
+        } else {
+          // Compute virtual parent locations for each occurrence's nested struct child
+          rmm::device_uvector<field_location> d_nested_locs(total_count, stream, mr);
+          rmm::device_uvector<cudf::size_type> d_nested_row_offsets(total_count, stream, mr);
+          launch_compute_nested_struct_locations(d_child_locs.data(),
+                                                 d_msg_locs.data(),
+                                                 d_msg_row_offsets.data(),
+                                                 ci,
+                                                 num_child_fields,
+                                                 d_nested_locs.data(),
+                                                 d_nested_row_offsets.data(),
+                                                 total_count,
+                                                 d_error_top.data(),
+                                                 stream);
+
+          struct_children.push_back(build_nested_struct_column(message_data,
+                                                               message_data_size,
+                                                               d_nested_row_offsets.data(),
+                                                               0,
+                                                               d_nested_locs,
+                                                               grandchild_indices,
+                                                               schema,
+                                                               num_schema_fields,
+                                                               default_ints,
+                                                               default_floats,
+                                                               default_bools,
+                                                               default_strings,
+                                                               enum_valid_values,
+                                                               enum_names,
+                                                               d_row_force_null,
+                                                               d_error_top,
+                                                               total_count,
+                                                               stream,
+                                                               mr,
+                                                               d_top_row_indices.data(),
+                                                               0,
+                                                               false));
+        }
+        break;
+      }
+      default:
+        // Unsupported child type - create null column
+        struct_children.push_back(make_null_column(dt, total_count, stream, mr));
+        break;
+    }
+  }
+
+  // Build the struct column from child columns
+  auto struct_col = cudf::make_structs_column(
+    total_count, std::move(struct_children), 0, rmm::device_buffer{}, stream, mr);
+
+  // Build the list offsets column
+  auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                    num_rows + 1,
+                                                    list_offs.release(),
+                                                    rmm::device_buffer{},
+                                                    0);
+
+  // Build the final LIST column
+  if (input_null_count > 0) {
+    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
+    return cudf::make_lists_column(num_rows,
+                                   std::move(offsets_col),
+                                   std::move(struct_col),
+                                   input_null_count,
+                                   std::move(null_mask));
+  }
+
+  return cudf::make_lists_column(
+    num_rows, std::move(offsets_col), std::move(struct_col), 0, rmm::device_buffer{});
+}
+
+std::unique_ptr<cudf::column> build_nested_struct_column(
+  uint8_t const* message_data,
+  cudf::size_type message_data_size,
+  cudf::size_type const* list_offsets,
+  cudf::size_type base_offset,
+  rmm::device_uvector<field_location> const& d_parent_locs,
+  std::vector<int> const& child_field_indices,
+  std::vector<nested_field_descriptor> const& schema,
+  int num_fields,
+  std::vector<int64_t> const& default_ints,
+  std::vector<double> const& default_floats,
+  std::vector<bool> const& default_bools,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
+  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
+  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  rmm::device_uvector<bool>& d_row_force_null,
+  rmm::device_uvector<int>& d_error,
+  int num_rows,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr,
+  int32_t const* top_row_indices,
+  int depth,
+  bool propagate_invalid_rows)
+{
+  CUDF_EXPECTS(depth < MAX_NESTING_DEPTH,
+               "Nested protobuf struct depth exceeds supported decode recursion limit");
+
+  if (num_rows == 0) {
+    std::vector<std::unique_ptr<cudf::column>> empty_children;
+    for (int child_schema_idx : child_field_indices) {
+      auto child_type = cudf::data_type{schema[child_schema_idx].output_type};
+      std::unique_ptr<cudf::column> child_col;
+      if (child_type.id() == cudf::type_id::STRUCT) {
+        child_col =
+          make_empty_struct_column_with_schema(schema, child_schema_idx, num_fields, stream, mr);
+      } else {
+        child_col = make_empty_column_safe(child_type, stream, mr);
+      }
+      if (schema[child_schema_idx].is_repeated) {
+        child_col = make_empty_list_column(std::move(child_col), stream, mr);
+      }
+      empty_children.push_back(std::move(child_col));
+    }
+    return cudf::make_structs_column(
+      0, std::move(empty_children), 0, rmm::device_buffer{}, stream, mr);
+  }
+
+  auto const threads   = THREADS_PER_BLOCK;
+  auto const blocks    = static_cast<int>((num_rows + threads - 1u) / threads);
+  int num_child_fields = static_cast<int>(child_field_indices.size());
+
+  std::vector<field_descriptor> h_child_field_descs(num_child_fields);
+  for (int i = 0; i < num_child_fields; i++) {
+    int child_idx                             = child_field_indices[i];
+    h_child_field_descs[i].field_number       = schema[child_idx].field_number;
+    h_child_field_descs[i].expected_wire_type = static_cast<int>(schema[child_idx].wire_type);
+    h_child_field_descs[i].is_repeated        = schema[child_idx].is_repeated;
+  }
+
+  rmm::device_uvector<field_descriptor> d_child_field_descs(num_child_fields, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_field_descs.data(),
+                                h_child_field_descs.data(),
+                                num_child_fields * sizeof(field_descriptor),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+
+  rmm::device_uvector<field_location> d_child_locations(
+    static_cast<size_t>(num_rows) * num_child_fields, stream, mr);
+  launch_scan_nested_message_fields(message_data,
+                                    message_data_size,
+                                    list_offsets,
+                                    base_offset,
+                                    d_parent_locs.data(),
+                                    num_rows,
+                                    d_child_field_descs.data(),
+                                    num_child_fields,
+                                    d_child_locations.data(),
+                                    d_error.data(),
+                                    stream);
+
+  // Enforce proto2 required semantics for direct children of this nested message.
+  maybe_check_required_fields(d_child_locations.data(),
+                              child_field_indices,
+                              schema,
+                              num_rows,
+                              nullptr,
+                              0,
+                              d_parent_locs.data(),
+                              d_row_force_null.size() > 0 ? d_row_force_null.data() : nullptr,
+                              top_row_indices,
+                              d_error.data(),
+                              stream);
+
+  std::vector<std::unique_ptr<cudf::column>> struct_children;
+  for (int ci = 0; ci < num_child_fields; ci++) {
+    int child_schema_idx = child_field_indices[ci];
+    auto const dt        = cudf::data_type{schema[child_schema_idx].output_type};
+    auto const enc       = static_cast<int>(schema[child_schema_idx].encoding);
+    bool has_def         = schema[child_schema_idx].has_default_value;
+    bool is_repeated     = schema[child_schema_idx].is_repeated;
+
+    if (is_repeated) {
+      struct_children.push_back(build_repeated_child_list_column(message_data,
+                                                                 message_data_size,
+                                                                 list_offsets,
+                                                                 base_offset,
+                                                                 d_parent_locs.data(),
+                                                                 num_rows,
+                                                                 child_schema_idx,
+                                                                 schema,
+                                                                 num_fields,
+                                                                 default_ints,
+                                                                 default_floats,
+                                                                 default_bools,
+                                                                 default_strings,
+                                                                 enum_valid_values,
+                                                                 enum_names,
+                                                                 d_row_force_null,
+                                                                 d_error,
+                                                                 stream,
+                                                                 mr,
+                                                                 top_row_indices,
+                                                                 depth,
+                                                                 propagate_invalid_rows));
+      continue;
+    }
+
+    switch (dt.id()) {
+      case cudf::type_id::BOOL8:
+      case cudf::type_id::INT32:
+      case cudf::type_id::UINT32:
+      case cudf::type_id::INT64:
+      case cudf::type_id::UINT64:
+      case cudf::type_id::FLOAT32:
+      case cudf::type_id::FLOAT64: {
+        nested_location_provider loc_provider{list_offsets,
+                                              base_offset,
+                                              d_parent_locs.data(),
+                                              d_child_locations.data(),
+                                              ci,
+                                              num_child_fields};
+        struct_children.push_back(
+          extract_typed_column(dt,
+                               enc,
+                               message_data,
+                               loc_provider,
+                               num_rows,
+                               blocks,
+                               threads,
+                               has_def,
+                               has_def ? default_ints[child_schema_idx] : 0,
+                               has_def ? default_floats[child_schema_idx] : 0.0,
+                               has_def ? default_bools[child_schema_idx] : false,
+                               default_strings[child_schema_idx],
+                               child_schema_idx,
+                               enum_valid_values,
+                               enum_names,
+                               d_row_force_null,
+                               d_error,
+                               stream,
+                               mr,
+                               top_row_indices,
+                               propagate_invalid_rows));
+        break;
+      }
+      case cudf::type_id::STRING: {
+        if (enc == encoding_value(proto_encoding::ENUM_STRING)) {
+          rmm::device_uvector<int32_t> out(num_rows, stream, mr);
+          rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
+          int64_t def_int = has_def ? default_ints[child_schema_idx] : 0;
+          nested_location_provider loc_provider{list_offsets,
+                                                base_offset,
+                                                d_parent_locs.data(),
+                                                d_child_locations.data(),
+                                                ci,
+                                                num_child_fields};
+          extract_varint_kernel<int32_t, false, nested_location_provider>
+            <<<blocks, threads, 0, stream.value()>>>(message_data,
+                                                     loc_provider,
+                                                     num_rows,
+                                                     out.data(),
+                                                     valid.data(),
+                                                     d_error.data(),
+                                                     has_def,
+                                                     def_int);
+
+          if (child_schema_idx < static_cast<int>(enum_valid_values.size()) &&
+              child_schema_idx < static_cast<int>(enum_names.size())) {
+            auto const& valid_enums     = enum_valid_values[child_schema_idx];
+            auto const& enum_name_bytes = enum_names[child_schema_idx];
+            if (!valid_enums.empty() && valid_enums.size() == enum_name_bytes.size()) {
+              struct_children.push_back(build_enum_string_column(out,
+                                                                 valid,
+                                                                 valid_enums,
+                                                                 enum_name_bytes,
+                                                                 d_row_force_null,
+                                                                 num_rows,
+                                                                 stream,
+                                                                 mr,
+                                                                 top_row_indices,
+                                                                 propagate_invalid_rows));
+            } else {
+              set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+              struct_children.push_back(make_null_column(dt, num_rows, stream, mr));
+            }
+          } else {
+            set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+            struct_children.push_back(make_null_column(dt, num_rows, stream, mr));
+          }
+        } else {
+          bool has_def_str    = has_def;
+          auto const& def_str = default_strings[child_schema_idx];
+          nested_location_provider len_provider{list_offsets,
+                                                base_offset,
+                                                d_parent_locs.data(),
+                                                d_child_locations.data(),
+                                                ci,
+                                                num_child_fields};
+          nested_location_provider copy_provider{list_offsets,
+                                                 base_offset,
+                                                 d_parent_locs.data(),
+                                                 d_child_locations.data(),
+                                                 ci,
+                                                 num_child_fields};
+          auto valid_fn = [plocs = d_parent_locs.data(),
+                           flocs = d_child_locations.data(),
+                           ci,
+                           num_child_fields,
+                           has_def_str] __device__(cudf::size_type row) {
+            return (plocs[row].offset >= 0 &&
+                    flocs[flat_index(static_cast<size_t>(row),
+                                     static_cast<size_t>(num_child_fields),
+                                     static_cast<size_t>(ci))]
+                        .offset >= 0) ||
+                   has_def_str;
+          };
+          struct_children.push_back(extract_and_build_string_or_bytes_column(false,
+                                                                             message_data,
+                                                                             num_rows,
+                                                                             len_provider,
+                                                                             copy_provider,
+                                                                             valid_fn,
+                                                                             has_def_str,
+                                                                             def_str,
+                                                                             d_error,
+                                                                             stream,
+                                                                             mr));
+        }
+        break;
+      }
+      case cudf::type_id::LIST: {
+        // bytes (BinaryType) represented as LIST<UINT8>
+        bool has_def_bytes    = has_def;
+        auto const& def_bytes = default_strings[child_schema_idx];
+        nested_location_provider len_provider{list_offsets,
+                                              base_offset,
+                                              d_parent_locs.data(),
+                                              d_child_locations.data(),
+                                              ci,
+                                              num_child_fields};
+        nested_location_provider copy_provider{list_offsets,
+                                               base_offset,
+                                               d_parent_locs.data(),
+                                               d_child_locations.data(),
+                                               ci,
+                                               num_child_fields};
+        auto valid_fn = [plocs = d_parent_locs.data(),
+                         flocs = d_child_locations.data(),
+                         ci,
+                         num_child_fields,
+                         has_def_bytes] __device__(cudf::size_type row) {
+          return (plocs[row].offset >= 0 && flocs[flat_index(static_cast<size_t>(row),
+                                                             static_cast<size_t>(num_child_fields),
+                                                             static_cast<size_t>(ci))]
+                                                .offset >= 0) ||
+                 has_def_bytes;
+        };
+        struct_children.push_back(extract_and_build_string_or_bytes_column(true,
+                                                                           message_data,
+                                                                           num_rows,
+                                                                           len_provider,
+                                                                           copy_provider,
+                                                                           valid_fn,
+                                                                           has_def_bytes,
+                                                                           def_bytes,
+                                                                           d_error,
+                                                                           stream,
+                                                                           mr));
+        break;
+      }
+      case cudf::type_id::STRUCT: {
+        auto gc_indices = find_child_field_indices(schema, num_fields, child_schema_idx);
+        if (gc_indices.empty()) {
+          struct_children.push_back(make_null_column(dt, num_rows, stream, mr));
+          break;
+        }
+        rmm::device_uvector<field_location> d_gc_parent(num_rows, stream, mr);
+        launch_compute_grandchild_parent_locations(d_parent_locs.data(),
+                                                   d_child_locations.data(),
+                                                   ci,
+                                                   num_child_fields,
+                                                   d_gc_parent.data(),
+                                                   num_rows,
+                                                   d_error.data(),
+                                                   stream);
+        struct_children.push_back(build_nested_struct_column(message_data,
+                                                             message_data_size,
+                                                             list_offsets,
+                                                             base_offset,
+                                                             d_gc_parent,
+                                                             gc_indices,
+                                                             schema,
+                                                             num_fields,
+                                                             default_ints,
+                                                             default_floats,
+                                                             default_bools,
+                                                             default_strings,
+                                                             enum_valid_values,
+                                                             enum_names,
+                                                             d_row_force_null,
+                                                             d_error,
+                                                             num_rows,
+                                                             stream,
+                                                             mr,
+                                                             top_row_indices,
+                                                             depth + 1,
+                                                             propagate_invalid_rows));
+        break;
+      }
+      default: struct_children.push_back(make_null_column(dt, num_rows, stream, mr)); break;
+    }
+  }
+
+  rmm::device_uvector<bool> struct_valid((num_rows > 0 ? num_rows : 1), stream, mr);
+  thrust::transform(
+    rmm::exec_policy_nosync(stream),
+    thrust::make_counting_iterator<cudf::size_type>(0),
+    thrust::make_counting_iterator<cudf::size_type>(num_rows),
+    struct_valid.data(),
+    [plocs = d_parent_locs.data()] __device__(auto row) { return plocs[row].offset >= 0; });
+  auto [struct_mask, struct_null_count] = make_null_mask_from_valid(struct_valid, stream, mr);
+  return cudf::make_structs_column(
+    num_rows, std::move(struct_children), struct_null_count, std::move(struct_mask), stream, mr);
+}
+
+/**
+ * Build a LIST column for a repeated child field inside a parent message.
+ * Shared between build_nested_struct_column and build_repeated_struct_column.
+ */
+std::unique_ptr<cudf::column> build_repeated_child_list_column(
+  uint8_t const* message_data,
+  cudf::size_type message_data_size,
+  cudf::size_type const* row_offsets,
+  cudf::size_type base_offset,
+  field_location const* parent_locs,
+  int num_parent_rows,
+  int child_schema_idx,
+  std::vector<nested_field_descriptor> const& schema,
+  int num_fields,
+  std::vector<int64_t> const& default_ints,
+  std::vector<double> const& default_floats,
+  std::vector<bool> const& default_bools,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
+  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
+  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  rmm::device_uvector<bool>& d_row_force_null,
+  rmm::device_uvector<int>& d_error,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr,
+  int32_t const* top_row_indices,
+  int depth,
+  bool propagate_invalid_rows)
+{
+  auto elem_type_id = schema[child_schema_idx].output_type;
+  rmm::device_uvector<repeated_field_info> d_rep_info(num_parent_rows, stream, mr);
+
+  std::vector<int> rep_indices = {0};
+  rmm::device_uvector<int> d_rep_indices(1, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+    d_rep_indices.data(), rep_indices.data(), sizeof(int), cudaMemcpyHostToDevice, stream.value()));
+
+  device_nested_field_descriptor rep_desc;
+  rep_desc.field_number      = schema[child_schema_idx].field_number;
+  rep_desc.wire_type         = static_cast<int>(schema[child_schema_idx].wire_type);
+  rep_desc.output_type_id    = static_cast<int>(schema[child_schema_idx].output_type);
+  rep_desc.is_repeated       = true;
+  rep_desc.parent_idx        = -1;
+  rep_desc.depth             = 0;
+  rep_desc.encoding          = 0;
+  rep_desc.is_required       = false;
+  rep_desc.has_default_value = false;
+  CUDF_EXPECTS(schema[child_schema_idx].is_repeated,
+               "count_repeated_in_nested_kernel launch requires repeated child schema");
+  CUDF_EXPECTS(rep_desc.depth == 0,
+               "count_repeated_in_nested_kernel launch requires pre-filtered local depth 0");
+
+  std::vector<device_nested_field_descriptor> h_rep_schema = {rep_desc};
+  rmm::device_uvector<device_nested_field_descriptor> d_rep_schema(1, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_rep_schema.data(),
+                                h_rep_schema.data(),
+                                sizeof(device_nested_field_descriptor),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+
+  launch_count_repeated_in_nested(message_data,
+                                  message_data_size,
+                                  row_offsets,
+                                  base_offset,
+                                  parent_locs,
+                                  num_parent_rows,
+                                  d_rep_schema.data(),
+                                  1,
+                                  d_rep_info.data(),
+                                  1,
+                                  d_rep_indices.data(),
+                                  d_error.data(),
+                                  stream);
+
+  rmm::device_uvector<int32_t> d_rep_counts(num_parent_rows, stream, mr);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    d_rep_info.data(),
+                    d_rep_info.end(),
+                    d_rep_counts.data(),
+                    [] __device__(repeated_field_info const& info) { return info.count; });
+  int total_rep_count =
+    thrust::reduce(rmm::exec_policy_nosync(stream), d_rep_counts.data(), d_rep_counts.end(), 0);
+
+  if (total_rep_count == 0) {
+    rmm::device_uvector<int32_t> list_offsets_vec(num_parent_rows + 1, stream, mr);
+    thrust::fill(
+      rmm::exec_policy_nosync(stream), list_offsets_vec.data(), list_offsets_vec.end(), 0);
+    auto list_offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                           num_parent_rows + 1,
+                                                           list_offsets_vec.release(),
+                                                           rmm::device_buffer{},
+                                                           0);
+    std::unique_ptr<cudf::column> child_col;
+    if (elem_type_id == cudf::type_id::STRUCT) {
+      child_col =
+        make_empty_struct_column_with_schema(schema, child_schema_idx, num_fields, stream, mr);
+    } else {
+      child_col = make_empty_column_safe(cudf::data_type{elem_type_id}, stream, mr);
+    }
+    return cudf::make_lists_column(
+      num_parent_rows, std::move(list_offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+  }
+
+  rmm::device_uvector<int32_t> list_offs(num_parent_rows + 1, stream, mr);
+  thrust::exclusive_scan(
+    rmm::exec_policy_nosync(stream), d_rep_counts.data(), d_rep_counts.end(), list_offs.begin(), 0);
+  thrust::fill_n(
+    rmm::exec_policy_nosync(stream), list_offs.data() + num_parent_rows, 1, total_rep_count);
+
+  rmm::device_uvector<repeated_occurrence> d_rep_occs(total_rep_count, stream, mr);
+  launch_scan_repeated_in_nested(message_data,
+                                 message_data_size,
+                                 row_offsets,
+                                 base_offset,
+                                 parent_locs,
+                                 num_parent_rows,
+                                 d_rep_schema.data(),
+                                 list_offs.data(),
+                                 d_rep_indices.data(),
+                                 d_rep_occs.data(),
+                                 d_error.data(),
+                                 stream);
+
+  rmm::device_uvector<int32_t> d_rep_top_row_indices(total_rep_count, stream, mr);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    d_rep_occs.begin(),
+                    d_rep_occs.end(),
+                    d_rep_top_row_indices.begin(),
+                    [top_row_indices] __device__(repeated_occurrence const& occ) {
+                      return top_row_indices != nullptr ? top_row_indices[occ.row_idx]
+                                                        : occ.row_idx;
+                    });
+
+  std::unique_ptr<cudf::column> child_values;
+  auto const rep_blocks =
+    static_cast<int>((total_rep_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  nested_repeated_location_provider nr_loc{
+    row_offsets, base_offset, parent_locs, d_rep_occs.data()};
+
+  if (elem_type_id == cudf::type_id::BOOL8 || elem_type_id == cudf::type_id::INT32 ||
+      elem_type_id == cudf::type_id::UINT32 || elem_type_id == cudf::type_id::INT64 ||
+      elem_type_id == cudf::type_id::UINT64 || elem_type_id == cudf::type_id::FLOAT32 ||
+      elem_type_id == cudf::type_id::FLOAT64) {
+    child_values = extract_typed_column(cudf::data_type{elem_type_id},
+                                        static_cast<int>(schema[child_schema_idx].encoding),
+                                        message_data,
+                                        nr_loc,
+                                        total_rep_count,
+                                        rep_blocks,
+                                        THREADS_PER_BLOCK,
+                                        false,
+                                        0,
+                                        0.0,
+                                        false,
+                                        cudf::detail::make_pinned_vector_async<uint8_t>(0, stream),
+                                        child_schema_idx,
+                                        enum_valid_values,
+                                        enum_names,
+                                        d_row_force_null,
+                                        d_error,
+                                        stream,
+                                        mr,
+                                        d_rep_top_row_indices.data(),
+                                        propagate_invalid_rows);
+  } else if (elem_type_id == cudf::type_id::STRING || elem_type_id == cudf::type_id::LIST) {
+    if (elem_type_id == cudf::type_id::STRING &&
+        schema[child_schema_idx].encoding == proto_encoding::ENUM_STRING) {
+      if (child_schema_idx < static_cast<int>(enum_valid_values.size()) &&
+          child_schema_idx < static_cast<int>(enum_names.size()) &&
+          !enum_valid_values[child_schema_idx].empty() &&
+          enum_valid_values[child_schema_idx].size() == enum_names[child_schema_idx].size()) {
+        auto lookup = make_enum_string_lookup_tables(
+          enum_valid_values[child_schema_idx], enum_names[child_schema_idx], stream, mr);
+        rmm::device_uvector<int32_t> enum_values(total_rep_count, stream, mr);
+        rmm::device_uvector<bool> valid((total_rep_count > 0 ? total_rep_count : 1), stream, mr);
+        extract_varint_kernel<int32_t, false, nested_repeated_location_provider>
+          <<<rep_blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(message_data,
+                                                                 nr_loc,
+                                                                 total_rep_count,
+                                                                 enum_values.data(),
+                                                                 valid.data(),
+                                                                 d_error.data(),
+                                                                 false,
+                                                                 0);
+
+        rmm::device_uvector<bool> d_elem_has_invalid_enum(total_rep_count, stream, mr);
+        thrust::fill(rmm::exec_policy_nosync(stream),
+                     d_elem_has_invalid_enum.begin(),
+                     d_elem_has_invalid_enum.end(),
+                     false);
+        launch_validate_enum_values(enum_values.data(),
+                                    valid.data(),
+                                    d_elem_has_invalid_enum.data(),
+                                    lookup.d_valid_enums.data(),
+                                    static_cast<int>(lookup.d_valid_enums.size()),
+                                    total_rep_count,
+                                    stream);
+        propagate_invalid_enum_flags_to_rows(d_elem_has_invalid_enum,
+                                             d_row_force_null,
+                                             total_rep_count,
+                                             d_rep_top_row_indices.data(),
+                                             propagate_invalid_rows,
+                                             stream);
+        child_values =
+          build_enum_string_values_column(enum_values, valid, lookup, total_rep_count, stream, mr);
+      } else {
+        set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+        child_values = make_null_column(cudf::data_type{elem_type_id}, total_rep_count, stream, mr);
+      }
+    } else {
+      bool as_bytes      = (elem_type_id == cudf::type_id::LIST);
+      auto valid_fn      = [] __device__(cudf::size_type) { return true; };
+      auto empty_default = cudf::detail::make_pinned_vector_async<uint8_t>(0, stream);
+      child_values       = extract_and_build_string_or_bytes_column(as_bytes,
+                                                              message_data,
+                                                              total_rep_count,
+                                                              nr_loc,
+                                                              nr_loc,
+                                                              valid_fn,
+                                                              false,
+                                                              empty_default,
+                                                              d_error,
+                                                              stream,
+                                                              mr);
+    }
+  } else if (elem_type_id == cudf::type_id::STRUCT) {
+    auto gc_indices = find_child_field_indices(schema, num_fields, child_schema_idx);
+    if (gc_indices.empty()) {
+      child_values = cudf::make_structs_column(total_rep_count,
+                                               std::vector<std::unique_ptr<cudf::column>>{},
+                                               0,
+                                               rmm::device_buffer{},
+                                               stream,
+                                               mr);
+    } else {
+      rmm::device_uvector<cudf::size_type> d_virtual_row_offsets(total_rep_count, stream, mr);
+      rmm::device_uvector<field_location> d_virtual_parent_locs(total_rep_count, stream, mr);
+      launch_compute_virtual_parents_for_nested_repeated(d_rep_occs.data(),
+                                                         row_offsets,
+                                                         parent_locs,
+                                                         d_virtual_row_offsets.data(),
+                                                         d_virtual_parent_locs.data(),
+                                                         total_rep_count,
+                                                         d_error.data(),
+                                                         stream);
+
+      child_values = build_nested_struct_column(message_data,
+                                                message_data_size,
+                                                d_virtual_row_offsets.data(),
+                                                base_offset,
+                                                d_virtual_parent_locs,
+                                                gc_indices,
+                                                schema,
+                                                num_fields,
+                                                default_ints,
+                                                default_floats,
+                                                default_bools,
+                                                default_strings,
+                                                enum_valid_values,
+                                                enum_names,
+                                                d_row_force_null,
+                                                d_error,
+                                                total_rep_count,
+                                                stream,
+                                                mr,
+                                                d_rep_top_row_indices.data(),
+                                                depth + 1,
+                                                propagate_invalid_rows);
+    }
+  } else {
+    child_values = make_empty_column_safe(cudf::data_type{elem_type_id}, stream, mr);
+  }
+
+  auto list_offs_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
+                                                      num_parent_rows + 1,
+                                                      list_offs.release(),
+                                                      rmm::device_buffer{},
+                                                      0);
+  return cudf::make_lists_column(
+    num_parent_rows, std::move(list_offs_col), std::move(child_values), 0, rmm::device_buffer{});
 }
 
 }  // namespace spark_rapids_jni::protobuf::detail

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -19,7 +19,89 @@
 #include <cudf/lists/detail/lists_column_factories.hpp>
 #include <cudf/strings/detail/strings_column_factories.cuh>
 
+#include <optional>
+
 namespace spark_rapids_jni::protobuf::detail {
+
+namespace {
+
+// Compute LIST<...> per-row offsets from a per-row count array. Produces a
+// `device_uvector<int32_t>` of size `num_rows + 1` with `offsets[num_rows] = total_count`.
+// `mr` should be the output memory resource since the returned offsets feed into the LIST column.
+inline rmm::device_uvector<int32_t> make_list_offsets_from_counts(
+  rmm::device_uvector<int32_t> const& counts,
+  int total_count,
+  int num_rows,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
+  thrust::exclusive_scan(
+    rmm::exec_policy_nosync(stream), counts.begin(), counts.end(), offsets.begin(), 0);
+  thrust::fill_n(
+    rmm::exec_policy_nosync(stream), offsets.data() + num_rows, 1, static_cast<int32_t>(total_count));
+  return offsets;
+}
+
+// Build a LIST<...> column whose null mask comes from the input column when it has nulls.
+// Used by all repeated-* builders to wrap `(offsets_col, child_col)` into a LIST column with
+// input-null propagation in a single shape.
+inline std::unique_ptr<cudf::column> make_list_column_with_input_nulls(
+  int num_rows,
+  std::unique_ptr<cudf::column> offsets_col,
+  std::unique_ptr<cudf::column> child_col,
+  cudf::column_view const& binary_input,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const input_null_count = binary_input.null_count();
+  if (input_null_count > 0) {
+    return cudf::make_lists_column(num_rows,
+                                   std::move(offsets_col),
+                                   std::move(child_col),
+                                   input_null_count,
+                                   cudf::copy_bitmask(binary_input, stream, mr));
+  }
+  return cudf::make_lists_column(
+    num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+}
+
+// Construct the singleton ([1]-element) device schema and indices that
+// `launch_count_repeated_in_nested` / `launch_scan_repeated_in_nested` consume when
+// `build_repeated_child_list_column` is processing a single repeated child field.
+// `parent_idx=-1` and `depth=0` are intentional: the kernel walks one local nested level only.
+inline std::pair<rmm::device_uvector<device_nested_field_descriptor>, rmm::device_uvector<int>>
+make_single_repeated_schema(int child_schema_idx,
+                            std::vector<nested_field_descriptor> const& schema,
+                            rmm::cuda_stream_view stream,
+                            rmm::device_async_resource_ref mr)
+{
+  device_nested_field_descriptor rep_desc;
+  rep_desc.field_number      = schema[child_schema_idx].field_number;
+  rep_desc.wire_type         = static_cast<int>(schema[child_schema_idx].wire_type);
+  rep_desc.output_type_id    = static_cast<int>(schema[child_schema_idx].output_type);
+  rep_desc.is_repeated       = true;
+  rep_desc.parent_idx        = -1;
+  rep_desc.depth             = 0;
+  rep_desc.encoding          = 0;
+  rep_desc.is_required       = false;
+  rep_desc.has_default_value = false;
+
+  rmm::device_uvector<device_nested_field_descriptor> d_schema(1, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_schema.data(),
+                                &rep_desc,
+                                sizeof(device_nested_field_descriptor),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+
+  int const zero = 0;
+  rmm::device_uvector<int> d_indices(1, stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+    d_indices.data(), &zero, sizeof(int), cudaMemcpyHostToDevice, stream.value()));
+  return {std::move(d_schema), std::move(d_indices)};
+}
+
+}  // namespace
 
 std::unique_ptr<cudf::column> build_repeated_msg_child_varlen_column(
   uint8_t const* message_data,
@@ -39,7 +121,8 @@ std::unique_ptr<cudf::column> build_repeated_msg_child_varlen_column(
     return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
   }
 
-  rmm::device_uvector<int32_t> d_lengths(total_count, stream, mr);
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<int32_t> d_lengths(total_count, stream, scratch_mr);
   thrust::transform(
     rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator(0),
@@ -55,7 +138,7 @@ std::unique_ptr<cudf::column> build_repeated_msg_child_varlen_column(
     d_lengths.begin(), d_lengths.end(), stream, mr);
 
   rmm::device_uvector<char> d_data(total_data, stream, mr);
-  rmm::device_uvector<bool> d_valid((total_count > 0 ? total_count : 1), stream, mr);
+  rmm::device_uvector<bool> d_valid((total_count > 0 ? total_count : 1), stream, scratch_mr);
 
   thrust::transform(
     rmm::exec_policy_nosync(stream),
@@ -103,7 +186,7 @@ std::unique_ptr<cudf::column> build_repeated_msg_child_varlen_column(
     size_t temp_storage_bytes = 0;
     cub::DeviceMemcpy::Batched(
       nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, total_count, stream.value());
-    rmm::device_buffer temp_storage(temp_storage_bytes, stream, mr);
+    rmm::device_buffer temp_storage(temp_storage_bytes, stream, scratch_mr);
     cub::DeviceMemcpy::Batched(temp_storage.data(),
                                temp_storage_bytes,
                                src_iter,
@@ -113,7 +196,7 @@ std::unique_ptr<cudf::column> build_repeated_msg_child_varlen_column(
                                stream.value());
   }
 
-  auto [mask, null_count] = make_null_mask_from_valid(d_valid, stream, mr);
+  auto [mask, null_count] = make_null_mask_from_valid(d_valid, total_count, stream, mr);
 
   if (as_bytes) {
     auto bytes_child =
@@ -236,11 +319,42 @@ std::unique_ptr<cudf::column> make_empty_list_column(std::unique_ptr<cudf::colum
 // Enum-as-string column builders
 // ============================================================================
 
-struct enum_string_lookup_tables {
-  rmm::device_uvector<int32_t> d_valid_enums;
-  rmm::device_uvector<int32_t> d_name_offsets;
-  rmm::device_uvector<uint8_t> d_name_chars;
-};
+// Forward declaration of the public builder (defined further down).
+enum_string_lookup_tables make_enum_string_lookup_tables(
+  cudf::detail::host_vector<int32_t> const& valid_enums,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+namespace {
+
+// Returns a const-ref to the lookup table for `schema_idx`, populating `ctx.enum_lookup_cache`
+// on first use. Falls back to building (without caching) when the cache is null.
+enum_string_lookup_tables const* get_enum_lookup(
+  schema_context_view const& ctx,
+  int schema_idx,
+  cudf::detail::host_vector<int32_t> const& valid_enums,
+  std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr,
+  std::optional<enum_string_lookup_tables>& fallback)
+{
+  if (ctx.enum_lookup_cache != nullptr) {
+    auto& cache = *ctx.enum_lookup_cache;
+    auto it     = cache.find(schema_idx);
+    if (it == cache.end()) {
+      it = cache
+             .emplace(schema_idx,
+                      make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr))
+             .first;
+    }
+    return &it->second;
+  }
+  fallback.emplace(make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr));
+  return &*fallback;
+}
+
+}  // namespace
 
 enum_string_lookup_tables make_enum_string_lookup_tables(
   cudf::detail::host_vector<int32_t> const& valid_enums,
@@ -253,7 +367,7 @@ enum_string_lookup_tables make_enum_string_lookup_tables(
 
   auto h_name_offsets =
     cudf::detail::make_pinned_vector_async<int32_t>(valid_enums.size() + 1, stream);
-  std::fill(h_name_offsets.begin(), h_name_offsets.end(), 0);
+  h_name_offsets[0]        = 0;
   int64_t total_name_chars = 0;
   for (size_t k = 0; k < enum_name_bytes.size(); ++k) {
     total_name_chars += static_cast<int64_t>(enum_name_bytes[k].size());
@@ -320,7 +434,7 @@ std::unique_ptr<cudf::column> build_enum_string_values_column(
                                   stream);
   }
 
-  auto [mask, null_count] = make_null_mask_from_valid(valid, stream, mr);
+  auto [mask, null_count] = make_null_mask_from_valid(valid, num_rows, stream, mr);
   return cudf::make_strings_column(
     num_rows, std::move(offsets_col), chars.release(), null_count, std::move(mask));
 }
@@ -378,12 +492,13 @@ std::unique_ptr<cudf::column> build_repeated_msg_child_enum_string_column(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  auto const threads = THREADS_PER_BLOCK;
-  auto const blocks  = static_cast<int>((total_count + threads - 1u) / threads);
-  auto lookup        = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+  auto const threads    = THREADS_PER_BLOCK;
+  auto const blocks     = static_cast<int>((total_count + threads - 1u) / threads);
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  auto lookup           = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
 
-  rmm::device_uvector<int32_t> enum_values(total_count, stream, mr);
-  rmm::device_uvector<bool> valid((total_count > 0 ? total_count : 1), stream, mr);
+  rmm::device_uvector<int32_t> enum_values(total_count, stream, scratch_mr);
+  rmm::device_uvector<bool> valid((total_count > 0 ? total_count : 1), stream, scratch_mr);
   repeated_msg_child_location_provider loc_provider{d_msg_row_offsets.data(),
                                                     0,
                                                     d_msg_locs.data(),
@@ -400,7 +515,7 @@ std::unique_ptr<cudf::column> build_repeated_msg_child_enum_string_column(
                                              false,
                                              0);
 
-  rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, mr);
+  rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, scratch_mr);
   thrust::fill(rmm::exec_policy_nosync(stream),
                d_elem_has_invalid_enum.begin(),
                d_elem_has_invalid_enum.end(),
@@ -439,11 +554,12 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
 {
   auto const rep_blocks =
     static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  auto lookup = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  auto lookup           = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
 
   // 1. Extract enum integer values from occurrences
-  rmm::device_uvector<int32_t> enum_ints(total_count, stream, mr);
-  rmm::device_uvector<bool> elem_valid(total_count, stream, mr);
+  rmm::device_uvector<int32_t> enum_ints(total_count, stream, scratch_mr);
+  rmm::device_uvector<bool> elem_valid(total_count, stream, scratch_mr);
   repeated_location_provider rep_loc{list_offsets, base_offset, d_occurrences.data()};
   extract_varint_kernel<int32_t, false>
     <<<rep_blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(message_data,
@@ -458,7 +574,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   // 2. Validate enum values — mark invalid as false in elem_valid
   // (elem_valid was already populated by extract_varint_kernel: true for success, false for
   // failure)
-  rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, mr);
+  rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, scratch_mr);
   thrust::fill(rmm::exec_policy_nosync(stream),
                d_elem_has_invalid_enum.begin(),
                d_elem_has_invalid_enum.end(),
@@ -471,7 +587,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
                               total_count,
                               stream);
 
-  rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, mr);
+  rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, scratch_mr);
   thrust::transform(rmm::exec_policy_nosync(stream),
                     d_occurrences.begin(),
                     d_occurrences.end(),
@@ -484,26 +600,12 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
     build_enum_string_values_column(enum_ints, elem_valid, lookup, total_count, stream, mr);
 
   // Build the final LIST<STRING> column from the per-row counts and decoded child strings.
-  rmm::device_uvector<int32_t> lo(num_rows + 1, stream, mr);
-  thrust::exclusive_scan(
-    rmm::exec_policy_nosync(stream), d_field_counts.begin(), d_field_counts.end(), lo.begin(), 0);
-  int32_t tc_i32 = static_cast<int32_t>(total_count);
-  thrust::fill_n(rmm::exec_policy_nosync(stream), lo.data() + num_rows, 1, tc_i32);
-
+  auto lo            = make_list_offsets_from_counts(d_field_counts, total_count, num_rows, stream, mr);
   auto list_offs_col = std::make_unique<cudf::column>(
     cudf::data_type{cudf::type_id::INT32}, num_rows + 1, lo.release(), rmm::device_buffer{}, 0);
 
-  auto input_null_count = binary_input.null_count();
-  if (input_null_count > 0) {
-    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
-    return cudf::make_lists_column(num_rows,
-                                   std::move(list_offs_col),
-                                   std::move(child_col),
-                                   input_null_count,
-                                   std::move(null_mask));
-  }
-  return cudf::make_lists_column(
-    num_rows, std::move(list_offs_col), std::move(child_col), 0, rmm::device_buffer{});
+  return make_list_column_with_input_nulls(
+    num_rows, std::move(list_offs_col), std::move(child_col), binary_input, stream, mr);
 }
 
 std::unique_ptr<cudf::column> build_repeated_string_column(
@@ -536,33 +638,15 @@ std::unique_ptr<cudf::column> build_repeated_string_column(
                                   cudf::data_type{cudf::type_id::LIST}, stream, mr)  // LIST<UINT8>
                                 : cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
 
-    if (input_null_count > 0) {
-      // Copy input null mask - only input nulls produce output nulls
-      auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
-      return cudf::make_lists_column(num_rows,
-                                     std::move(offsets_col),
-                                     std::move(child_col),
-                                     input_null_count,
-                                     std::move(null_mask));
-    } else {
-      // No input nulls, all rows get empty arrays []
-      return cudf::make_lists_column(
-        num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
-    }
+    return make_list_column_with_input_nulls(
+      num_rows, std::move(offsets_col), std::move(child_col), binary_input, stream, mr);
   }
 
-  rmm::device_uvector<int32_t> list_offs(num_rows + 1, stream, mr);
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
-                         d_field_counts.begin(),
-                         d_field_counts.end(),
-                         list_offs.begin(),
-                         0);
-
-  int32_t total_count_i32 = static_cast<int32_t>(total_count);
-  thrust::fill_n(rmm::exec_policy_nosync(stream), list_offs.data() + num_rows, 1, total_count_i32);
+  auto list_offs = make_list_offsets_from_counts(d_field_counts, total_count, num_rows, stream, mr);
 
   // Extract string lengths from occurrences
-  rmm::device_uvector<int32_t> str_lengths(total_count, stream, mr);
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<int32_t> str_lengths(total_count, stream, scratch_mr);
   auto const threads = THREADS_PER_BLOCK;
   auto const blocks  = static_cast<int>((total_count + threads - 1u) / threads);
   repeated_location_provider loc_provider{list_offsets, base_offset, d_occurrences.data()};
@@ -602,7 +686,7 @@ std::unique_ptr<cudf::column> build_repeated_string_column(
     size_t temp_storage_bytes = 0;
     cub::DeviceMemcpy::Batched(
       nullptr, temp_storage_bytes, src_iter, dst_iter, size_iter, total_count, stream.value());
-    rmm::device_buffer temp_storage(temp_storage_bytes, stream, mr);
+    rmm::device_buffer temp_storage(temp_storage_bytes, stream, scratch_mr);
     cub::DeviceMemcpy::Batched(temp_storage.data(),
                                temp_storage_bytes,
                                src_iter,
@@ -633,20 +717,10 @@ std::unique_ptr<cudf::column> build_repeated_string_column(
                                                     rmm::device_buffer{},
                                                     0);
 
-  // Only rows where INPUT is null should produce null output
-  // Rows with valid input but count=0 should produce empty array []
-  if (input_null_count > 0) {
-    // Copy input null mask - only input nulls produce output nulls
-    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
-    return cudf::make_lists_column(num_rows,
-                                   std::move(offsets_col),
-                                   std::move(child_col),
-                                   input_null_count,
-                                   std::move(null_mask));
-  }
-
-  return cudf::make_lists_column(
-    num_rows, std::move(offsets_col), std::move(child_col), 0, rmm::device_buffer{});
+  // Only rows where INPUT is null should produce null output;
+  // rows with valid input but count=0 produce empty array [].
+  return make_list_column_with_input_nulls(
+    num_rows, std::move(offsets_col), std::move(child_col), binary_input, stream, mr);
 }
 
 // Forward declaration -- build_nested_struct_column is defined after build_repeated_struct_column
@@ -660,12 +734,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<int> const& child_field_indices,
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,
@@ -688,12 +757,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
   int child_schema_idx,
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -715,20 +779,21 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
   int num_rows,
   std::vector<device_nested_field_descriptor> const& h_device_schema,
   std::vector<int> const& child_field_indices,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
   std::vector<nested_field_descriptor> const& schema,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error_top,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  auto const input_null_count = binary_input.null_count();
-  int num_child_fields        = static_cast<int>(child_field_indices.size());
+  auto const& default_ints      = ctx.default_ints;
+  auto const& default_floats    = ctx.default_floats;
+  auto const& default_bools     = ctx.default_bools;
+  auto const& default_strings   = ctx.default_strings;
+  auto const& enum_valid_values = ctx.enum_valid_values;
+  auto const& enum_names        = ctx.enum_names;
+  auto const input_null_count   = binary_input.null_count();
+  int num_child_fields          = static_cast<int>(child_field_indices.size());
 
   if (total_count == 0 || num_child_fields == 0) {
     // All rows have count=0 or no child fields - return list of empty structs
@@ -760,47 +825,36 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
     auto empty_struct = cudf::make_structs_column(
       0, std::move(empty_struct_children), 0, rmm::device_buffer{}, stream, mr);
 
-    if (input_null_count > 0) {
-      auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
-      return cudf::make_lists_column(num_rows,
-                                     std::move(offsets_col),
-                                     std::move(empty_struct),
-                                     input_null_count,
-                                     std::move(null_mask));
-    } else {
-      return cudf::make_lists_column(
-        num_rows, std::move(offsets_col), std::move(empty_struct), 0, rmm::device_buffer{});
-    }
+    return make_list_column_with_input_nulls(
+      num_rows, std::move(offsets_col), std::move(empty_struct), binary_input, stream, mr);
   }
 
-  rmm::device_uvector<int32_t> list_offs(num_rows + 1, stream, mr);
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
-                         d_field_counts.begin(),
-                         d_field_counts.end(),
-                         list_offs.begin(),
-                         0);
+  auto list_offs = make_list_offsets_from_counts(d_field_counts, total_count, num_rows, stream, mr);
 
-  int32_t total_count_i32 = static_cast<int32_t>(total_count);
-  thrust::fill_n(rmm::exec_policy_nosync(stream), list_offs.data() + num_rows, 1, total_count_i32);
-
-  // Build child field descriptors for scanning within each message occurrence
-  std::vector<field_descriptor> h_child_descs(num_child_fields);
+  // Build child field descriptors for scanning within each message occurrence.
+  // Stage through pinned memory so the H2D is truly stream-async.
+  auto h_child_descs =
+    cudf::detail::make_pinned_vector_async<field_descriptor>(num_child_fields, stream);
   for (int ci = 0; ci < num_child_fields; ci++) {
     int child_schema_idx                 = child_field_indices[ci];
     h_child_descs[ci].field_number       = h_device_schema[child_schema_idx].field_number;
     h_child_descs[ci].expected_wire_type = h_device_schema[child_schema_idx].wire_type;
     h_child_descs[ci].is_repeated        = h_device_schema[child_schema_idx].is_repeated;
   }
-  rmm::device_uvector<field_descriptor> d_child_descs(num_child_fields, stream, mr);
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<field_descriptor> d_child_descs(num_child_fields, stream, scratch_mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_descs.data(),
                                 h_child_descs.data(),
                                 num_child_fields * sizeof(field_descriptor),
                                 cudaMemcpyHostToDevice,
                                 stream.value()));
-  auto h_child_lookup = build_field_lookup_table(h_child_descs.data(), num_child_fields);
-  rmm::device_uvector<int> d_child_lookup(0, stream, mr);
-  if (!h_child_lookup.empty()) {
-    d_child_lookup = rmm::device_uvector<int>(h_child_lookup.size(), stream, mr);
+  auto h_lookup_vec = build_field_lookup_table(h_child_descs.data(), num_child_fields);
+  rmm::device_uvector<int> d_child_lookup(0, stream, scratch_mr);
+  if (!h_lookup_vec.empty()) {
+    auto h_child_lookup =
+      cudf::detail::make_pinned_vector_async<int>(h_lookup_vec.size(), stream);
+    std::copy(h_lookup_vec.begin(), h_lookup_vec.end(), h_child_lookup.begin());
+    d_child_lookup = rmm::device_uvector<int>(h_child_lookup.size(), stream, scratch_mr);
     CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_lookup.data(),
                                   h_child_lookup.data(),
                                   h_child_lookup.size() * sizeof(int),
@@ -811,8 +865,8 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
   // For each occurrence, we need to scan for child fields
   // Create "virtual" parent locations from the occurrences using GPU kernel
   // This replaces the host-side loop with D->H->D copy pattern (critical performance fix!)
-  rmm::device_uvector<field_location> d_msg_locs(total_count, stream, mr);
-  rmm::device_uvector<cudf::size_type> d_msg_row_offsets(total_count, stream, mr);
+  rmm::device_uvector<field_location> d_msg_locs(total_count, stream, scratch_mr);
+  rmm::device_uvector<cudf::size_type> d_msg_row_offsets(total_count, stream, scratch_mr);
   launch_compute_msg_locations_from_occurrences(d_occurrences.data(),
                                                 list_offsets,
                                                 base_offset,
@@ -821,7 +875,7 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                                                 total_count,
                                                 d_error_top.data(),
                                                 stream);
-  rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, mr);
+  rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, scratch_mr);
   thrust::transform(rmm::exec_policy_nosync(stream),
                     d_occurrences.data(),
                     d_occurrences.end(),
@@ -829,7 +883,8 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                     [] __device__(repeated_occurrence const& occ) { return occ.row_idx; });
 
   // Scan for child fields within each message occurrence
-  rmm::device_uvector<field_location> d_child_locs(total_count * num_child_fields, stream, mr);
+  rmm::device_uvector<field_location> d_child_locs(
+    static_cast<size_t>(total_count) * num_child_fields, stream, scratch_mr);
   // Reuse top-level error flag so failfast can observe nested repeated-message failures.
   auto& d_error = d_error_top;
 
@@ -847,7 +902,7 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                                         num_child_fields,
                                         d_child_locs.data(),
                                         d_error.data(),
-                                        h_child_lookup.empty() ? nullptr : d_child_lookup.data(),
+                                        h_lookup_vec.empty() ? nullptr : d_child_lookup.data(),
                                         static_cast<int>(d_child_lookup.size()),
                                         stream);
 
@@ -889,12 +944,7 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                                                                  child_schema_idx,
                                                                  schema,
                                                                  num_schema_fields,
-                                                                 default_ints,
-                                                                 default_floats,
-                                                                 default_bools,
-                                                                 default_strings,
-                                                                 enum_valid_values,
-                                                                 enum_names,
+                                                                 ctx,
                                                                  d_row_force_null,
                                                                  d_error_top,
                                                                  stream,
@@ -1014,8 +1064,9 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                                       mr));
         } else {
           // Compute virtual parent locations for each occurrence's nested struct child
-          rmm::device_uvector<field_location> d_nested_locs(total_count, stream, mr);
-          rmm::device_uvector<cudf::size_type> d_nested_row_offsets(total_count, stream, mr);
+          rmm::device_uvector<field_location> d_nested_locs(total_count, stream, scratch_mr);
+          rmm::device_uvector<cudf::size_type> d_nested_row_offsets(
+            total_count, stream, scratch_mr);
           launch_compute_nested_struct_locations(d_child_locs.data(),
                                                  d_msg_locs.data(),
                                                  d_msg_row_offsets.data(),
@@ -1035,12 +1086,7 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                                                                grandchild_indices,
                                                                schema,
                                                                num_schema_fields,
-                                                               default_ints,
-                                                               default_floats,
-                                                               default_bools,
-                                                               default_strings,
-                                                               enum_valid_values,
-                                                               enum_names,
+                                                               ctx,
                                                                d_row_force_null,
                                                                d_error_top,
                                                                total_count,
@@ -1071,17 +1117,8 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
                                                     0);
 
   // Build the final LIST column
-  if (input_null_count > 0) {
-    auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);
-    return cudf::make_lists_column(num_rows,
-                                   std::move(offsets_col),
-                                   std::move(struct_col),
-                                   input_null_count,
-                                   std::move(null_mask));
-  }
-
-  return cudf::make_lists_column(
-    num_rows, std::move(offsets_col), std::move(struct_col), 0, rmm::device_buffer{});
+  return make_list_column_with_input_nulls(
+    num_rows, std::move(offsets_col), std::move(struct_col), binary_input, stream, mr);
 }
 
 std::unique_ptr<cudf::column> build_nested_struct_column(
@@ -1093,12 +1130,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<int> const& child_field_indices,
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,
@@ -1108,6 +1140,12 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   int depth,
   bool propagate_invalid_rows)
 {
+  auto const& default_ints      = ctx.default_ints;
+  auto const& default_floats    = ctx.default_floats;
+  auto const& default_bools     = ctx.default_bools;
+  auto const& default_strings   = ctx.default_strings;
+  auto const& enum_valid_values = ctx.enum_valid_values;
+  auto const& enum_names        = ctx.enum_names;
   CUDF_EXPECTS(depth < MAX_NESTING_DEPTH,
                "Nested protobuf struct depth exceeds supported decode recursion limit");
 
@@ -1135,7 +1173,9 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   auto const blocks    = static_cast<int>((num_rows + threads - 1u) / threads);
   int num_child_fields = static_cast<int>(child_field_indices.size());
 
-  std::vector<field_descriptor> h_child_field_descs(num_child_fields);
+  // Stage child field descriptors through pinned memory so the H2D stays stream-async.
+  auto h_child_field_descs =
+    cudf::detail::make_pinned_vector_async<field_descriptor>(num_child_fields, stream);
   for (int i = 0; i < num_child_fields; i++) {
     int child_idx                             = child_field_indices[i];
     h_child_field_descs[i].field_number       = schema[child_idx].field_number;
@@ -1143,7 +1183,8 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
     h_child_field_descs[i].is_repeated        = schema[child_idx].is_repeated;
   }
 
-  rmm::device_uvector<field_descriptor> d_child_field_descs(num_child_fields, stream, mr);
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<field_descriptor> d_child_field_descs(num_child_fields, stream, scratch_mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_field_descs.data(),
                                 h_child_field_descs.data(),
                                 num_child_fields * sizeof(field_descriptor),
@@ -1151,7 +1192,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                 stream.value()));
 
   rmm::device_uvector<field_location> d_child_locations(
-    static_cast<size_t>(num_rows) * num_child_fields, stream, mr);
+    static_cast<size_t>(num_rows) * num_child_fields, stream, scratch_mr);
   launch_scan_nested_message_fields(message_data,
                                     message_data_size,
                                     list_offsets,
@@ -1195,12 +1236,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                                                  child_schema_idx,
                                                                  schema,
                                                                  num_fields,
-                                                                 default_ints,
-                                                                 default_floats,
-                                                                 default_bools,
-                                                                 default_strings,
-                                                                 enum_valid_values,
-                                                                 enum_names,
+                                                                 ctx,
                                                                  d_row_force_null,
                                                                  d_error,
                                                                  stream,
@@ -1296,18 +1332,12 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
         } else {
           bool has_def_str    = has_def;
           auto const& def_str = default_strings[child_schema_idx];
-          nested_location_provider len_provider{list_offsets,
+          nested_location_provider loc_provider{list_offsets,
                                                 base_offset,
                                                 d_parent_locs.data(),
                                                 d_child_locations.data(),
                                                 ci,
                                                 num_child_fields};
-          nested_location_provider copy_provider{list_offsets,
-                                                 base_offset,
-                                                 d_parent_locs.data(),
-                                                 d_child_locations.data(),
-                                                 ci,
-                                                 num_child_fields};
           auto valid_fn = [plocs = d_parent_locs.data(),
                            flocs = d_child_locations.data(),
                            ci,
@@ -1323,8 +1353,8 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
           struct_children.push_back(extract_and_build_string_or_bytes_column(false,
                                                                              message_data,
                                                                              num_rows,
-                                                                             len_provider,
-                                                                             copy_provider,
+                                                                             loc_provider,
+                                                                             loc_provider,
                                                                              valid_fn,
                                                                              has_def_str,
                                                                              def_str,
@@ -1338,18 +1368,12 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
         // bytes (BinaryType) represented as LIST<UINT8>
         bool has_def_bytes    = has_def;
         auto const& def_bytes = default_strings[child_schema_idx];
-        nested_location_provider len_provider{list_offsets,
+        nested_location_provider loc_provider{list_offsets,
                                               base_offset,
                                               d_parent_locs.data(),
                                               d_child_locations.data(),
                                               ci,
                                               num_child_fields};
-        nested_location_provider copy_provider{list_offsets,
-                                               base_offset,
-                                               d_parent_locs.data(),
-                                               d_child_locations.data(),
-                                               ci,
-                                               num_child_fields};
         auto valid_fn = [plocs = d_parent_locs.data(),
                          flocs = d_child_locations.data(),
                          ci,
@@ -1364,8 +1388,8 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
         struct_children.push_back(extract_and_build_string_or_bytes_column(true,
                                                                            message_data,
                                                                            num_rows,
-                                                                           len_provider,
-                                                                           copy_provider,
+                                                                           loc_provider,
+                                                                           loc_provider,
                                                                            valid_fn,
                                                                            has_def_bytes,
                                                                            def_bytes,
@@ -1380,7 +1404,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
           struct_children.push_back(make_null_column(dt, num_rows, stream, mr));
           break;
         }
-        rmm::device_uvector<field_location> d_gc_parent(num_rows, stream, mr);
+        rmm::device_uvector<field_location> d_gc_parent(num_rows, stream, scratch_mr);
         launch_compute_grandchild_parent_locations(d_parent_locs.data(),
                                                    d_child_locations.data(),
                                                    ci,
@@ -1397,12 +1421,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                                              gc_indices,
                                                              schema,
                                                              num_fields,
-                                                             default_ints,
-                                                             default_floats,
-                                                             default_bools,
-                                                             default_strings,
-                                                             enum_valid_values,
-                                                             enum_names,
+                                                             ctx,
                                                              d_row_force_null,
                                                              d_error,
                                                              num_rows,
@@ -1417,14 +1436,15 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
     }
   }
 
-  rmm::device_uvector<bool> struct_valid((num_rows > 0 ? num_rows : 1), stream, mr);
+  rmm::device_uvector<bool> struct_valid((num_rows > 0 ? num_rows : 1), stream, scratch_mr);
   thrust::transform(
     rmm::exec_policy_nosync(stream),
     thrust::make_counting_iterator<cudf::size_type>(0),
     thrust::make_counting_iterator<cudf::size_type>(num_rows),
     struct_valid.data(),
     [plocs = d_parent_locs.data()] __device__(auto row) { return plocs[row].offset >= 0; });
-  auto [struct_mask, struct_null_count] = make_null_mask_from_valid(struct_valid, stream, mr);
+  auto [struct_mask, struct_null_count] =
+    make_null_mask_from_valid(struct_valid, num_rows, stream, mr);
   return cudf::make_structs_column(
     num_rows, std::move(struct_children), struct_null_count, std::move(struct_mask), stream, mr);
 }
@@ -1443,12 +1463,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
   int child_schema_idx,
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -1457,36 +1472,18 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
   int depth,
   bool propagate_invalid_rows)
 {
-  auto elem_type_id = schema[child_schema_idx].output_type;
-  rmm::device_uvector<repeated_field_info> d_rep_info(num_parent_rows, stream, mr);
+  // This function only consumes enum metadata directly — defaults are forwarded through `ctx`
+  // to the recursive `build_nested_struct_column` call.
+  auto const& enum_valid_values = ctx.enum_valid_values;
+  auto const& enum_names        = ctx.enum_names;
+  auto elem_type_id             = schema[child_schema_idx].output_type;
+  auto const scratch_mr         = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<repeated_field_info> d_rep_info(num_parent_rows, stream, scratch_mr);
 
-  std::vector<int> rep_indices = {0};
-  rmm::device_uvector<int> d_rep_indices(1, stream, mr);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(
-    d_rep_indices.data(), rep_indices.data(), sizeof(int), cudaMemcpyHostToDevice, stream.value()));
-
-  device_nested_field_descriptor rep_desc;
-  rep_desc.field_number      = schema[child_schema_idx].field_number;
-  rep_desc.wire_type         = static_cast<int>(schema[child_schema_idx].wire_type);
-  rep_desc.output_type_id    = static_cast<int>(schema[child_schema_idx].output_type);
-  rep_desc.is_repeated       = true;
-  rep_desc.parent_idx        = -1;
-  rep_desc.depth             = 0;
-  rep_desc.encoding          = 0;
-  rep_desc.is_required       = false;
-  rep_desc.has_default_value = false;
   CUDF_EXPECTS(schema[child_schema_idx].is_repeated,
                "count_repeated_in_nested_kernel launch requires repeated child schema");
-  CUDF_EXPECTS(rep_desc.depth == 0,
-               "count_repeated_in_nested_kernel launch requires pre-filtered local depth 0");
-
-  std::vector<device_nested_field_descriptor> h_rep_schema = {rep_desc};
-  rmm::device_uvector<device_nested_field_descriptor> d_rep_schema(1, stream, mr);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(d_rep_schema.data(),
-                                h_rep_schema.data(),
-                                sizeof(device_nested_field_descriptor),
-                                cudaMemcpyHostToDevice,
-                                stream.value()));
+  auto [d_rep_schema, d_rep_indices] =
+    make_single_repeated_schema(child_schema_idx, schema, stream, scratch_mr);
 
   launch_count_repeated_in_nested(message_data,
                                   message_data_size,
@@ -1502,14 +1499,17 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
                                   d_error.data(),
                                   stream);
 
-  rmm::device_uvector<int32_t> d_rep_counts(num_parent_rows, stream, mr);
+  rmm::device_uvector<int32_t> d_rep_counts(num_parent_rows, stream, scratch_mr);
   thrust::transform(rmm::exec_policy_nosync(stream),
                     d_rep_info.data(),
                     d_rep_info.end(),
                     d_rep_counts.data(),
                     [] __device__(repeated_field_info const& info) { return info.count; });
-  int total_rep_count =
-    thrust::reduce(rmm::exec_policy_nosync(stream), d_rep_counts.data(), d_rep_counts.end(), 0);
+  int64_t total_rep_count_64 = thrust::reduce(
+    rmm::exec_policy_nosync(stream), d_rep_counts.data(), d_rep_counts.end(), int64_t{0});
+  CUDF_EXPECTS(total_rep_count_64 <= std::numeric_limits<int32_t>::max(),
+               "Repeated nested-field total element count exceeds 2^31-1");
+  int const total_rep_count = static_cast<int>(total_rep_count_64);
 
   if (total_rep_count == 0) {
     rmm::device_uvector<int32_t> list_offsets_vec(num_parent_rows + 1, stream, mr);
@@ -1531,13 +1531,10 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
       num_parent_rows, std::move(list_offsets_col), std::move(child_col), 0, rmm::device_buffer{});
   }
 
-  rmm::device_uvector<int32_t> list_offs(num_parent_rows + 1, stream, mr);
-  thrust::exclusive_scan(
-    rmm::exec_policy_nosync(stream), d_rep_counts.data(), d_rep_counts.end(), list_offs.begin(), 0);
-  thrust::fill_n(
-    rmm::exec_policy_nosync(stream), list_offs.data() + num_parent_rows, 1, total_rep_count);
+  auto list_offs =
+    make_list_offsets_from_counts(d_rep_counts, total_rep_count, num_parent_rows, stream, mr);
 
-  rmm::device_uvector<repeated_occurrence> d_rep_occs(total_rep_count, stream, mr);
+  rmm::device_uvector<repeated_occurrence> d_rep_occs(total_rep_count, stream, scratch_mr);
   launch_scan_repeated_in_nested(message_data,
                                  message_data_size,
                                  row_offsets,
@@ -1551,7 +1548,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
                                  d_error.data(),
                                  stream);
 
-  rmm::device_uvector<int32_t> d_rep_top_row_indices(total_rep_count, stream, mr);
+  rmm::device_uvector<int32_t> d_rep_top_row_indices(total_rep_count, stream, scratch_mr);
   thrust::transform(rmm::exec_policy_nosync(stream),
                     d_rep_occs.begin(),
                     d_rep_occs.end(),
@@ -1599,10 +1596,17 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
           child_schema_idx < static_cast<int>(enum_names.size()) &&
           !enum_valid_values[child_schema_idx].empty() &&
           enum_valid_values[child_schema_idx].size() == enum_names[child_schema_idx].size()) {
-        auto lookup = make_enum_string_lookup_tables(
-          enum_valid_values[child_schema_idx], enum_names[child_schema_idx], stream, mr);
-        rmm::device_uvector<int32_t> enum_values(total_rep_count, stream, mr);
-        rmm::device_uvector<bool> valid((total_rep_count > 0 ? total_rep_count : 1), stream, mr);
+        std::optional<enum_string_lookup_tables> fallback_lookup;
+        auto const& lookup = *get_enum_lookup(ctx,
+                                              child_schema_idx,
+                                              enum_valid_values[child_schema_idx],
+                                              enum_names[child_schema_idx],
+                                              stream,
+                                              mr,
+                                              fallback_lookup);
+        rmm::device_uvector<int32_t> enum_values(total_rep_count, stream, scratch_mr);
+        rmm::device_uvector<bool> valid(
+          (total_rep_count > 0 ? total_rep_count : 1), stream, scratch_mr);
         extract_varint_kernel<int32_t, false, nested_repeated_location_provider>
           <<<rep_blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(message_data,
                                                                  nr_loc,
@@ -1613,7 +1617,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
                                                                  false,
                                                                  0);
 
-        rmm::device_uvector<bool> d_elem_has_invalid_enum(total_rep_count, stream, mr);
+        rmm::device_uvector<bool> d_elem_has_invalid_enum(total_rep_count, stream, scratch_mr);
         thrust::fill(rmm::exec_policy_nosync(stream),
                      d_elem_has_invalid_enum.begin(),
                      d_elem_has_invalid_enum.end(),
@@ -1663,8 +1667,10 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
                                                stream,
                                                mr);
     } else {
-      rmm::device_uvector<cudf::size_type> d_virtual_row_offsets(total_rep_count, stream, mr);
-      rmm::device_uvector<field_location> d_virtual_parent_locs(total_rep_count, stream, mr);
+      rmm::device_uvector<cudf::size_type> d_virtual_row_offsets(
+        total_rep_count, stream, scratch_mr);
+      rmm::device_uvector<field_location> d_virtual_parent_locs(
+        total_rep_count, stream, scratch_mr);
       launch_compute_virtual_parents_for_nested_repeated(d_rep_occs.data(),
                                                          row_offsets,
                                                          parent_locs,
@@ -1682,12 +1688,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
                                                 gc_indices,
                                                 schema,
                                                 num_fields,
-                                                default_ints,
-                                                default_floats,
-                                                default_bools,
-                                                default_strings,
-                                                enum_valid_values,
-                                                enum_names,
+                                                ctx,
                                                 d_row_force_null,
                                                 d_error,
                                                 total_rep_count,

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace spark_rapids_jni::protobuf::detail {

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -28,9 +28,51 @@
 #include <cstdint>
 #include <memory>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 namespace spark_rapids_jni::protobuf::detail {
+
+// ============================================================================
+// Enum-as-string lookup tables
+// ============================================================================
+
+/**
+ * Device-side lookup tables for an enum-as-string field. `make_enum_string_lookup_tables`
+ * builds them; the per-decode cache (`enum_string_lookup_cache`) keeps them alive across
+ * call sites so deeply-nested decoders don't rebuild and re-upload the same metadata.
+ */
+struct enum_string_lookup_tables {
+  rmm::device_uvector<int32_t> d_valid_enums;
+  rmm::device_uvector<int32_t> d_name_offsets;
+  rmm::device_uvector<uint8_t> d_name_chars;
+};
+
+// Map keyed by schema field index. unordered_map is chosen because element references stay
+// stable across insertions (only erase invalidates), so callers can hold `auto const&` into
+// it during recursion.
+using enum_string_lookup_cache = std::unordered_map<int, enum_string_lookup_tables>;
+
+// ============================================================================
+// Schema-context bundle
+// ============================================================================
+
+/**
+ * View of the per-decode default-value and enum metadata. Reduces parameter pressure on the
+ * recursive nested/repeated builders, which all consume the same six host vectors. The struct
+ * holds non-owning references — its lifetime must enclose the calls. Optionally carries a
+ * pointer to a mutable enum lookup cache; when present, builders reuse cached lookup tables
+ * across recursive call sites instead of re-running `make_enum_string_lookup_tables`.
+ */
+struct schema_context_view {
+  std::vector<int64_t> const& default_ints;
+  std::vector<double> const& default_floats;
+  std::vector<bool> const& default_bools;
+  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings;
+  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values;
+  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names;
+  enum_string_lookup_cache* enum_lookup_cache = nullptr;
+};
 
 // ============================================================================
 // Field number lookup table helpers
@@ -240,12 +282,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<int> const& child_field_indices,
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,
@@ -265,12 +302,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
   int child_schema_idx,
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -292,13 +324,8 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
   int num_rows,
   std::vector<device_nested_field_descriptor> const& h_device_schema,
   std::vector<int> const& child_field_indices,
-  std::vector<int64_t> const& default_ints,
-  std::vector<double> const& default_floats,
-  std::vector<bool> const& default_bools,
-  std::vector<cudf::detail::host_vector<uint8_t>> const& default_strings,
   std::vector<nested_field_descriptor> const& schema,
-  std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
-  std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
+  schema_context_view const& ctx,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error_top,
   rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -438,6 +438,7 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
                 error_flag)) {
             return;
           }
+          break;  // Each tag dispatches to at most one repeated index (mirrors lookup-table path)
         }
       }
     }
@@ -530,7 +531,11 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
   uint8_t const* cur     = bytes + start;
   uint8_t const* msg_end = bytes + end;
 
-  constexpr int MAX_STACK_FIELDS = 128;
+  // Tighter bound matches realistic Spark schemas (typical: <16 top-level repeated fields per
+  // message). Keeping the cap small keeps `write_idx` in registers / L1 instead of spilling into
+  // local memory, which would otherwise cost 4x the per-thread footprint at MAX_STACK_FIELDS=128
+  // and pressure occupancy. ERR_SCHEMA_TOO_LARGE remains the host-visible cap.
+  constexpr int MAX_STACK_FIELDS = 32;
   if (num_scan_fields > MAX_STACK_FIELDS) {
     set_error_once(error_flag, ERR_SCHEMA_TOO_LARGE);
     return;
@@ -575,6 +580,7 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
       for (int f = 0; f < num_scan_fields; f++) {
         if (scan_descs[f].field_number == fn) {
           if (!try_scan(f)) return;
+          break;  // Each tag dispatches to at most one scan descriptor
         }
       }
     }
@@ -897,6 +903,7 @@ CUDF_KERNEL void count_repeated_in_nested_kernel(uint8_t const* message_data,
                                     error_flag)) {
           return;
         }
+        break;  // Each tag dispatches to at most one repeated index
       }
     }
 
@@ -1186,6 +1193,30 @@ CUDF_KERNEL void check_required_fields_kernel(
 }
 
 /**
+ * Binary search a sorted enum-value array. Returns the matched index or -1 if not found.
+ * Shared between the validate / lengths / chars enum-as-string kernels.
+ */
+__device__ inline int enum_binary_search(int32_t const* valid_enum_values,
+                                         int num_valid_values,
+                                         int32_t val)
+{
+  int left  = 0;
+  int right = num_valid_values - 1;
+  while (left <= right) {
+    int mid         = left + (right - left) / 2;
+    int32_t mid_val = valid_enum_values[mid];
+    if (mid_val == val) {
+      return mid;
+    } else if (mid_val < val) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+  return -1;
+}
+
+/**
  * Validate enum values against a set of valid values.
  * If a value is not in the valid set:
  * 1. Mark the field as invalid (valid[row] = false)
@@ -1212,27 +1243,7 @@ CUDF_KERNEL void validate_enum_values_kernel(
   // Skip if already invalid (field was missing) - missing field is not an enum error
   if (!valid[row]) return;
 
-  int32_t val = values[row];
-
-  // Binary search for the value in valid_enum_values
-  int left   = 0;
-  int right  = num_valid_values - 1;
-  bool found = false;
-
-  while (left <= right) {
-    int mid = left + (right - left) / 2;
-    if (valid_enum_values[mid] == val) {
-      found = true;
-      break;
-    } else if (valid_enum_values[mid] < val) {
-      left = mid + 1;
-    } else {
-      right = mid - 1;
-    }
-  }
-
-  // If not found, mark as invalid
-  if (!found) {
+  if (enum_binary_search(valid_enum_values, num_valid_values, values[row]) < 0) {
     valid[row] = false;
     // Also mark the row as having an invalid enum - this will null the entire struct row
     row_has_invalid_enum[row] = true;
@@ -1261,24 +1272,9 @@ CUDF_KERNEL void compute_enum_string_lengths_kernel(
     return;
   }
 
-  int32_t val = values[row];
-  int left    = 0;
-  int right   = num_valid_values - 1;
-  while (left <= right) {
-    int mid         = left + (right - left) / 2;
-    int32_t mid_val = valid_enum_values[mid];
-    if (mid_val == val) {
-      lengths[row] = enum_name_offsets[mid + 1] - enum_name_offsets[mid];
-      return;
-    } else if (mid_val < val) {
-      left = mid + 1;
-    } else {
-      right = mid - 1;
-    }
-  }
-
+  int idx = enum_binary_search(valid_enum_values, num_valid_values, values[row]);
   // Should not happen when validate_enum_values_kernel has already run, but keep safe.
-  lengths[row] = 0;
+  lengths[row] = idx >= 0 ? (enum_name_offsets[idx + 1] - enum_name_offsets[idx]) : 0;
 }
 
 /**
@@ -1299,26 +1295,13 @@ CUDF_KERNEL void copy_enum_string_chars_kernel(
   if (row >= num_rows) return;
   if (!valid[row]) return;
 
-  int32_t val = values[row];
-  int left    = 0;
-  int right   = num_valid_values - 1;
-  while (left <= right) {
-    int mid         = left + (right - left) / 2;
-    int32_t mid_val = valid_enum_values[mid];
-    if (mid_val == val) {
-      int32_t src_begin = enum_name_offsets[mid];
-      int32_t src_end   = enum_name_offsets[mid + 1];
-      int32_t dst_begin = output_offsets[row];
-      memcpy(out_chars + dst_begin,
-             enum_name_chars + src_begin,
-             static_cast<size_t>(src_end - src_begin));
-      return;
-    } else if (mid_val < val) {
-      left = mid + 1;
-    } else {
-      right = mid - 1;
-    }
-  }
+  int idx = enum_binary_search(valid_enum_values, num_valid_values, values[row]);
+  if (idx < 0) return;
+  int32_t src_begin = enum_name_offsets[idx];
+  int32_t src_end   = enum_name_offsets[idx + 1];
+  int32_t dst_begin = output_offsets[row];
+  memcpy(
+    out_chars + dst_begin, enum_name_chars + src_begin, static_cast<size_t>(src_end - src_begin));
 }
 
 }  // anonymous namespace

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -410,7 +410,10 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
       int i = fn_to_rep_idx[fn];
       if (i >= 0) {
         int schema_idx = repeated_field_indices[i];
-        if (schema[schema_idx].depth == depth_level &&
+        // Defensive: also verify field_number matches, mirroring the linear-scan fallback below.
+        // A correct lookup table guarantees this, but failing closed on a buggy table is cheap
+        // and avoids dispatching to the wrong field index silently.
+        if (schema[schema_idx].field_number == fn && schema[schema_idx].depth == depth_level &&
             !count_repeated_element(
               cur,
               msg_end,
@@ -481,7 +484,8 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
       int i = fn_to_nested_idx[fn];
       if (i >= 0) {
         int schema_idx = nested_field_indices[i];
-        if (schema[schema_idx].depth == depth_level) {
+        // Defensive: verify field_number matches the lookup, mirroring the linear-scan fallback.
+        if (schema[schema_idx].field_number == fn && schema[schema_idx].depth == depth_level) {
           if (!handle_nested(i)) return;
         }
       }
@@ -573,7 +577,10 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
 
     if (fn_to_desc_idx != nullptr && fn > 0 && fn < fn_to_desc_size) {
       int f = fn_to_desc_idx[fn];
-      if (f >= 0 && f < num_scan_fields) {
+      // Defensive sanity check: a correct lookup table guarantees scan_descs[f].field_number == fn,
+      // but verifying matches the linear-scan fallback's behavior so a buggy table cannot dispatch
+      // to the wrong descriptor silently.
+      if (f >= 0 && f < num_scan_fields && scan_descs[f].field_number == fn) {
         if (!try_scan(f)) return;
       }
     } else {

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -58,9 +58,9 @@ CUDF_KERNEL void scan_all_fields_kernel(
   cudf::column_device_view const d_in,
   field_descriptor const* field_descs,  // [num_fields]
   int num_fields,
-  int const* field_lookup,              // direct-mapped lookup table (nullable)
-  int field_lookup_size,                // size of lookup table (0 if null)
-  field_location* locations,            // [num_rows * num_fields] row-major
+  int const* field_lookup,    // direct-mapped lookup table (nullable)
+  int field_lookup_size,      // size of lookup table (0 if null)
+  field_location* locations,  // [num_rows * num_fields] row-major
   int* error_flag,
   bool* row_has_invalid_data)
 {
@@ -161,6 +161,984 @@ CUDF_KERNEL void scan_all_fields_kernel(
     }
     cur = next;
   }
+}
+
+// ============================================================================
+// Shared device functions for repeated field processing
+// ============================================================================
+
+/**
+ * Count a single repeated field occurrence (packed or unpacked).
+ * Updates info.count and info.total_length.
+ * Returns false on error (error_flag set), true on success.
+ */
+__device__ bool count_repeated_element(uint8_t const* cur,
+                                       uint8_t const* msg_end,
+                                       int wt,
+                                       int expected_wt,
+                                       repeated_field_info& info,
+                                       int* error_flag)
+{
+  bool is_packed = (wt == wire_type_value(proto_wire_type::LEN) &&
+                    expected_wt != wire_type_value(proto_wire_type::LEN));
+
+  if (!is_packed && wt != expected_wt) {
+    set_error_once(error_flag, ERR_WIRE_TYPE);
+    return false;
+  }
+
+  if (is_packed) {
+    uint64_t packed_len;
+    int len_bytes;
+    if (!read_varint(cur, msg_end, packed_len, len_bytes)) {
+      set_error_once(error_flag, ERR_VARINT);
+      return false;
+    }
+    uint8_t const* packed_start = cur + len_bytes;
+    if (packed_len > static_cast<uint64_t>(msg_end - packed_start)) {
+      set_error_once(error_flag, ERR_OVERFLOW);
+      return false;
+    }
+    uint8_t const* packed_end = packed_start + packed_len;
+
+    int count = 0;
+    if (expected_wt == wire_type_value(proto_wire_type::VARINT)) {
+      uint8_t const* p = packed_start;
+      while (p < packed_end) {
+        uint64_t dummy;
+        int vbytes;
+        if (!read_varint(p, packed_end, dummy, vbytes)) {
+          set_error_once(error_flag, ERR_VARINT);
+          return false;
+        }
+        p += vbytes;
+        count++;
+      }
+    } else if (expected_wt == wire_type_value(proto_wire_type::I32BIT)) {
+      if ((packed_len % 4) != 0) {
+        set_error_once(error_flag, ERR_FIXED_LEN);
+        return false;
+      }
+      count = static_cast<int>(packed_len / 4);
+    } else if (expected_wt == wire_type_value(proto_wire_type::I64BIT)) {
+      if ((packed_len % 8) != 0) {
+        set_error_once(error_flag, ERR_FIXED_LEN);
+        return false;
+      }
+      count = static_cast<int>(packed_len / 8);
+    }
+
+    info.count += count;
+    info.total_length += static_cast<int32_t>(packed_len);
+  } else {
+    int32_t data_offset, data_length;
+    if (!get_field_data_location(cur, msg_end, wt, data_offset, data_length)) {
+      set_error_once(error_flag, ERR_FIELD_SIZE);
+      return false;
+    }
+    info.count++;
+    info.total_length += data_length;
+  }
+  return true;
+}
+
+/**
+ * Record a single repeated field occurrence (packed or unpacked).
+ * Writes to occurrences[write_idx] and advances write_idx.
+ * Offsets are computed relative to msg_base.
+ * Returns false on error (error_flag set), true on success.
+ */
+__device__ bool scan_repeated_element(uint8_t const* cur,
+                                      uint8_t const* msg_end,
+                                      uint8_t const* msg_base,
+                                      int wt,
+                                      int expected_wt,
+                                      int32_t row,
+                                      repeated_occurrence* occurrences,
+                                      int& write_idx,
+                                      int write_end,
+                                      int* error_flag)
+{
+  bool is_packed = (wt == wire_type_value(proto_wire_type::LEN) &&
+                    expected_wt != wire_type_value(proto_wire_type::LEN));
+
+  if (!is_packed && wt != expected_wt) {
+    set_error_once(error_flag, ERR_WIRE_TYPE);
+    return false;
+  }
+
+  if (is_packed) {
+    uint64_t packed_len;
+    int len_bytes;
+    if (!read_varint(cur, msg_end, packed_len, len_bytes)) {
+      set_error_once(error_flag, ERR_VARINT);
+      return false;
+    }
+    uint8_t const* packed_start = cur + len_bytes;
+    if (packed_len > static_cast<uint64_t>(msg_end - packed_start)) {
+      set_error_once(error_flag, ERR_OVERFLOW);
+      return false;
+    }
+    uint8_t const* packed_end = packed_start + packed_len;
+
+    if (expected_wt == wire_type_value(proto_wire_type::VARINT)) {
+      uint8_t const* p = packed_start;
+      while (p < packed_end) {
+        int32_t elem_offset = static_cast<int32_t>(p - msg_base);
+        uint64_t dummy;
+        int vbytes;
+        if (!read_varint(p, packed_end, dummy, vbytes)) {
+          set_error_once(error_flag, ERR_VARINT);
+          return false;
+        }
+        if (write_idx >= write_end) {
+          set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+          return false;
+        }
+        occurrences[write_idx] = {row, elem_offset, vbytes};
+        write_idx++;
+        p += vbytes;
+      }
+    } else if (expected_wt == wire_type_value(proto_wire_type::I32BIT)) {
+      if ((packed_len % 4) != 0) {
+        set_error_once(error_flag, ERR_FIXED_LEN);
+        return false;
+      }
+      for (uint64_t i = 0; i < packed_len; i += 4) {
+        if (write_idx >= write_end) {
+          set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+          return false;
+        }
+        occurrences[write_idx] = {row, static_cast<int32_t>(packed_start - msg_base + i), 4};
+        write_idx++;
+      }
+    } else if (expected_wt == wire_type_value(proto_wire_type::I64BIT)) {
+      if ((packed_len % 8) != 0) {
+        set_error_once(error_flag, ERR_FIXED_LEN);
+        return false;
+      }
+      for (uint64_t i = 0; i < packed_len; i += 8) {
+        if (write_idx >= write_end) {
+          set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+          return false;
+        }
+        occurrences[write_idx] = {row, static_cast<int32_t>(packed_start - msg_base + i), 8};
+        write_idx++;
+      }
+    }
+  } else {
+    int32_t data_offset, data_length;
+    if (!get_field_data_location(cur, msg_end, wt, data_offset, data_length)) {
+      set_error_once(error_flag, ERR_FIELD_SIZE);
+      return false;
+    }
+    if (write_idx >= write_end) {
+      set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+      return false;
+    }
+    int32_t abs_offset     = static_cast<int32_t>(cur - msg_base) + data_offset;
+    occurrences[write_idx] = {row, abs_offset, data_length};
+    write_idx++;
+  }
+  return true;
+}
+
+// ============================================================================
+// Pass 1b: Count repeated fields kernel
+// ============================================================================
+
+/**
+ * Count occurrences of repeated fields in each row.
+ * Also records locations of nested message fields for hierarchical processing.
+ *
+ * Optional lookup tables (fn_to_rep_idx, fn_to_nested_idx) provide O(1) field_number
+ * to local index mapping. When nullptr, falls back to linear search.
+ */
+CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_in,
+                                              device_nested_field_descriptor const* schema,
+                                              int num_fields,
+                                              int depth_level,
+                                              repeated_field_info* repeated_info,
+                                              int num_repeated_fields,
+                                              int const* repeated_field_indices,
+                                              field_location* nested_locations,
+                                              int num_nested_fields,
+                                              int const* nested_field_indices,
+                                              int* error_flag,
+                                              int const* fn_to_rep_idx,
+                                              int fn_to_rep_size,
+                                              int const* fn_to_nested_idx,
+                                              int fn_to_nested_size)
+{
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  cudf::detail::lists_column_device_view in{d_in};
+  if (row >= in.size()) return;
+
+  // Initialize repeated counts to 0
+  for (int f = 0; f < num_repeated_fields; f++) {
+    repeated_info[flat_index(
+      static_cast<size_t>(row), static_cast<size_t>(num_repeated_fields), static_cast<size_t>(f))] =
+      {0, 0};
+  }
+
+  // Initialize nested locations to not found
+  for (int f = 0; f < num_nested_fields; f++) {
+    nested_locations[flat_index(
+      static_cast<size_t>(row), static_cast<size_t>(num_nested_fields), static_cast<size_t>(f))] = {
+      -1, 0};
+  }
+
+  if (in.nullable() && in.is_null(row)) return;
+
+  auto const base   = in.offset_at(0);
+  auto const child  = in.get_sliced_child();
+  auto const* bytes = reinterpret_cast<uint8_t const*>(child.data<int8_t>());
+  int32_t start     = in.offset_at(row) - base;
+  int32_t end       = in.offset_at(row + 1) - base;
+  if (!check_message_bounds(start, end, child.size(), error_flag)) return;
+
+  uint8_t const* cur     = bytes + start;
+  uint8_t const* msg_end = bytes + end;
+
+  while (cur < msg_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, msg_end, tag, error_flag)) return;
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    if (fn_to_rep_idx != nullptr && fn > 0 && fn < fn_to_rep_size) {
+      int i = fn_to_rep_idx[fn];
+      if (i >= 0) {
+        int schema_idx = repeated_field_indices[i];
+        if (schema[schema_idx].depth == depth_level &&
+            !count_repeated_element(
+              cur,
+              msg_end,
+              wt,
+              schema[schema_idx].wire_type,
+              repeated_info[flat_index(static_cast<size_t>(row),
+                                       static_cast<size_t>(num_repeated_fields),
+                                       static_cast<size_t>(i))],
+              error_flag)) {
+          return;
+        }
+      }
+    } else {
+      for (int i = 0; i < num_repeated_fields; i++) {
+        int schema_idx = repeated_field_indices[i];
+        if (schema[schema_idx].field_number == fn && schema[schema_idx].depth == depth_level) {
+          if (!count_repeated_element(
+                cur,
+                msg_end,
+                wt,
+                schema[schema_idx].wire_type,
+                repeated_info[flat_index(static_cast<size_t>(row),
+                                         static_cast<size_t>(num_repeated_fields),
+                                         static_cast<size_t>(i))],
+                error_flag)) {
+            return;
+          }
+        }
+      }
+    }
+
+    // Check nested message fields at this depth
+    auto handle_nested = [&](int i) {
+      if (wt != wire_type_value(proto_wire_type::LEN)) {
+        set_error_once(error_flag, ERR_WIRE_TYPE);
+        return false;
+      }
+      uint64_t len;
+      int len_bytes;
+      if (!read_varint(cur, msg_end, len, len_bytes)) {
+        set_error_once(error_flag, ERR_VARINT);
+        return false;
+      }
+      if (len > static_cast<uint64_t>(msg_end - cur - len_bytes) ||
+          len > static_cast<uint64_t>(cuda::std::numeric_limits<int>::max())) {
+        set_error_once(error_flag, ERR_OVERFLOW);
+        return false;
+      }
+      auto const rel_offset64 = static_cast<int64_t>(cur - bytes - start);
+      if (rel_offset64 < cuda::std::numeric_limits<int32_t>::min() ||
+          rel_offset64 > cuda::std::numeric_limits<int32_t>::max()) {
+        set_error_once(error_flag, ERR_OVERFLOW);
+        return false;
+      }
+      int32_t msg_offset;
+      if (!checked_add_int32(static_cast<int32_t>(rel_offset64), len_bytes, msg_offset)) {
+        set_error_once(error_flag, ERR_OVERFLOW);
+        return false;
+      }
+      nested_locations[flat_index(
+        static_cast<size_t>(row), static_cast<size_t>(num_nested_fields), static_cast<size_t>(i))] =
+        {msg_offset, static_cast<int32_t>(len)};
+      return true;
+    };
+
+    if (fn_to_nested_idx != nullptr && fn > 0 && fn < fn_to_nested_size) {
+      int i = fn_to_nested_idx[fn];
+      if (i >= 0) {
+        int schema_idx = nested_field_indices[i];
+        if (schema[schema_idx].depth == depth_level) {
+          if (!handle_nested(i)) return;
+        }
+      }
+    } else {
+      for (int i = 0; i < num_nested_fields; i++) {
+        int schema_idx = nested_field_indices[i];
+        if (schema[schema_idx].field_number == fn && schema[schema_idx].depth == depth_level) {
+          if (!handle_nested(i)) return;
+        }
+      }
+    }
+
+    // Skip to next field
+    uint8_t const* next;
+    if (!skip_field(cur, msg_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      return;
+    }
+    cur = next;
+  }
+}
+
+/**
+ * Combined occurrence scan: scans each message ONCE and writes occurrences for ALL
+ * repeated fields simultaneously, scanning each message only once.
+ */
+CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view const d_in,
+                                                      repeated_field_scan_desc const* scan_descs,
+                                                      int num_scan_fields,
+                                                      int* error_flag,
+                                                      int const* fn_to_desc_idx,
+                                                      int fn_to_desc_size)
+{
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  cudf::detail::lists_column_device_view in{d_in};
+  if (row >= in.size()) return;
+
+  if (in.nullable() && in.is_null(row)) return;
+
+  auto const base   = in.offset_at(0);
+  auto const child  = in.get_sliced_child();
+  auto const* bytes = reinterpret_cast<uint8_t const*>(child.data<int8_t>());
+  int32_t start     = in.offset_at(row) - base;
+  int32_t end       = in.offset_at(row + 1) - base;
+  if (!check_message_bounds(start, end, child.size(), error_flag)) return;
+
+  uint8_t const* cur     = bytes + start;
+  uint8_t const* msg_end = bytes + end;
+
+  constexpr int MAX_STACK_FIELDS = 128;
+  if (num_scan_fields > MAX_STACK_FIELDS) {
+    set_error_once(error_flag, ERR_SCHEMA_TOO_LARGE);
+    return;
+  }
+  int write_idx[MAX_STACK_FIELDS];
+  for (int f = 0; f < num_scan_fields; f++) {
+    write_idx[f] = scan_descs[f].row_offsets[row];
+  }
+
+  while (cur < msg_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, msg_end, tag, error_flag)) return;
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    auto try_scan = [&](int f) -> bool {
+      int target_wt  = scan_descs[f].wire_type;
+      bool is_packed = (wt == wire_type_value(proto_wire_type::LEN) &&
+                        target_wt != wire_type_value(proto_wire_type::LEN));
+      if (is_packed || wt == target_wt) {
+        return scan_repeated_element(cur,
+                                     msg_end,
+                                     bytes + start,
+                                     wt,
+                                     target_wt,
+                                     static_cast<int32_t>(row),
+                                     scan_descs[f].occurrences,
+                                     write_idx[f],
+                                     scan_descs[f].row_offsets[row + 1],
+                                     error_flag);
+      }
+      set_error_once(error_flag, ERR_WIRE_TYPE);
+      return false;
+    };
+
+    if (fn_to_desc_idx != nullptr && fn > 0 && fn < fn_to_desc_size) {
+      int f = fn_to_desc_idx[fn];
+      if (f >= 0 && f < num_scan_fields) {
+        if (!try_scan(f)) return;
+      }
+    } else {
+      for (int f = 0; f < num_scan_fields; f++) {
+        if (scan_descs[f].field_number == fn) {
+          if (!try_scan(f)) return;
+        }
+      }
+    }
+
+    uint8_t const* next;
+    if (!skip_field(cur, msg_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      return;
+    }
+    cur = next;
+  }
+
+  for (int f = 0; f < num_scan_fields; f++) {
+    if (write_idx[f] != scan_descs[f].row_offsets[row + 1]) {
+      set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+      return;
+    }
+  }
+}
+
+// ============================================================================
+// Nested message scanning kernels
+// ============================================================================
+
+/**
+ * Scan nested message fields.
+ * Each row represents a nested message at a specific parent location.
+ * This kernel finds fields within the nested message bytes.
+ *
+ * Note: this path intentionally keeps a linear child-field scan. Unlike repeated-message child
+ * scanning, previous benchmarking did not show a stable win from adding a host-built lookup table
+ * here, so we keep the simpler implementation unless that trade-off changes.
+ */
+CUDF_KERNEL void scan_nested_message_fields_kernel(uint8_t const* message_data,
+                                                   cudf::size_type message_data_size,
+                                                   cudf::size_type const* parent_row_offsets,
+                                                   cudf::size_type parent_base_offset,
+                                                   field_location const* parent_locations,
+                                                   int num_parent_rows,
+                                                   field_descriptor const* field_descs,
+                                                   int num_fields,
+                                                   field_location* output_locations,
+                                                   int* error_flag)
+{
+  auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_parent_rows) return;
+
+  for (int f = 0; f < num_fields; f++) {
+    output_locations[flat_index(
+      static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(f))] = {-1, 0};
+  }
+
+  auto const& parent_loc = parent_locations[row];
+  if (parent_loc.offset < 0) return;
+
+  auto parent_row_start    = parent_row_offsets[row] - parent_base_offset;
+  int64_t nested_start_off = static_cast<int64_t>(parent_row_start) + parent_loc.offset;
+  int64_t nested_end_off   = nested_start_off + parent_loc.length;
+  if (nested_start_off < 0 || nested_end_off > message_data_size) {
+    set_error_once(error_flag, ERR_BOUNDS);
+    return;
+  }
+  uint8_t const* nested_start = message_data + nested_start_off;
+  uint8_t const* nested_end   = nested_start + parent_loc.length;
+
+  uint8_t const* cur = nested_start;
+
+  while (cur < nested_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, nested_end, tag, error_flag)) return;
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    for (int f = 0; f < num_fields; f++) {
+      if (field_descs[f].field_number == fn) {
+        if (field_descs[f].is_repeated) {
+          // Repeated children are handled by the dedicated count/scan path, not by
+          // the direct-child location scan used for scalar/nested singleton fields.
+          break;
+        }
+        if (wt != field_descs[f].expected_wire_type) {
+          set_error_once(error_flag, ERR_WIRE_TYPE);
+          return;
+        }
+
+        int data_offset = static_cast<int>(cur - nested_start);
+
+        if (wt == wire_type_value(proto_wire_type::LEN)) {
+          uint64_t len;
+          int len_bytes;
+          if (!read_varint(cur, nested_end, len, len_bytes)) {
+            set_error_once(error_flag, ERR_VARINT);
+            return;
+          }
+          if (len > static_cast<uint64_t>(nested_end - cur - len_bytes) ||
+              len > static_cast<uint64_t>(cuda::std::numeric_limits<int>::max())) {
+            set_error_once(error_flag, ERR_OVERFLOW);
+            return;
+          }
+          int32_t data_location;
+          if (!checked_add_int32(data_offset, len_bytes, data_location)) {
+            set_error_once(error_flag, ERR_OVERFLOW);
+            return;
+          }
+          output_locations[flat_index(
+            static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(f))] = {
+            data_location, static_cast<int32_t>(len)};
+        } else {
+          int field_size = get_wire_type_size(wt, cur, nested_end);
+          if (field_size < 0) {
+            set_error_once(error_flag, ERR_FIELD_SIZE);
+            return;
+          }
+          output_locations[flat_index(
+            static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(f))] = {
+            data_offset, field_size};
+        }
+        break;
+      }
+    }
+
+    uint8_t const* next;
+    if (!skip_field(cur, nested_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      return;
+    }
+    cur = next;
+  }
+}
+
+/**
+ * Scan for child fields within repeated message occurrences.
+ * Each occurrence is a protobuf message, and we need to find child field locations within it.
+ */
+CUDF_KERNEL void scan_repeated_message_children_kernel(
+  uint8_t const* message_data,
+  cudf::size_type message_data_size,
+  cudf::size_type const* msg_row_offsets,  // Row offset for each occurrence
+  field_location const*
+    msg_locs,  // Location of each message occurrence (offset within row, length)
+  int num_occurrences,
+  field_descriptor const* child_descs,
+  int num_child_fields,
+  field_location* child_locs,  // Output: [num_occurrences * num_child_fields]
+  int* error_flag,
+  int const* child_lookup,
+  int child_lookup_size)
+{
+  auto occ_idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (occ_idx >= num_occurrences) return;
+
+  // Initialize child locations to not found
+  for (int f = 0; f < num_child_fields; f++) {
+    child_locs[flat_index(static_cast<size_t>(occ_idx),
+                          static_cast<size_t>(num_child_fields),
+                          static_cast<size_t>(f))] = {-1, 0};
+  }
+
+  auto const& msg_loc = msg_locs[occ_idx];
+  if (msg_loc.offset < 0) return;
+
+  cudf::size_type row_offset = msg_row_offsets[occ_idx];
+  int64_t msg_start_off      = static_cast<int64_t>(row_offset) + msg_loc.offset;
+  int64_t msg_end_off        = msg_start_off + msg_loc.length;
+  if (msg_start_off < 0 || msg_end_off > message_data_size) {
+    set_error_once(error_flag, ERR_BOUNDS);
+    return;
+  }
+  uint8_t const* msg_start = message_data + msg_start_off;
+  uint8_t const* msg_end   = msg_start + msg_loc.length;
+
+  uint8_t const* cur = msg_start;
+
+  while (cur < msg_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, msg_end, tag, error_flag)) return;
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    int f = lookup_field(fn, child_lookup, child_lookup_size, child_descs, num_child_fields);
+    if (f >= 0) {
+      if (child_descs[f].is_repeated) {
+        // Repeated children are decoded by build_repeated_child_list_column via the
+        // nested repeated count/scan kernels, so do not record a singleton location here.
+      } else if (wt != child_descs[f].expected_wire_type) {
+        set_error_once(error_flag, ERR_WIRE_TYPE);
+        return;
+      } else {
+        int data_offset = static_cast<int>(cur - msg_start);
+
+        if (wt == wire_type_value(proto_wire_type::LEN)) {
+          uint64_t len;
+          int len_bytes;
+          if (!read_varint(cur, msg_end, len, len_bytes)) {
+            set_error_once(error_flag, ERR_VARINT);
+            return;
+          }
+          if (len > static_cast<uint64_t>(msg_end - cur - len_bytes) ||
+              len > static_cast<uint64_t>(cuda::std::numeric_limits<int>::max())) {
+            set_error_once(error_flag, ERR_OVERFLOW);
+            return;
+          }
+          int32_t data_location;
+          if (!checked_add_int32(data_offset, len_bytes, data_location)) {
+            set_error_once(error_flag, ERR_OVERFLOW);
+            return;
+          }
+          child_locs[flat_index(static_cast<size_t>(occ_idx),
+                                static_cast<size_t>(num_child_fields),
+                                static_cast<size_t>(f))] = {data_location,
+                                                            static_cast<int32_t>(len)};
+        } else {
+          // For varint/fixed types, store offset and estimated length
+          int32_t data_length = 0;
+          if (wt == wire_type_value(proto_wire_type::VARINT)) {
+            uint64_t dummy;
+            int vbytes;
+            if (!read_varint(cur, msg_end, dummy, vbytes)) {
+              set_error_once(error_flag, ERR_VARINT);
+              return;
+            }
+            data_length = vbytes;
+          } else if (wt == wire_type_value(proto_wire_type::I32BIT)) {
+            if (msg_end - cur < 4) {
+              set_error_once(error_flag, ERR_FIXED_LEN);
+              return;
+            }
+            data_length = 4;
+          } else if (wt == wire_type_value(proto_wire_type::I64BIT)) {
+            if (msg_end - cur < 8) {
+              set_error_once(error_flag, ERR_FIXED_LEN);
+              return;
+            }
+            data_length = 8;
+          }
+          child_locs[flat_index(static_cast<size_t>(occ_idx),
+                                static_cast<size_t>(num_child_fields),
+                                static_cast<size_t>(f))] = {data_offset, data_length};
+        }
+      }
+    }
+
+    // Skip to next field
+    uint8_t const* next;
+    if (!skip_field(cur, msg_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      return;
+    }
+    cur = next;
+  }
+}
+
+/**
+ * Count repeated field occurrences within nested messages.
+ * Similar to count_repeated_fields_kernel but operates on nested message locations.
+ *
+ * Note: unlike the top-level count_repeated_fields_kernel, this kernel does not perform
+ * a depth-level check because it operates within a specific parent message context where
+ * the depth is implicitly fixed. Callers must pre-filter repeated_indices to include only
+ * fields at the expected child depth.
+ */
+CUDF_KERNEL void count_repeated_in_nested_kernel(uint8_t const* message_data,
+                                                 cudf::size_type message_data_size,
+                                                 cudf::size_type const* row_offsets,
+                                                 cudf::size_type base_offset,
+                                                 field_location const* parent_locs,
+                                                 int num_rows,
+                                                 device_nested_field_descriptor const* schema,
+                                                 int num_fields,
+                                                 repeated_field_info* repeated_info,
+                                                 int num_repeated,
+                                                 int const* repeated_indices,
+                                                 int* error_flag)
+{
+  auto row = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_rows) return;
+
+  // Initialize counts
+  for (int ri = 0; ri < num_repeated; ri++) {
+    repeated_info[flat_index(
+      static_cast<size_t>(row), static_cast<size_t>(num_repeated), static_cast<size_t>(ri))] = {0,
+                                                                                                0};
+  }
+
+  auto const& parent_loc = parent_locs[row];
+  if (parent_loc.offset < 0) return;
+
+  cudf::size_type row_off;
+  row_off = row_offsets[row] - base_offset;
+
+  int64_t msg_start_off = static_cast<int64_t>(row_off) + parent_loc.offset;
+  int64_t msg_end_off   = msg_start_off + parent_loc.length;
+  if (msg_start_off < 0 || msg_end_off > message_data_size) {
+    set_error_once(error_flag, ERR_BOUNDS);
+    return;
+  }
+
+  uint8_t const* msg_start = message_data + msg_start_off;
+  uint8_t const* msg_end   = msg_start + parent_loc.length;
+  uint8_t const* cur       = msg_start;
+
+  while (cur < msg_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, msg_end, tag, error_flag)) return;
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    // After decode_tag, `cur` points past the tag bytes (at the field data).
+    // Both count_repeated_element and skip_field expect this post-tag position.
+    for (int ri = 0; ri < num_repeated; ri++) {
+      int schema_idx = repeated_indices[ri];
+      if (schema[schema_idx].field_number == fn && schema[schema_idx].is_repeated) {
+        if (!count_repeated_element(cur,
+                                    msg_end,
+                                    wt,
+                                    schema[schema_idx].wire_type,
+                                    repeated_info[flat_index(static_cast<size_t>(row),
+                                                             static_cast<size_t>(num_repeated),
+                                                             static_cast<size_t>(ri))],
+                                    error_flag)) {
+          return;
+        }
+      }
+    }
+
+    uint8_t const* next;
+    if (!skip_field(cur, msg_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      return;
+    }
+    cur = next;
+  }
+}
+
+/**
+ * Scan for repeated field occurrences of a single repeated field within nested
+ * messages. Must be launched once per repeated field — the caller passes
+ * exactly one schema index via repeated_indices[0].
+ *
+ * Note: no depth-level check is performed; see count_repeated_in_nested_kernel comment.
+ */
+CUDF_KERNEL void scan_repeated_in_nested_kernel(uint8_t const* message_data,
+                                                cudf::size_type message_data_size,
+                                                cudf::size_type const* row_offsets,
+                                                cudf::size_type base_offset,
+                                                field_location const* parent_locs,
+                                                int num_rows,
+                                                device_nested_field_descriptor const* schema,
+                                                int32_t const* occ_prefix_sums,
+                                                int const* repeated_indices,
+                                                repeated_occurrence* occurrences,
+                                                int* error_flag)
+{
+  auto row = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (row >= num_rows) return;
+
+  int write_idx          = occ_prefix_sums[row];
+  int write_end          = occ_prefix_sums[row + 1];
+  auto const& parent_loc = parent_locs[row];
+  if (parent_loc.offset < 0) {
+    if (write_idx != write_end) set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+    return;
+  }
+
+  cudf::size_type row_off = row_offsets[row] - base_offset;
+
+  int64_t msg_start_off = static_cast<int64_t>(row_off) + parent_loc.offset;
+  int64_t msg_end_off   = msg_start_off + parent_loc.length;
+  if (msg_start_off < 0 || msg_end_off > message_data_size) {
+    set_error_once(error_flag, ERR_BOUNDS);
+    return;
+  }
+
+  uint8_t const* msg_start = message_data + msg_start_off;
+  uint8_t const* msg_end   = msg_start + parent_loc.length;
+  uint8_t const* cur       = msg_start;
+
+  int schema_idx = repeated_indices[0];
+
+  while (cur < msg_end) {
+    proto_tag tag;
+    if (!decode_tag(cur, msg_end, tag, error_flag)) return;
+    int fn = tag.field_number;
+    int wt = tag.wire_type;
+
+    if (schema[schema_idx].field_number == fn && schema[schema_idx].is_repeated) {
+      if (!scan_repeated_element(cur,
+                                 msg_end,
+                                 msg_start,
+                                 wt,
+                                 schema[schema_idx].wire_type,
+                                 static_cast<int32_t>(row),
+                                 occurrences,
+                                 write_idx,
+                                 write_end,
+                                 error_flag)) {
+        return;
+      }
+    }
+
+    uint8_t const* next;
+    if (!skip_field(cur, msg_end, wt, next)) {
+      set_error_once(error_flag, ERR_SKIP);
+      return;
+    }
+    cur = next;
+  }
+
+  if (write_idx != write_end) set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+}
+
+/**
+ * Kernel to compute nested struct locations from child field locations.
+ * Replaces host-side loop that was copying data D->H, processing, then H->D.
+ * This is a critical performance optimization.
+ */
+CUDF_KERNEL void compute_nested_struct_locations_kernel(
+  field_location const* child_locs,        // Child field locations from parent scan
+  field_location const* msg_locs,          // Parent message locations
+  cudf::size_type const* msg_row_offsets,  // Parent message row offsets
+  int child_idx,                           // Which child field is the nested struct
+  int num_child_fields,                    // Total number of child fields per occurrence
+  field_location* nested_locs,             // Output: nested struct locations
+  cudf::size_type* nested_row_offsets,     // Output: nested struct row offsets
+  int total_count,
+  int* error_flag)
+{
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_count) return;
+
+  nested_locs[idx] = child_locs[flat_index(static_cast<size_t>(idx),
+                                           static_cast<size_t>(num_child_fields),
+                                           static_cast<size_t>(child_idx))];
+  auto sum         = static_cast<int64_t>(msg_row_offsets[idx]) + msg_locs[idx].offset;
+  if (sum < cuda::std::numeric_limits<cudf::size_type>::min() ||
+      sum > cuda::std::numeric_limits<cudf::size_type>::max()) {
+    nested_locs[idx]        = {-1, 0};
+    nested_row_offsets[idx] = 0;
+    set_error_once(error_flag, ERR_OVERFLOW);
+    return;
+  }
+  nested_row_offsets[idx] = static_cast<cudf::size_type>(sum);
+}
+
+/**
+ * Kernel to compute absolute grandchild parent locations from parent and child locations.
+ * Computes: gc_parent_abs[i] = parent[i].offset + child[i * ncf + ci].offset
+ * This replaces host-side loop with D->H->D copy pattern.
+ */
+CUDF_KERNEL void compute_grandchild_parent_locations_kernel(
+  field_location const* parent_locs,  // Parent locations (row count)
+  field_location const* child_locs,   // Child locations (row * num_child_fields)
+  int child_idx,                      // Which child field
+  int num_child_fields,               // Total child fields per row
+  field_location* gc_parent_abs,      // Output: absolute grandchild parent locations
+  int num_rows,
+  int* error_flag)
+{
+  int row = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row >= num_rows) return;
+
+  auto const& parent_loc = parent_locs[row];
+  auto const& child_loc  = child_locs[flat_index(static_cast<size_t>(row),
+                                                static_cast<size_t>(num_child_fields),
+                                                static_cast<size_t>(child_idx))];
+
+  if (parent_loc.offset >= 0 && child_loc.offset >= 0) {
+    // Absolute offset = parent offset + child's relative offset
+    auto sum = static_cast<int64_t>(parent_loc.offset) + child_loc.offset;
+    if (sum < cuda::std::numeric_limits<int32_t>::min() ||
+        sum > cuda::std::numeric_limits<int32_t>::max()) {
+      gc_parent_abs[row] = {-1, 0};
+      set_error_once(error_flag, ERR_OVERFLOW);
+      return;
+    }
+    gc_parent_abs[row].offset = static_cast<int32_t>(sum);
+    gc_parent_abs[row].length = child_loc.length;
+  } else {
+    gc_parent_abs[row] = {-1, 0};
+  }
+}
+
+/**
+ * Compute virtual parent row offsets and locations for repeated message occurrences
+ * inside nested messages. Each occurrence becomes a virtual "row" so that
+ * build_nested_struct_column can recursively process the children.
+ */
+CUDF_KERNEL void compute_virtual_parents_for_nested_repeated_kernel(
+  repeated_occurrence const* occurrences,
+  cudf::size_type const* row_list_offsets,  // original binary input list offsets
+  field_location const* parent_locations,   // parent nested message locations
+  cudf::size_type* virtual_row_offsets,     // output: [total_count]
+  field_location* virtual_parent_locs,      // output: [total_count]
+  int total_count,
+  int* error_flag)
+{
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_count) return;
+
+  auto const& occ  = occurrences[idx];
+  auto const& ploc = parent_locations[occ.row_idx];
+
+  virtual_row_offsets[idx] = row_list_offsets[occ.row_idx];
+
+  // Keep zero-length embedded messages as "present but empty".
+  // Protobuf allows an embedded message with length=0, which maps to a non-null
+  // struct with all-null children (not a null struct).
+  if (ploc.offset >= 0) {
+    auto sum = static_cast<int64_t>(ploc.offset) + occ.offset;
+    if (sum < cuda::std::numeric_limits<int32_t>::min() ||
+        sum > cuda::std::numeric_limits<int32_t>::max()) {
+      virtual_parent_locs[idx] = {-1, 0};
+      set_error_once(error_flag, ERR_OVERFLOW);
+      return;
+    }
+    virtual_parent_locs[idx] = {static_cast<int32_t>(sum), occ.length};
+  } else {
+    virtual_parent_locs[idx] = {-1, 0};
+  }
+}
+
+/**
+ * Kernel to compute message locations and row offsets from repeated occurrences.
+ * Replaces host-side loop that processed occurrences.
+ */
+CUDF_KERNEL void compute_msg_locations_from_occurrences_kernel(
+  repeated_occurrence const* occurrences,  // Repeated field occurrences
+  cudf::size_type const* list_offsets,     // List offsets for rows
+  cudf::size_type base_offset,             // Base offset to subtract
+  field_location* msg_locs,                // Output: message locations
+  cudf::size_type* msg_row_offsets,        // Output: message row offsets
+  int total_count,
+  int* error_flag)
+{
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total_count) return;
+
+  auto const& occ = occurrences[idx];
+  auto row_offset = static_cast<int64_t>(list_offsets[occ.row_idx]) - base_offset;
+  if (row_offset < cuda::std::numeric_limits<cudf::size_type>::min() ||
+      row_offset > cuda::std::numeric_limits<cudf::size_type>::max()) {
+    msg_row_offsets[idx] = 0;
+    msg_locs[idx]        = {-1, 0};
+    set_error_once(error_flag, ERR_OVERFLOW);
+    return;
+  }
+  msg_row_offsets[idx] = static_cast<cudf::size_type>(row_offset);
+  msg_locs[idx]        = {occ.offset, occ.length};
+}
+
+/**
+ * Extract a single field's locations from a 2D strided array on the GPU.
+ * Replaces a D2H + CPU loop + H2D pattern for nested message location extraction.
+ */
+CUDF_KERNEL void extract_strided_locations_kernel(field_location const* nested_locations,
+                                                  int field_idx,
+                                                  int num_fields,
+                                                  field_location* parent_locs,
+                                                  int num_rows)
+{
+  int row = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row >= num_rows) return;
+  parent_locs[row] = nested_locations[flat_index(
+    static_cast<size_t>(row), static_cast<size_t>(num_fields), static_cast<size_t>(field_idx))];
 }
 
 // ============================================================================
@@ -272,7 +1250,7 @@ CUDF_KERNEL void compute_enum_string_lengths_kernel(
   int32_t const* valid_enum_values,  // sorted enum numeric values
   int32_t const* enum_name_offsets,  // [num_valid_values + 1]
   int num_valid_values,
-  int32_t* lengths,                  // [num_rows]
+  int32_t* lengths,  // [num_rows]
   int num_rows)
 {
   auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -313,8 +1291,8 @@ CUDF_KERNEL void copy_enum_string_chars_kernel(
   int32_t const* enum_name_offsets,  // [num_valid_values + 1]
   uint8_t const* enum_name_chars,    // concatenated enum UTF-8 names
   int num_valid_values,
-  int32_t const* output_offsets,     // [num_rows + 1]
-  char* out_chars,                   // [total_chars]
+  int32_t const* output_offsets,  // [num_rows + 1]
+  char* out_chars,                // [total_chars]
   int num_rows)
 {
   auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -376,6 +1354,268 @@ void launch_scan_all_fields(cudf::column_device_view const& d_in,
                                                                            locations,
                                                                            error_flag,
                                                                            row_has_invalid_data);
+}
+
+void launch_count_repeated_fields(cudf::column_device_view const& d_in,
+                                  device_nested_field_descriptor const* schema,
+                                  int num_fields,
+                                  int depth_level,
+                                  repeated_field_info* repeated_info,
+                                  int num_repeated_fields,
+                                  int const* repeated_field_indices,
+                                  field_location* nested_locations,
+                                  int num_nested_fields,
+                                  int const* nested_field_indices,
+                                  int* error_flag,
+                                  int const* fn_to_rep_idx,
+                                  int fn_to_rep_size,
+                                  int const* fn_to_nested_idx,
+                                  int fn_to_nested_size,
+                                  int num_rows,
+                                  rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  count_repeated_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    d_in,
+    schema,
+    num_fields,
+    depth_level,
+    repeated_info,
+    num_repeated_fields,
+    repeated_field_indices,
+    nested_locations,
+    num_nested_fields,
+    nested_field_indices,
+    error_flag,
+    fn_to_rep_idx,
+    fn_to_rep_size,
+    fn_to_nested_idx,
+    fn_to_nested_size);
+}
+
+void launch_scan_all_repeated_occurrences(cudf::column_device_view const& d_in,
+                                          repeated_field_scan_desc const* scan_descs,
+                                          int num_scan_fields,
+                                          int* error_flag,
+                                          int const* fn_to_desc_idx,
+                                          int fn_to_desc_size,
+                                          int num_rows,
+                                          rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  scan_all_repeated_occurrences_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    d_in, scan_descs, num_scan_fields, error_flag, fn_to_desc_idx, fn_to_desc_size);
+}
+
+void launch_extract_strided_locations(field_location const* nested_locations,
+                                      int field_idx,
+                                      int num_fields,
+                                      field_location* parent_locs,
+                                      int num_rows,
+                                      rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  extract_strided_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    nested_locations, field_idx, num_fields, parent_locs, num_rows);
+}
+
+void launch_scan_nested_message_fields(uint8_t const* message_data,
+                                       cudf::size_type message_data_size,
+                                       cudf::size_type const* parent_row_offsets,
+                                       cudf::size_type parent_base_offset,
+                                       field_location const* parent_locations,
+                                       int num_parent_rows,
+                                       field_descriptor const* field_descs,
+                                       int num_fields,
+                                       field_location* output_locations,
+                                       int* error_flag,
+                                       rmm::cuda_stream_view stream)
+{
+  if (num_parent_rows == 0) return;
+  auto const blocks =
+    static_cast<int>((num_parent_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  scan_nested_message_fields_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    message_data,
+    message_data_size,
+    parent_row_offsets,
+    parent_base_offset,
+    parent_locations,
+    num_parent_rows,
+    field_descs,
+    num_fields,
+    output_locations,
+    error_flag);
+}
+
+void launch_scan_repeated_message_children(uint8_t const* message_data,
+                                           cudf::size_type message_data_size,
+                                           cudf::size_type const* msg_row_offsets,
+                                           field_location const* msg_locs,
+                                           int num_occurrences,
+                                           field_descriptor const* child_descs,
+                                           int num_child_fields,
+                                           field_location* child_locs,
+                                           int* error_flag,
+                                           int const* child_lookup,
+                                           int child_lookup_size,
+                                           rmm::cuda_stream_view stream)
+{
+  if (num_occurrences == 0) return;
+  auto const blocks =
+    static_cast<int>((num_occurrences + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  scan_repeated_message_children_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    message_data,
+    message_data_size,
+    msg_row_offsets,
+    msg_locs,
+    num_occurrences,
+    child_descs,
+    num_child_fields,
+    child_locs,
+    error_flag,
+    child_lookup,
+    child_lookup_size);
+}
+
+void launch_count_repeated_in_nested(uint8_t const* message_data,
+                                     cudf::size_type message_data_size,
+                                     cudf::size_type const* row_offsets,
+                                     cudf::size_type base_offset,
+                                     field_location const* parent_locs,
+                                     int num_rows,
+                                     device_nested_field_descriptor const* schema,
+                                     int num_fields,
+                                     repeated_field_info* repeated_info,
+                                     int num_repeated,
+                                     int const* repeated_indices,
+                                     int* error_flag,
+                                     rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  count_repeated_in_nested_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    message_data,
+    message_data_size,
+    row_offsets,
+    base_offset,
+    parent_locs,
+    num_rows,
+    schema,
+    num_fields,
+    repeated_info,
+    num_repeated,
+    repeated_indices,
+    error_flag);
+}
+
+void launch_scan_repeated_in_nested(uint8_t const* message_data,
+                                    cudf::size_type message_data_size,
+                                    cudf::size_type const* row_offsets,
+                                    cudf::size_type base_offset,
+                                    field_location const* parent_locs,
+                                    int num_rows,
+                                    device_nested_field_descriptor const* schema,
+                                    int32_t const* occ_prefix_sums,
+                                    int const* repeated_indices,
+                                    repeated_occurrence* occurrences,
+                                    int* error_flag,
+                                    rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  scan_repeated_in_nested_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    message_data,
+    message_data_size,
+    row_offsets,
+    base_offset,
+    parent_locs,
+    num_rows,
+    schema,
+    occ_prefix_sums,
+    repeated_indices,
+    occurrences,
+    error_flag);
+}
+
+void launch_compute_nested_struct_locations(field_location const* child_locs,
+                                            field_location const* msg_locs,
+                                            cudf::size_type const* msg_row_offsets,
+                                            int child_idx,
+                                            int num_child_fields,
+                                            field_location* nested_locs,
+                                            cudf::size_type* nested_row_offsets,
+                                            int total_count,
+                                            int* error_flag,
+                                            rmm::cuda_stream_view stream)
+{
+  if (total_count == 0) return;
+  auto const blocks = static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  compute_nested_struct_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    child_locs,
+    msg_locs,
+    msg_row_offsets,
+    child_idx,
+    num_child_fields,
+    nested_locs,
+    nested_row_offsets,
+    total_count,
+    error_flag);
+}
+
+void launch_compute_grandchild_parent_locations(field_location const* parent_locs,
+                                                field_location const* child_locs,
+                                                int child_idx,
+                                                int num_child_fields,
+                                                field_location* gc_parent_abs,
+                                                int num_rows,
+                                                int* error_flag,
+                                                rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  compute_grandchild_parent_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    parent_locs, child_locs, child_idx, num_child_fields, gc_parent_abs, num_rows, error_flag);
+}
+
+void launch_compute_virtual_parents_for_nested_repeated(repeated_occurrence const* occurrences,
+                                                        cudf::size_type const* row_list_offsets,
+                                                        field_location const* parent_locations,
+                                                        cudf::size_type* virtual_row_offsets,
+                                                        field_location* virtual_parent_locs,
+                                                        int total_count,
+                                                        int* error_flag,
+                                                        rmm::cuda_stream_view stream)
+{
+  if (total_count == 0) return;
+  auto const blocks = static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  compute_virtual_parents_for_nested_repeated_kernel<<<blocks,
+                                                       THREADS_PER_BLOCK,
+                                                       0,
+                                                       stream.value()>>>(occurrences,
+                                                                         row_list_offsets,
+                                                                         parent_locations,
+                                                                         virtual_row_offsets,
+                                                                         virtual_parent_locs,
+                                                                         total_count,
+                                                                         error_flag);
+}
+
+void launch_compute_msg_locations_from_occurrences(repeated_occurrence const* occurrences,
+                                                   cudf::size_type const* list_offsets,
+                                                   cudf::size_type base_offset,
+                                                   field_location* msg_locs,
+                                                   cudf::size_type* msg_row_offsets,
+                                                   int total_count,
+                                                   int* error_flag,
+                                                   rmm::cuda_stream_view stream)
+{
+  if (total_count == 0) return;
+  auto const blocks = static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  compute_msg_locations_from_occurrences_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    occurrences, list_offsets, base_offset, msg_locs, msg_row_offsets, total_count, error_flag);
 }
 
 void launch_validate_enum_values(int32_t const* values,

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -535,14 +535,21 @@ void launch_compute_msg_locations_from_occurrences(repeated_occurrence const* oc
 // Host-side template helpers that launch CUDA kernels
 // ============================================================================
 
+// Build a row-aligned null mask from `valid[row]` boolean flags. `num_rows` is the logical row
+// count and must be <= `valid.size()` — this matters because some callers pad `valid` to
+// `max(1, num_rows)` to avoid a 0-sized device_uvector, and feeding that padded size into
+// `valid_if` would produce a 1-bit mask for a 0-row column.
 template <typename T>
 inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_valid(
   rmm::device_uvector<T> const& valid,
+  cudf::size_type num_rows,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  CUDF_EXPECTS(valid.size() >= static_cast<size_t>(num_rows),
+               "valid buffer smaller than requested null mask");
   auto begin = thrust::make_counting_iterator<cudf::size_type>(0);
-  auto end   = begin + valid.size();
+  auto end   = begin + num_rows;
   auto pred  = [ptr = valid.data()] __device__(cudf::size_type i) {
     return static_cast<bool>(ptr[i]);
   };
@@ -562,7 +569,7 @@ std::unique_ptr<cudf::column> extract_and_build_scalar_column(cudf::data_type dt
     return std::make_unique<cudf::column>(dt, 0, out.release(), rmm::device_buffer{}, 0);
   }
   launch_extract(out.data(), valid.data());
-  auto [mask, null_count] = make_null_mask_from_valid(valid, stream, mr);
+  auto [mask, null_count] = make_null_mask_from_valid(valid, num_rows, stream, mr);
   return std::make_unique<cudf::column>(dt, num_rows, out.release(), std::move(mask), null_count);
 }
 
@@ -772,7 +779,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
                     thrust::make_counting_iterator<cudf::size_type>(num_rows),
                     valid.data(),
                     validity_fn);
-  auto [mask, null_count] = make_null_mask_from_valid(valid, stream, mr);
+  auto [mask, null_count] = make_null_mask_from_valid(valid, num_rows, stream, mr);
   if (as_bytes) {
     auto bytes_child =
       std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT8},
@@ -864,7 +871,7 @@ inline std::unique_ptr<cudf::column> extract_typed_column(
                                            stream);
         }
       }
-      auto [mask, null_count] = make_null_mask_from_valid(valid, stream, mr);
+      auto [mask, null_count] = make_null_mask_from_valid(valid, num_items, stream, mr);
       return std::make_unique<cudf::column>(
         dt, num_items, out.release(), std::move(mask), null_count);
     }

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -404,6 +404,134 @@ CUDF_KERNEL void extract_lengths_kernel(LocationProvider loc_provider,
 }
 
 // ============================================================================
+// Host wrapper declarations for kernel launches (repeated + nested)
+// ============================================================================
+
+void launch_count_repeated_fields(cudf::column_device_view const& d_in,
+                                  device_nested_field_descriptor const* schema,
+                                  int num_fields,
+                                  int depth_level,
+                                  repeated_field_info* repeated_info,
+                                  int num_repeated_fields,
+                                  int const* repeated_field_indices,
+                                  field_location* nested_locations,
+                                  int num_nested_fields,
+                                  int const* nested_field_indices,
+                                  int* error_flag,
+                                  int const* fn_to_rep_idx,
+                                  int fn_to_rep_size,
+                                  int const* fn_to_nested_idx,
+                                  int fn_to_nested_size,
+                                  int num_rows,
+                                  rmm::cuda_stream_view stream);
+
+void launch_scan_all_repeated_occurrences(cudf::column_device_view const& d_in,
+                                          repeated_field_scan_desc const* scan_descs,
+                                          int num_scan_fields,
+                                          int* error_flag,
+                                          int const* fn_to_desc_idx,
+                                          int fn_to_desc_size,
+                                          int num_rows,
+                                          rmm::cuda_stream_view stream);
+
+void launch_extract_strided_locations(field_location const* nested_locations,
+                                      int field_idx,
+                                      int num_fields,
+                                      field_location* parent_locs,
+                                      int num_rows,
+                                      rmm::cuda_stream_view stream);
+
+void launch_scan_nested_message_fields(uint8_t const* message_data,
+                                       cudf::size_type message_data_size,
+                                       cudf::size_type const* parent_row_offsets,
+                                       cudf::size_type parent_base_offset,
+                                       field_location const* parent_locations,
+                                       int num_parent_rows,
+                                       field_descriptor const* field_descs,
+                                       int num_fields,
+                                       field_location* output_locations,
+                                       int* error_flag,
+                                       rmm::cuda_stream_view stream);
+
+void launch_scan_repeated_message_children(uint8_t const* message_data,
+                                           cudf::size_type message_data_size,
+                                           cudf::size_type const* msg_row_offsets,
+                                           field_location const* msg_locs,
+                                           int num_occurrences,
+                                           field_descriptor const* child_descs,
+                                           int num_child_fields,
+                                           field_location* child_locs,
+                                           int* error_flag,
+                                           int const* child_lookup,
+                                           int child_lookup_size,
+                                           rmm::cuda_stream_view stream);
+
+void launch_count_repeated_in_nested(uint8_t const* message_data,
+                                     cudf::size_type message_data_size,
+                                     cudf::size_type const* row_offsets,
+                                     cudf::size_type base_offset,
+                                     field_location const* parent_locs,
+                                     int num_rows,
+                                     device_nested_field_descriptor const* schema,
+                                     int num_fields,
+                                     repeated_field_info* repeated_info,
+                                     int num_repeated,
+                                     int const* repeated_indices,
+                                     int* error_flag,
+                                     rmm::cuda_stream_view stream);
+
+void launch_scan_repeated_in_nested(uint8_t const* message_data,
+                                    cudf::size_type message_data_size,
+                                    cudf::size_type const* row_offsets,
+                                    cudf::size_type base_offset,
+                                    field_location const* parent_locs,
+                                    int num_rows,
+                                    device_nested_field_descriptor const* schema,
+                                    int32_t const* occ_prefix_sums,
+                                    int const* repeated_indices,
+                                    repeated_occurrence* occurrences,
+                                    int* error_flag,
+                                    rmm::cuda_stream_view stream);
+
+void launch_compute_nested_struct_locations(field_location const* child_locs,
+                                            field_location const* msg_locs,
+                                            cudf::size_type const* msg_row_offsets,
+                                            int child_idx,
+                                            int num_child_fields,
+                                            field_location* nested_locs,
+                                            cudf::size_type* nested_row_offsets,
+                                            int total_count,
+                                            int* error_flag,
+                                            rmm::cuda_stream_view stream);
+
+void launch_compute_grandchild_parent_locations(field_location const* parent_locs,
+                                                field_location const* child_locs,
+                                                int child_idx,
+                                                int num_child_fields,
+                                                field_location* gc_parent_abs,
+                                                int num_rows,
+                                                int* error_flag,
+                                                rmm::cuda_stream_view stream);
+
+void launch_compute_virtual_parents_for_nested_repeated(repeated_occurrence const* occurrences,
+                                                        cudf::size_type const* row_list_offsets,
+                                                        field_location const* parent_locations,
+                                                        cudf::size_type* virtual_row_offsets,
+                                                        field_location* virtual_parent_locs,
+                                                        int total_count,
+                                                        int* error_flag,
+                                                        rmm::cuda_stream_view stream);
+
+void launch_compute_msg_locations_from_occurrences(repeated_occurrence const* occurrences,
+                                                   cudf::size_type const* list_offsets,
+                                                   cudf::size_type base_offset,
+                                                   field_location* msg_locs,
+                                                   cudf::size_type* msg_row_offsets,
+                                                   int total_count,
+                                                   int* error_flag,
+                                                   rmm::cuda_stream_view stream);
+
+// ============================================================================
 // Host-side template helpers that launch CUDA kernels
 // ============================================================================
 
@@ -840,6 +968,7 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
   rmm::device_async_resource_ref mr)
 {
   auto const input_null_count = binary_input.null_count();
+  auto const field_type_id    = static_cast<cudf::type_id>(field_desc.output_type_id);
 
   if (total_count == 0) {
     rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
@@ -849,9 +978,7 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
                                                       offsets.release(),
                                                       rmm::device_buffer{},
                                                       0);
-    auto elem_type   = field_desc.output_type_id == static_cast<int>(cudf::type_id::LIST)
-                         ? cudf::type_id::UINT8
-                         : static_cast<cudf::type_id>(field_desc.output_type_id);
+    auto elem_type   = field_type_id == cudf::type_id::LIST ? cudf::type_id::UINT8 : field_type_id;
     auto child_col   = make_empty_column_safe(cudf::data_type{elem_type}, stream, mr);
 
     if (input_null_count > 0) {
@@ -915,11 +1042,7 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
                                                     rmm::device_buffer{},
                                                     0);
   auto child_col   = std::make_unique<cudf::column>(
-    cudf::data_type{static_cast<cudf::type_id>(field_desc.output_type_id)},
-    total_count,
-    values.release(),
-    rmm::device_buffer{},
-    0);
+    cudf::data_type{field_type_id}, total_count, values.release(), rmm::device_buffer{}, 0);
 
   if (input_null_count > 0) {
     auto null_mask = cudf::copy_bitmask(binary_input, stream, mr);

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -24,7 +24,6 @@ import ai.rapids.cudf.HostColumnVector;
 import ai.rapids.cudf.HostColumnVectorCore;
 import ai.rapids.cudf.HostColumnVector.*;
 import ai.rapids.cudf.Table;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1916,10 +1915,19 @@ public class ProtobufTest {
           new byte[][]{null},              // defaultStrings
           new int[][]{null},               // enumValidValues
           false)) {                        // failOnErrors
-        // Result should be STRUCT<ids: LIST<INT32>>
-        // The list should contain [1, 2, 3]
+        // Result should be STRUCT<ids: LIST<INT32>> containing [1, 2, 3]
         assertNotNull(result);
         assertEquals(DType.STRUCT, result.getType());
+        try (ColumnVector listCol = result.getChildColumnView(0).copyToColumnVector();
+             ColumnVector children = listCol.getChildColumnView(0).copyToColumnVector();
+             HostColumnVector hostChildren = children.copyToHost()) {
+          assertEquals(DType.LIST, listCol.getType());
+          assertEquals(DType.INT32, children.getType());
+          assertEquals(3, children.getRowCount());
+          assertEquals(1, hostChildren.getInt(0));
+          assertEquals(2, hostChildren.getInt(1));
+          assertEquals(3, hostChildren.getInt(2));
+        }
       }
     }
   }
@@ -2066,6 +2074,11 @@ public class ProtobufTest {
           false)) {
         assertNotNull(result);
         assertEquals(DType.STRUCT, result.getType());
+        try (ColumnVector expectedX = ColumnVector.fromBoxedInts(42);
+             ColumnVector expectedInner = ColumnVector.makeStruct(expectedX);
+             ColumnVector expectedOuter = ColumnVector.makeStruct(expectedInner)) {
+          AssertUtils.assertStructColumnsAreEqual(expectedOuter, result);
+        }
       }
     }
   }
@@ -2294,9 +2307,13 @@ public class ProtobufTest {
              new int[][]{null},
              false)) {
       try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
-           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector()) {
+           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostVals = vals.copyToHost()) {
         assertEquals(DType.UINT32, vals.getType());
         assertEquals(3, vals.getRowCount());
+        assertEquals(1, Integer.toUnsignedLong(hostVals.getInt(0)));
+        assertEquals(2, Integer.toUnsignedLong(hostVals.getInt(1)));
+        assertEquals(3, Integer.toUnsignedLong(hostVals.getInt(2)));
       }
     }
   }
@@ -2327,9 +2344,13 @@ public class ProtobufTest {
              new int[][]{null},
              false)) {
       try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
-           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector()) {
+           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostVals = vals.copyToHost()) {
         assertEquals(DType.UINT64, vals.getType());
         assertEquals(3, vals.getRowCount());
+        assertEquals(11L, hostVals.getLong(0));
+        assertEquals(22L, hostVals.getLong(1));
+        assertEquals(33L, hostVals.getLong(2));
       }
     }
   }
@@ -3426,8 +3447,14 @@ public class ProtobufTest {
              false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
-      try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector()) {
+      try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
+           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostVals = vals.copyToHost()) {
         assertEquals(DType.LIST, list.getType());
+        assertEquals(100000, vals.getRowCount(), "All 100K elements should be decoded");
+        assertEquals(0, hostVals.getInt(0));
+        assertEquals(50000, hostVals.getInt(50000));
+        assertEquals(99999, hostVals.getInt(99999));
       }
     }
   }
@@ -3641,6 +3668,12 @@ public class ProtobufTest {
              defaultStrings, enumValidValues, false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
+      // Verify the deepest leaf (encoded as 1 in this synthetic schema) actually decodes to 1.
+      try (ColumnVector firstChild = result.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostChild = firstChild.copyToHost()) {
+        assertEquals(DType.INT32, firstChild.getType());
+        assertEquals(1, hostChild.getInt(0));
+      }
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -24,6 +24,7 @@ import ai.rapids.cudf.HostColumnVector;
 import ai.rapids.cudf.HostColumnVectorCore;
 import ai.rapids.cudf.HostColumnVector.*;
 import ai.rapids.cudf.Table;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1372,6 +1373,145 @@ public class ProtobufTest {
     }
   }
 
+  @Test
+  void testRequiredNestedMessageMissing_Failfast() {
+    // message Outer { required Inner detail = 1; }
+    // message Inner { optional int32 id = 1; }
+    // Missing top-level required nested message should fail in FAILFAST mode.
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector ignored = decodeRaw(
+            input.getColumn(0),
+            new int[]{1, 1},
+            new int[]{-1, 0},
+            new int[]{0, 1},
+            new int[]{WT_LEN, WT_VARINT},
+            new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+            new boolean[]{false, false},
+            new boolean[]{true, false},
+            new boolean[]{false, false},
+            new long[]{0, 0},
+            new double[]{0.0, 0.0},
+            new boolean[]{false, false},
+            new byte[][]{null, null},
+            new int[][]{null, null},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testRequiredFieldInsideNestedMessageMissing_Failfast() {
+    // message Outer { optional Inner detail = 1; }
+    // message Inner { required int32 id = 1; optional string name = 2; }
+    // If detail is present but nested required id is missing, FAILFAST should throw.
+    Byte[] inner = concat(
+        box(tag(2, WT_LEN)), box(encodeVarint(4)), box("oops".getBytes()));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(inner.length)), inner);
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector ignored = decodeRaw(
+            input.getColumn(0),
+            new int[]{1, 1, 2},
+            new int[]{-1, 0, 0},
+            new int[]{0, 1, 1},
+            new int[]{WT_LEN, WT_VARINT, WT_LEN},
+            new int[]{DType.STRUCT.getTypeId().getNativeId(),
+                      DType.INT32.getTypeId().getNativeId(),
+                      DType.STRING.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+            new boolean[]{false, false, false},
+            new boolean[]{false, true, false},
+            new boolean[]{false, false, false},
+            new long[]{0, 0, 0},
+            new double[]{0.0, 0.0, 0.0},
+            new boolean[]{false, false, false},
+            new byte[][]{null, null, null},
+            new int[][]{null, null, null},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testRequiredFieldInsideNestedMessageMissing_Permissive() {
+    // message Outer { optional Inner detail = 1; optional string name = 2; }
+    // message Inner { required int32 id = 1; optional string note = 2; }
+    // If detail is present but nested required id is missing, PERMISSIVE should null the row.
+    Byte[] inner = concat(
+        box(tag(2, WT_LEN)), box(encodeVarint(4)), box("oops".getBytes()));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(inner.length)), inner,
+        box(tag(2, WT_LEN)), box(encodeVarint(7)), box("outside".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1, 2, 2},
+             new int[]{-1, 0, 0, -1},
+             new int[]{0, 1, 1, 0},
+             new int[]{WT_LEN, WT_VARINT, WT_LEN, WT_LEN},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId(),
+                       DType.STRING.getTypeId().getNativeId(),
+                       DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false, false, false},
+             new boolean[]{false, true, false, false},
+             new boolean[]{false, false, false, false},
+             new long[]{0, 0, 0, 0},
+             new double[]{0.0, 0.0, 0.0, 0.0},
+             new boolean[]{false, false, false, false},
+             new byte[][]{null, null, null, null},
+             new int[][]{null, null, null, null},
+             false)) {
+      assertSingleNullStructRow(actual,
+          "Missing nested required field should null the outer row in PERMISSIVE mode");
+    }
+  }
+
+  @Test
+  void testAbsentNestedParentSkipsRequiredChildCheck_Failfast() {
+    // message Outer { optional Inner detail = 1; }
+    // message Inner { required int32 id = 1; }
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false},
+             new boolean[]{false, true},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, null},
+             true);
+         ColumnVector detailCol = actual.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostStruct = actual.copyToHost();
+         HostColumnVector hostDetail = detailCol.copyToHost()) {
+      assertEquals(0, actual.getNullCount(), "Outer row should remain valid");
+      assertFalse(hostStruct.isNull(0), "Top-level row should not be null");
+      assertEquals(1, detailCol.getNullCount(), "Absent nested parent should stay null");
+      assertTrue(hostDetail.isNull(0), "Missing optional nested struct should skip required-child error");
+    }
+  }
+
   // ============================================================================
   // Default Value Tests (API accepts parameters, CUDA fill not yet implemented)
   // ============================================================================
@@ -1747,6 +1887,138 @@ public class ProtobufTest {
   // Tests for Nested and Repeated Fields (Phase 1-3 Implementation)
   // ============================================================================
 
+  @Test
+  void testUnpackedRepeatedInt32() {
+    // Unpacked repeated: same field number appears multiple times
+    // message TestMsg { repeated int32 ids = 1; }
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(3)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      // Use the new nested API for repeated fields
+      // Field: ids (field_number=1, parent=-1, depth=0, wire_type=VARINT, type=INT32, repeated=true)
+      try (ColumnVector result = decodeRaw(
+          input.getColumn(0),
+          new int[]{1},                    // fieldNumbers
+          new int[]{-1},                   // parentIndices (-1 = top level)
+          new int[]{0},                    // depthLevels
+          new int[]{Protobuf.WT_VARINT},   // wireTypes
+          new int[]{DType.INT32.getTypeId().getNativeId()},  // outputTypeIds (element type)
+          new int[]{Protobuf.ENC_DEFAULT}, // encodings
+          new boolean[]{true},             // isRepeated
+          new boolean[]{false},            // isRequired
+          new boolean[]{false},            // hasDefaultValue
+          new long[]{0},                   // defaultInts
+          new double[]{0.0},               // defaultFloats
+          new boolean[]{false},            // defaultBools
+          new byte[][]{null},              // defaultStrings
+          new int[][]{null},               // enumValidValues
+          false)) {                        // failOnErrors
+        // Result should be STRUCT<ids: LIST<INT32>>
+        // The list should contain [1, 2, 3]
+        assertNotNull(result);
+        assertEquals(DType.STRUCT, result.getType());
+      }
+    }
+  }
+
+  @Test
+  void testPackedRepeatedDoubleWithMultipleFields() {
+    // Test packed repeated fields with multiple types including edge cases.
+    // message WithPackedRepeated {
+    //   optional int32 id = 1;
+    //   repeated int32 int_values = 2 [packed=true];
+    //   repeated double double_values = 3 [packed=true];
+    //   repeated bool bool_values = 4 [packed=true];
+    // }
+
+    // Helper to build packed int data (varints)
+    java.io.ByteArrayOutputStream intBuf = new java.io.ByteArrayOutputStream();
+
+    // Row 0: id=42, int_values=[1,-1,100] (12 bytes packed), double_values=[1.5,2.5], bool=[true,false]
+    // Row 1: id=7, int_values=15x(-1) (150 bytes packed, 2-byte length varint!), double_values=[3.0,4.0], bool=[true]
+    // Row 2: id=0, int_values=[] (field omitted), double_values=[5.0], bool=[] (field omitted)
+
+    // --- Row 0 ---
+    byte[] r0IntVarints = concatBytes(encodeVarint(1), encodeVarint(-1L & 0xFFFFFFFFFFFFFFFFL), encodeVarint(100));
+    byte[] r0Doubles = concatBytes(encodeDouble(1.5), encodeDouble(2.5));
+    byte[] r0Bools = new byte[]{0x01, 0x00};
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(42)),
+        box(tag(2, WT_LEN)), box(encodeVarint(r0IntVarints.length)), box(r0IntVarints),
+        box(tag(3, WT_LEN)), box(encodeVarint(r0Doubles.length)), box(r0Doubles),
+        box(tag(4, WT_LEN)), box(encodeVarint(r0Bools.length)), box(r0Bools));
+
+    // --- Row 1: 15 negative ints => 150 bytes packed (length varint is 2 bytes: 0x96 0x01) ---
+    java.io.ByteArrayOutputStream buf1 = new java.io.ByteArrayOutputStream();
+    byte[] negOneVarint = encodeVarint(-1L & 0xFFFFFFFFFFFFFFFFL); // 10 bytes
+    for (int i = 0; i < 15; i++) {
+      buf1.write(negOneVarint, 0, negOneVarint.length);
+    }
+    byte[] r1IntVarints = buf1.toByteArray(); // 150 bytes
+    byte[] r1Doubles = concatBytes(encodeDouble(3.0), encodeDouble(4.0));
+    byte[] r1Bools = new byte[]{0x01};
+    Byte[] row1 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(7)),
+        box(tag(2, WT_LEN)), box(encodeVarint(r1IntVarints.length)), box(r1IntVarints),
+        box(tag(3, WT_LEN)), box(encodeVarint(r1Doubles.length)), box(r1Doubles),
+        box(tag(4, WT_LEN)), box(encodeVarint(r1Bools.length)), box(r1Bools));
+
+    // --- Row 2: no int_values, no bool_values ---
+    byte[] r2Doubles = encodeDouble(5.0);
+    Byte[] row2 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(0)),
+        box(tag(3, WT_LEN)), box(encodeVarint(r2Doubles.length)), box(r2Doubles));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, row1, row2}).build()) {
+      try (ColumnVector result = decodeRaw(
+          input.getColumn(0),
+          new int[]{1, 2, 3, 4},
+          new int[]{-1, -1, -1, -1},
+          new int[]{0, 0, 0, 0},
+          new int[]{WT_VARINT, WT_VARINT, WT_64BIT, WT_VARINT},
+          new int[]{
+            DType.INT32.getTypeId().getNativeId(),
+            DType.INT32.getTypeId().getNativeId(),
+            DType.FLOAT64.getTypeId().getNativeId(),
+            DType.BOOL8.getTypeId().getNativeId()
+          },
+          new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+          new boolean[]{false, true, true, true},
+          new boolean[]{false, false, false, false},
+          new boolean[]{false, false, false, false},
+          new long[]{0, 0, 0, 0},
+          new double[]{0.0, 0.0, 0.0, 0.0},
+          new boolean[]{false, false, false, false},
+          new byte[][]{null, null, null, null},
+          new int[][]{null, null, null, null},
+          false)) {
+        assertNotNull(result);
+        assertEquals(DType.STRUCT, result.getType());
+        assertEquals(3, result.getRowCount());
+
+        // Verify double_values child column has correct total count: 2 + 2 + 1 = 5
+        try (ColumnVector doubleListCol = result.getChildColumnView(2).copyToColumnVector()) {
+          assertEquals(DType.LIST, doubleListCol.getType());
+          try (ColumnVector doubleChildren = doubleListCol.getChildColumnView(0).copyToColumnVector()) {
+            assertEquals(DType.FLOAT64, doubleChildren.getType());
+            assertEquals(5, doubleChildren.getRowCount(),
+                "Total packed doubles across 3 rows should be 5, got " + doubleChildren.getRowCount());
+            try (HostColumnVector hd = doubleChildren.copyToHost()) {
+              assertEquals(1.5, hd.getDouble(0), 1e-10);
+              assertEquals(2.5, hd.getDouble(1), 1e-10);
+              assertEquals(3.0, hd.getDouble(2), 1e-10);
+              assertEquals(4.0, hd.getDouble(3), 1e-10);
+              assertEquals(5.0, hd.getDouble(4), 1e-10);
+            }
+          }
+        }
+      }
+    }
+  }
+
   /** Helper: concatenate byte arrays */
   private static byte[] concatBytes(byte[]... arrays) {
     int len = 0;
@@ -1795,6 +2067,301 @@ public class ProtobufTest {
         assertNotNull(result);
         assertEquals(DType.STRUCT, result.getType());
       }
+    }
+  }
+
+  @Test
+  void testDeepNestedMessageDepth3() {
+    // message Inner  { int32 a = 1; string b = 2; bool c = 3; }
+    // message Middle { Inner inner = 1; int64 m = 2; }
+    // message Outer  { Middle middle = 1; float score = 2; }
+    Byte[] innerMessage = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(7)),
+        box(tag(2, WT_LEN)), box(encodeVarint(3)), box("abc".getBytes()),
+        box(tag(3, WT_VARINT)), new Byte[]{0x01});
+    Byte[] middleMessage = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(innerMessage.length)), innerMessage,
+        box(tag(2, WT_VARINT)), box(encodeVarint(123L)));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(middleMessage.length)), middleMessage,
+        box(tag(2, WT_32BIT)), box(encodeFloat(1.25f)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(7);
+         ColumnVector expectedB = ColumnVector.fromStrings("abc");
+         ColumnVector expectedC = ColumnVector.fromBoxedBooleans(true);
+         ColumnVector expectedInner = ColumnVector.makeStruct(expectedA, expectedB, expectedC);
+         ColumnVector expectedM = ColumnVector.fromBoxedLongs(123L);
+         ColumnVector expectedMiddle = ColumnVector.makeStruct(expectedInner, expectedM);
+         ColumnVector expectedScore = ColumnVector.fromBoxedFloats(1.25f);
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedMiddle, expectedScore);
+         ColumnVector actualStruct = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1, 1, 2, 3, 2, 2},  // fieldNumbers
+             new int[]{-1, 0, 1, 1, 1, 0, -1},  // parentIndices
+             new int[]{0, 1, 2, 2, 2, 1, 0},  // depthLevels
+             new int[]{Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_VARINT, Protobuf.WT_LEN,
+                 Protobuf.WT_VARINT, Protobuf.WT_VARINT, Protobuf.WT_32BIT},  // wireTypes
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.STRUCT.getTypeId().getNativeId(),
+                 DType.INT32.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId(),
+                 DType.BOOL8.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId(),
+                 DType.FLOAT32.getTypeId().getNativeId()},  // outputTypeIds
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT,
+                 Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT,
+                 Protobuf.ENC_DEFAULT},  // encodings
+             new boolean[]{false, false, false, false, false, false, false},  // isRepeated
+             new boolean[]{false, false, false, false, false, false, false},  // isRequired
+             new boolean[]{false, false, false, false, false, false, false},  // hasDefaultValue
+             new long[]{0, 0, 0, 0, 0, 0, 0},
+             new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+             new boolean[]{false, false, false, false, false, false, false},
+             new byte[][]{null, null, null, null, null, null, null},
+             new int[][]{null, null, null, null, null, null, null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testPackedRepeatedInsideNestedMessage() {
+    // message Inner { repeated int32 ids = 1 [packed=true]; }
+    // message Outer { Inner inner = 1; }
+    byte[] packedIds = concatBytes(encodeVarint(10), encodeVarint(20), encodeVarint(30));
+    Byte[] inner = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(packedIds.length)),
+        box(packedIds));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(inner.length)),
+        inner);
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},  // outer.inner, inner.ids
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{false, true},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, null},
+             false)) {
+      assertEquals(DType.STRUCT, result.getType());
+      try (ColumnVector innerStruct = result.getChildColumnView(0).copyToColumnVector();
+           ColumnVector idsList = innerStruct.getChildColumnView(0).copyToColumnVector();
+           ColumnVector ids = idsList.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostIds = ids.copyToHost()) {
+        assertEquals(3, ids.getRowCount());
+        assertEquals(10, hostIds.getInt(0));
+        assertEquals(20, hostIds.getInt(1));
+        assertEquals(30, hostIds.getInt(2));
+      }
+    }
+  }
+
+  @Test
+  void testPackedRepeatedChildInsideRepeatedMessage() {
+    // message Item { repeated int32 ids = 1 [packed=true]; optional int32 score = 2; }
+    // message Outer { repeated Item items = 1; }
+    byte[] item0Ids = concatBytes(encodeVarint(10), encodeVarint(20));
+    Byte[] item0 = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(item0Ids.length)),
+        box(item0Ids),
+        box(tag(2, WT_VARINT)),
+        box(encodeVarint(7)));
+    byte[] item1Ids = concatBytes(encodeVarint(30));
+    Byte[] item1 = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(item1Ids.length)),
+        box(item1Ids),
+        box(tag(2, WT_VARINT)),
+        box(encodeVarint(9)));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(item0.length)),
+        item0,
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(item1.length)),
+        item1);
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedItems = ColumnVector.fromLists(
+             new ListType(true,
+                 new StructType(true,
+                     new ListType(true, new BasicType(true, DType.INT32)),
+                     new BasicType(true, DType.INT32))),
+             Arrays.asList(
+                 new StructData(Arrays.asList(10, 20), 7),
+                 new StructData(Arrays.asList(30), 9)));
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedItems);
+         ColumnVector actualStruct = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1, 2},
+             new int[]{-1, 0, 0},
+             new int[]{0, 1, 1},
+             new int[]{WT_LEN, WT_VARINT, WT_VARINT},
+             new int[]{
+                 DType.STRUCT.getTypeId().getNativeId(),
+                 DType.INT32.getTypeId().getNativeId(),
+                 DType.INT32.getTypeId().getNativeId()
+             },
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{true, true, false},
+             new boolean[]{false, false, false},
+             new boolean[]{false, false, false},
+             new long[]{0, 0, 0},
+             new double[]{0.0, 0.0, 0.0},
+             new boolean[]{false, false, false},
+             new byte[][]{null, null, null},
+             new int[][]{null, null, null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testPermissiveRepeatedWrongWireTypeDoesNotCorruptFollowingRow() {
+    // message Msg { repeated int32 ids = 1; }
+    // Row 0 has one valid element, then a malformed fixed32 occurrence for the same field,
+    // then another valid varint that must be ignored once the row is marked malformed.
+    // Row 1 must keep its own slot and not be overwritten by row 0's trailing occurrence.
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(1, WT_32BIT)), box(encodeFixed32(77)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)));
+    Byte[] row1 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(100)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, row1}).build();
+         ColumnVector expectedIds = ColumnVector.fromLists(
+             new ListType(true, new BasicType(true, DType.INT32)),
+             Arrays.asList(1),
+             Arrays.asList(100));
+         ColumnVector expectedStruct = ColumnVector.makeStruct(expectedIds);
+         ColumnVector actualStruct = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testRepeatedUint32() {
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(3)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.UINT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
+           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector()) {
+        assertEquals(DType.UINT32, vals.getType());
+        assertEquals(3, vals.getRowCount());
+      }
+    }
+  }
+
+  @Test
+  void testRepeatedUint64() {
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(11)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(22)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(33)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.UINT64.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
+           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector()) {
+        assertEquals(DType.UINT64, vals.getType());
+        assertEquals(3, vals.getRowCount());
+      }
+    }
+  }
+
+  @Test
+  void testWireTypeMismatchInRepeatedMessageChildFailfast() {
+    // message Item { int32 x = 1; }  message Outer { repeated Item items = 1; }
+    // Encode x with WT_64BIT instead of WT_VARINT to force hard mismatch.
+    Byte[] badItem = concat(box(tag(1, WT_64BIT)), box(encodeFixed64(123L)));
+    Byte[] row = concat(box(tag(1, WT_LEN)), box(encodeVarint(badItem.length)), badItem);
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector ignored = decodeRaw(
+            input.getColumn(0),
+            new int[]{1, 1},
+            new int[]{-1, 0},
+            new int[]{0, 1},
+            new int[]{WT_LEN, WT_VARINT},
+            new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+            new boolean[]{true, false},
+            new boolean[]{false, false},
+            new boolean[]{false, false},
+            new long[]{0, 0},
+            new double[]{0.0, 0.0},
+            new boolean[]{false, false},
+            new byte[][]{null, null},
+            new int[][]{null, null},
+            true)) {
+        }
+      });
     }
   }
 
@@ -2239,6 +2806,135 @@ public class ProtobufTest {
   }
 
   @Test
+  void testRepeatedStructEnumInvalidKeepsTopLevelRowValid() {
+    // enum Color { RED=0; GREEN=1; BLUE=2; }
+    // message Item { Color color = 1; }
+    // message Msg { repeated Item items = 1; }
+    Byte[] item00 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(0)));    // valid
+    Byte[] item01 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));  // invalid
+    Byte[] row0 = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(item00.length)), item00,
+        box(tag(1, WT_LEN)), box(encodeVarint(item01.length)), item01);
+    Byte[] item10 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));    // valid
+    Byte[] row1 = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(item10.length)), item10);
+
+    try (Table input = new Table.TestBuilder().column(row0, row1).build();
+         ColumnVector actualStruct = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{true, false},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, new int[]{0, 1, 2}},
+             false);
+         ColumnVector items = actualStruct.getChildColumnView(0).copyToColumnVector();
+         ColumnVector itemStructs = items.getChildColumnView(0).copyToColumnVector();
+         ColumnVector colors = itemStructs.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostStruct = actualStruct.copyToHost();
+         HostColumnVector hostColors = colors.copyToHost()) {
+      assertEquals(0, actualStruct.getNullCount(), "Invalid child enum should not null the top-level row");
+      assertFalse(hostStruct.isNull(0), "Row 0 should remain valid");
+      assertFalse(hostStruct.isNull(1), "Row 1 should remain valid");
+      assertEquals(3, colors.getRowCount(), "All repeated message elements should remain visible");
+      assertEquals(1, colors.getNullCount(), "Only the invalid enum field should be null");
+      assertEquals(0, hostColors.getInt(0), "The first repeated child should keep its valid enum");
+      assertTrue(hostColors.isNull(1), "The invalid repeated child enum should decode as null");
+      assertEquals(1, hostColors.getInt(2), "The second row should keep its valid enum");
+    }
+  }
+
+  @Test
+  void testRepeatedStructEnumInvalidKeepsSiblingFieldsVisible() {
+    // enum Color { RED=0; GREEN=1; BLUE=2; }
+    // message Item { Color color = 1; int32 count = 2; }
+    // message Msg { repeated Item items = 1; }
+    Byte[] item00 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(0)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(10)));
+    Byte[] item01 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(999)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(20)));
+    Byte[] row0 = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(item00.length)), item00,
+        box(tag(1, WT_LEN)), box(encodeVarint(item01.length)), item01);
+    Byte[] item10 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(30)));
+    Byte[] row1 = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(item10.length)), item10);
+
+    try (Table input = new Table.TestBuilder().column(row0, row1).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1, 2},
+             new int[]{-1, 0, 0},
+             new int[]{0, 1, 1},
+             new int[]{WT_LEN, WT_VARINT, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
+             new boolean[]{true, false, false},
+             new boolean[]{false, false, false},
+             new boolean[]{false, false, false},
+             new long[]{0, 0, 0},
+             new double[]{0.0, 0.0, 0.0},
+             new boolean[]{false, false, false},
+             new byte[][]{null, null, null},
+             new int[][]{null, new int[]{0, 1, 2}, null},
+             false);
+         ColumnView itemsView = actual.getChildColumnView(0);
+         ColumnView itemStructView = itemsView.getChildColumnView(0);
+         ColumnView colorView = itemStructView.getChildColumnView(0);
+         ColumnView countView = itemStructView.getChildColumnView(1);
+         ColumnVector colorVector = colorView.copyToColumnVector();
+         ColumnVector countVector = countView.copyToColumnVector();
+         HostColumnVector hostStruct = actual.copyToHost();
+         HostColumnVector hostColors = colorVector.copyToHost();
+         HostColumnVector hostCounts = countVector.copyToHost()) {
+      HostColumnVectorCore hostItems = hostStruct.getChildColumnView(0);
+
+      assertEquals(0, actual.getNullCount(), "Invalid child enum should not null the parent row");
+      assertFalse(hostStruct.isNull(0), "Row 0 should remain valid");
+      assertFalse(hostStruct.isNull(1), "Row 1 should remain valid");
+
+      assertEquals(0, hostItems.getNullCount(), "LIST rows should remain valid");
+      assertFalse(hostItems.isNull(0), "items[0] should remain valid");
+      assertFalse(hostItems.isNull(1), "items[1] should remain valid");
+
+      assertEquals(3, itemStructView.getRowCount(),
+          "All repeated message elements should remain visible");
+      assertEquals(0, itemStructView.getNullCount(),
+          "No repeated struct element should be dropped");
+      assertEquals(1, colorView.getNullCount(),
+          "Only the invalid enum child should be null");
+      assertEquals(0, hostColors.getInt(0),
+          "The first repeated child should keep its valid enum");
+      assertTrue(hostColors.isNull(1),
+          "The invalid repeated child enum should decode as null");
+      assertEquals(1, hostColors.getInt(2),
+          "The second row should keep its valid enum");
+      assertEquals(3, countView.getRowCount(),
+          "Sibling fields should remain visible for every repeated element");
+      assertEquals(0, countView.getNullCount(),
+          "Sibling scalar fields should stay non-null when only the enum is invalid");
+      assertEquals(10, hostCounts.getInt(0));
+      assertEquals(20, hostCounts.getInt(1));
+      assertEquals(30, hostCounts.getInt(2));
+    }
+  }
+
+  @Test
   void testEnumMissingFieldDoesNotNullRow() {
     // Missing enum field should return null for the field, but NOT null the entire row
     // Only unknown enum values (present but invalid) trigger row-level null
@@ -2257,6 +2953,146 @@ public class ProtobufTest {
       // Struct row should be valid (not null), only the field is null
       assertEquals(0, actualStruct.getNullCount(), "Struct row should NOT be null for missing field");
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
+    }
+  }
+
+  @Test
+  void testNestedEnumInvalidKeepsRowAndSiblingFieldsInPermissiveMode() {
+    // message WithNestedEnum {
+    //   optional int32 id = 1;
+    //   optional Detail detail = 2;
+    //   optional string name = 3;
+    // }
+    // message Detail {
+    //   enum Status { UNKNOWN = 0; OK = 1; BAD = 2; }
+    //   optional Status status = 1;
+    //   optional int32 count = 2;
+    // }
+    // Invalid nested enum should null the whole row, including grandchild field detail.count.
+    Byte[] detail = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(999)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(20)));
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(2, WT_LEN)), box(encodeVarint(detail.length)), detail,
+        box(tag(3, WT_LEN)), box(encodeVarint(3)), box("bad".getBytes()));
+
+    byte[][][] enumNames = new byte[][][] {
+        null,
+        null,
+        null,
+        new byte[][] {
+            "UNKNOWN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "OK".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BAD".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        },
+        null
+    };
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 2, 3, 1, 2},
+             new int[]{-1, -1, -1, 1, 1},
+             new int[]{0, 0, 0, 1, 1},
+             new int[]{WT_VARINT, WT_LEN, WT_LEN, WT_VARINT, WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId(),
+                       DType.STRUCT.getTypeId().getNativeId(),
+                       DType.STRING.getTypeId().getNativeId(),
+                       DType.STRING.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_ENUM_STRING,
+                       Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false, false, false, false},
+             new boolean[]{false, false, false, false, false},
+             new boolean[]{false, false, false, false, false},
+             new long[]{0, 0, 0, 0, 0},
+             new double[]{0.0, 0.0, 0.0, 0.0, 0.0},
+             new boolean[]{false, false, false, false, false},
+             new byte[][]{null, null, null, null, null},
+             new int[][]{null, null, null, new int[]{0, 1, 2}, null},
+             enumNames,
+             false);
+         ColumnVector detailCol = actual.getChildColumnView(1).copyToColumnVector();
+         ColumnVector statusCol = detailCol.getChildColumnView(0).copyToColumnVector();
+         ColumnVector countCol = detailCol.getChildColumnView(1).copyToColumnVector();
+         HostColumnVector hostStruct = actual.copyToHost();
+         HostColumnVector hostDetail = detailCol.copyToHost();
+         HostColumnVector hostStatus = statusCol.copyToHost();
+         HostColumnVector hostCount = countCol.copyToHost()) {
+      assertEquals(0, actual.getNullCount(), "Invalid nested enum should not null the top-level row");
+      assertFalse(hostStruct.isNull(0), "Top-level struct should remain valid");
+      assertEquals(0, detailCol.getNullCount(), "Nested struct should remain present");
+      assertFalse(hostDetail.isNull(0), "Nested struct row should remain valid");
+      assertEquals(1, statusCol.getNullCount(), "Only the invalid enum field should be null");
+      assertTrue(hostStatus.isNull(0), "detail.status should decode as null");
+      assertEquals(0, countCol.getNullCount(), "Sibling nested fields should remain visible");
+      assertFalse(hostCount.isNull(0), "detail.count should remain valid");
+      assertEquals(20, hostCount.getInt(0), "detail.count should preserve the decoded value");
+    }
+  }
+
+  @Test
+  void testMalformedNestedEnumPermissiveNullsWholeRow() {
+    // message WithNestedEnum {
+    //   optional int32 id = 1;
+    //   optional Detail detail = 2;
+    //   optional string name = 3;
+    // }
+    // message Detail {
+    //   enum Status { UNKNOWN = 0; OK = 1; BAD = 2; }
+    //   optional Status status = 1;
+    //   optional int32 count = 2;
+    // }
+    //
+    // The nested message length is intentionally truncated to 4 bytes. Spark CPU treats this as a
+    // malformed row in PERMISSIVE mode and returns a null struct row rather than partial data.
+    Byte[] rowValid = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(2, WT_LEN)), box(encodeVarint(4)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(10)),
+        box(tag(3, WT_LEN)), box(encodeVarint(2)), box("ok".getBytes()));
+    Byte[] rowInvalid = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(2, WT_LEN)), box(encodeVarint(4)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(999)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(20)),
+        box(tag(3, WT_LEN)), box(encodeVarint(3)), box("bad".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(rowValid, rowInvalid).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 2, 3, 1, 2},
+             new int[]{-1, -1, -1, 1, 1},
+             new int[]{0, 0, 0, 1, 1},
+             new int[]{WT_VARINT, WT_LEN, WT_LEN, WT_VARINT, WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId(),
+                       DType.STRUCT.getTypeId().getNativeId(),
+                       DType.STRING.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId(),
+                       DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT,
+                       Protobuf.ENC_DEFAULT},
+             new boolean[]{false, false, false, false, false},
+             new boolean[]{false, false, false, false, false},
+             new boolean[]{false, false, false, false, false},
+             new long[]{0, 0, 0, 0, 0},
+             new double[]{0.0, 0.0, 0.0, 0.0, 0.0},
+             new boolean[]{false, false, false, false, false},
+             new byte[][]{null, null, null, null, null},
+             new int[][]{null, null, null, new int[]{0, 1, 2}, null},
+             false);
+         HostColumnVector hostStruct = actual.copyToHost()) {
+      assertEquals(1, actual.getNullCount(), "Only the malformed row should be null");
+      assertFalse(hostStruct.isNull(0), "The valid row should remain decoded");
+      assertTrue(hostStruct.isNull(1), "The malformed nested row should be null in PERMISSIVE mode");
     }
   }
 
@@ -2289,9 +3125,312 @@ public class ProtobufTest {
   // Repeated Enum-as-String Tests
   // ============================================================================
 
+  @Test
+  void testRepeatedEnumAsString() {
+    // repeated Color colors = 1; with Color { RED=0; GREEN=1; BLUE=2; }
+    // Row with three occurrences: RED, BLUE, GREEN
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(0)),   // RED
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)),   // BLUE
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)));  // GREEN
+
+    byte[][][] enumNames = new byte[][][] {
+        new byte[][] {
+            "RED".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "GREEN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BLUE".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{Protobuf.WT_VARINT},
+             new int[]{DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_ENUM_STRING},
+             new boolean[]{true},   // isRepeated
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{{0, 1, 2}},
+             enumNames,
+             false)) {
+      assertNotNull(actual);
+      assertEquals(DType.STRUCT, actual.getType());
+      assertEquals(1, actual.getNumChildren());
+      try (ColumnView listCol = actual.getChildColumnView(0)) {
+        assertEquals(DType.LIST, listCol.getType());
+        try (ColumnView strChild = listCol.getChildColumnView(0);
+             HostColumnVector hostStrs = strChild.copyToHost()) {
+          assertEquals(3, hostStrs.getRowCount());
+          assertEquals("RED", hostStrs.getJavaString(0));
+          assertEquals("BLUE", hostStrs.getJavaString(1));
+          assertEquals("GREEN", hostStrs.getJavaString(2));
+        }
+      }
+    }
+  }
+
+  @Test
+  void testRepeatedMessageChildEnumAsString() {
+    // message Item { optional Priority priority = 1; }
+    // message Outer { repeated Item items = 1; }
+    // enum Priority { UNKNOWN=0; FOO=1; BAR=2; }
+    Byte[] item0 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));  // FOO
+    Byte[] item1 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(2)));  // BAR
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(item0.length)), item0,
+        box(tag(1, WT_LEN)), box(encodeVarint(item1.length)), item1);
+
+    byte[][][] enumNames = new byte[][][] {
+        null,
+        new byte[][] {
+            "UNKNOWN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "FOO".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BAR".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_ENUM_STRING},
+             new boolean[]{true, false},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, new int[]{0, 1, 2}},
+             enumNames,
+             false);
+         ColumnVector items = actual.getChildColumnView(0).copyToColumnVector();
+         ColumnVector itemStructs = items.getChildColumnView(0).copyToColumnVector();
+         ColumnVector priorities = itemStructs.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostPriorities = priorities.copyToHost()) {
+      assertEquals(2, priorities.getRowCount());
+      assertEquals("FOO", hostPriorities.getJavaString(0));
+      assertEquals("BAR", hostPriorities.getJavaString(1));
+    }
+  }
+
+  @Test
+  void testRepeatedMessageChildEnumAsStringInvalidKeepsRowValid() {
+    Byte[] item0 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(1)));    // FOO
+    Byte[] item1 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));  // invalid
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(item0.length)), item0,
+        box(tag(1, WT_LEN)), box(encodeVarint(item1.length)), item1);
+
+    byte[][][] enumNames = new byte[][][] {
+        null,
+        new byte[][] {
+            "UNKNOWN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "FOO".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BAR".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_ENUM_STRING},
+             new boolean[]{true, false},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, new int[]{0, 1, 2}},
+             enumNames,
+             false);
+         ColumnVector items = actual.getChildColumnView(0).copyToColumnVector();
+         ColumnVector itemStructs = items.getChildColumnView(0).copyToColumnVector();
+         ColumnVector priorities = itemStructs.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostStruct = actual.copyToHost();
+         HostColumnVector hostPriorities = priorities.copyToHost()) {
+      assertEquals(0, actual.getNullCount(), "Invalid child enum should not null the top-level row");
+      assertFalse(hostStruct.isNull(0), "The top-level row should remain valid");
+      assertEquals(2, priorities.getRowCount(), "Both repeated message elements should remain visible");
+      assertEquals(1, priorities.getNullCount(), "Only the invalid enum field should be null");
+      assertEquals("FOO", hostPriorities.getJavaString(0));
+      assertTrue(hostPriorities.isNull(1), "The invalid repeated child enum should decode as null");
+    }
+  }
+
+  @Test
+  void testNestedRepeatedEnumAsString() {
+    // message Inner { repeated Priority priority = 1; }
+    // message Outer { optional Inner inner = 1; }
+    // enum Priority { UNKNOWN=0; FOO=1; BAR=2; }
+    byte[] packedPriorities = concatBytes(encodeVarint(0), encodeVarint(2), encodeVarint(1));
+    Byte[] inner = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(packedPriorities.length)),
+        box(packedPriorities));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(inner.length)),
+        inner);
+
+    byte[][][] enumNames = new byte[][][] {
+        null,
+        new byte[][] {
+            "UNKNOWN".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "FOO".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            "BAR".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        }
+    };
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = decodeRaw(
+             input.getColumn(0),
+             new int[]{1, 1},
+             new int[]{-1, 0},
+             new int[]{0, 1},
+             new int[]{WT_LEN, WT_VARINT},
+             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_ENUM_STRING},
+             new boolean[]{false, true},
+             new boolean[]{false, false},
+             new boolean[]{false, false},
+             new long[]{0, 0},
+             new double[]{0.0, 0.0},
+             new boolean[]{false, false},
+             new byte[][]{null, null},
+             new int[][]{null, new int[]{0, 1, 2}},
+             enumNames,
+             false);
+         ColumnVector innerStruct = actual.getChildColumnView(0).copyToColumnVector();
+         ColumnVector priorityList = innerStruct.getChildColumnView(0).copyToColumnVector();
+         ColumnVector priorities = priorityList.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostPriorities = priorities.copyToHost()) {
+      assertEquals(3, priorities.getRowCount());
+      assertEquals("UNKNOWN", hostPriorities.getJavaString(0));
+      assertEquals("BAR", hostPriorities.getJavaString(1));
+      assertEquals("FOO", hostPriorities.getJavaString(2));
+    }
+  }
+
   // ============================================================================
   // Edge case and boundary tests
   // ============================================================================
+
+  @Test
+  void testPackedFixedMisaligned() {
+    byte[] packedData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(packedData.length)),
+        box(packedData));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(RuntimeException.class, () -> {
+        try (ColumnVector result = decodeRaw(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{-1},
+            new int[]{0},
+            new int[]{WT_32BIT},
+            new int[]{DType.INT32.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_FIXED},
+            new boolean[]{true},
+            new boolean[]{false},
+            new boolean[]{false},
+            new long[]{0},
+            new double[]{0.0},
+            new boolean[]{false},
+            new byte[][]{null},
+            new int[][]{null},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testPackedFixedMisaligned64() {
+    byte[] packedData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)),
+        box(encodeVarint(packedData.length)),
+        box(packedData));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(RuntimeException.class, () -> {
+        try (ColumnVector result = decodeRaw(
+            input.getColumn(0),
+            new int[]{1},
+            new int[]{-1},
+            new int[]{0},
+            new int[]{WT_64BIT},
+            new int[]{DType.INT64.getTypeId().getNativeId()},
+            new int[]{Protobuf.ENC_FIXED},
+            new boolean[]{true},
+            new boolean[]{false},
+            new boolean[]{false},
+            new long[]{0},
+            new double[]{0.0},
+            new boolean[]{false},
+            new byte[][]{null},
+            new int[][]{null},
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testLargeRepeatedField() throws Exception {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    for (int i = 0; i < 100000; i++) {
+      baos.write(tag(1, WT_VARINT));
+      baos.write(encodeVarint(i));
+    }
+    Byte[] row = box(baos.toByteArray());
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      assertNotNull(result);
+      assertEquals(DType.STRUCT, result.getType());
+      try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector()) {
+        assertEquals(DType.LIST, list.getType());
+      }
+    }
+  }
 
   @Test
   void testMultiFieldOutputShape() {
@@ -2348,6 +3487,46 @@ public class ProtobufTest {
       try (HostColumnVector hcv = result.copyToHost()) {
         assertFalse(hcv.isNull(0), "Row 0 should not be null");
         assertTrue(hcv.isNull(1), "Row 1 (null input) should be null in output struct");
+      }
+    }
+  }
+
+  @Test
+  void testMixedPackedUnpacked() {
+    byte[] packedContent = concatBytes(encodeVarint(30), encodeVarint(40));
+    Byte[] row = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(10)),
+        box(tag(1, WT_VARINT)), box(encodeVarint(20)),
+        box(tag(1, WT_LEN)), box(encodeVarint(packedContent.length)), box(packedContent));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = decodeRaw(
+             input.getColumn(0),
+             new int[]{1},
+             new int[]{-1},
+             new int[]{0},
+             new int[]{WT_VARINT},
+             new int[]{DType.INT32.getTypeId().getNativeId()},
+             new int[]{Protobuf.ENC_DEFAULT},
+             new boolean[]{true},
+             new boolean[]{false},
+             new boolean[]{false},
+             new long[]{0},
+             new double[]{0.0},
+             new boolean[]{false},
+             new byte[][]{null},
+             new int[][]{null},
+             false)) {
+      assertNotNull(result);
+      assertEquals(DType.STRUCT, result.getType());
+      try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
+           ColumnVector vals = list.getChildColumnView(0).copyToColumnVector();
+           HostColumnVector hostVals = vals.copyToHost()) {
+        assertEquals(4, vals.getRowCount());
+        assertEquals(10, hostVals.getInt(0));
+        assertEquals(20, hostVals.getInt(1));
+        assertEquals(30, hostVals.getInt(2));
+        assertEquals(40, hostVals.getInt(3));
       }
     }
   }
@@ -2524,6 +3703,16 @@ public class ProtobufTest {
       assertEquals(1, result.getChildColumnView(1).getNumChildren());
       assertEquals(DType.INT32, result.getChildColumnView(1).getChildColumnView(0).getType());
     }
+  }
+
+  @Test
+  void testDeepNesting9Levels() {
+    verifyDeepNesting(9);
+  }
+
+  @Test
+  void testDeepNesting10Levels() {
+    verifyDeepNesting(10);
   }
 
   @Test


### PR DESCRIPTION
## `from_protobuf` kernel (part 2): repeated fields + nested messages [3/4]

Part 2 of https://github.com/NVIDIA/spark-rapids-jni/pull/4107

### Summary

Third PR in the series. Replaces the null-column fallback for repeated and nested fields with actual GPU decoding. Adds the three-phase repeated-field pipeline (count → prefix-sum offsets → combined scan → build LIST columns) and recursive nested-message decoding up to 10 levels deep, including repeated-in-nested and repeated-in-repeated. After this PR, `decode_protobuf_to_struct` covers the full protobuf type system; only benchmarks and cleanup remain.

This is a pure insertion into the orchestrator: the new pipeline sits between the scalar section from part 1 and the final assembly. Existing scalar / enum-as-string / required-field / PERMISSIVE-mode logic is unchanged.

### What is included

**Repeated / nested kernels** (`protobuf_kernels.cu`):
- `count_repeated_fields_kernel`: per-row count of repeated occurrences with packed/unpacked auto-detection.
- `scan_all_repeated_occurrences_kernel`: combined-scan kernel that records `(offset, length, row_idx)` for every top-level repeated field in one launch.
- `scan_nested_message_fields_kernel`, `scan_repeated_message_children_kernel`: location scans inside nested messages and across all occurrences of a repeated message field.
- `count_repeated_in_nested_kernel`, `scan_repeated_in_nested_kernel`: repeated fields inside nested messages, packed and unpacked.
- `compute_nested_struct_locations_kernel`, `compute_grandchild_parent_locations_kernel`, `compute_virtual_parents_for_nested_repeated_kernel`, `compute_msg_locations_from_occurrences_kernel`, `extract_strided_locations_kernel`: GPU location-arithmetic helpers that replace D2H + CPU loop + H2D round-trips.

**Three-phase repeated pipeline** (`protobuf.cu`):
- Phase A — count repeated occurrences per row, exclusive-scan into per-row offsets.
- Phase B — allocate occurrence buffers and launch one combined scan kernel covering all top-level repeated fields.
- Phase C — type-dispatched LIST-column build (varint, fixed, zigzag, float/double, bool, string, bytes, enum-as-string, repeated message).

**Recursive nested decode** (`protobuf.cu` + `protobuf_builders.cu`):
- `build_nested_struct_column`: recursive struct builder, depth-capped at `MAX_NESTED_STRUCT_DECODE_DEPTH = 10`. Handles scalar, repeated, and further-nested children at every depth.
- `build_repeated_struct_column`: repeated message → `LIST<STRUCT>` (Spark `ArrayType(StructType)`).
- `build_repeated_child_list_column`: repeated-in-repeated, producing `LIST<LIST<...>>` via virtual parents derived from outer occurrences.
- O(1) field-number lookup tables (`build_index_lookup_table`) extended to nested scan and count passes.

**Repeated variable-length builders** (`protobuf_builders.cu`):
- `build_repeated_string_column`, `build_repeated_msg_child_varlen_column`, `build_repeated_enum_string_column`, `build_repeated_msg_child_enum_string_column` for STRING / BYTES / enum-as-string variants used both at top level and inside repeated messages.

### Test coverage (27 new tests)

- **Repeated scalar**: unpacked int32, packed double + multiple fields, uint32 / uint64, mixed packed/unpacked.
- **Repeated message**: `ArrayType(StructType)`, packed-repeated children inside repeated messages, wire-type mismatch in failfast.
- **Nested message**: 1-level, 3-level, 9-level, 10-level (depth limit), packed-repeated inside nested.
- **Required-in-nested**: failfast / permissive for missing nested required fields, absent nested parent skips required-child error.
- **Repeated enum-as-string**: top-level, repeated-in-message child, nested repeated, sibling-field visibility when an occurrence has an invalid enum.
- **PERMISSIVE null propagation through nested**: invalid enum nulls whole row while keeping siblings, malformed nested enum nulls row, wrong wire type in repeated does not corrupt following row.
- **Edge cases**: large repeated field (100K elements), packed misaligned for fixed32 / fixed64.

### Follow-up PRs

4. **Benchmarks + cleanup** — NVBench cases and remaining polish.