### PR TITLE
Compile fix for missing cuco headers.

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -140,6 +140,15 @@ else()
   rapids_find_package(cudf REQUIRED)
 endif()
 
+# cuCollections
+# As of rapidsai/cudf PR #22277 (commit 5a375a3417ef70c55564bd0c4c6255a2da5dca49), libcudf
+# wraps its `cuco::cuco` link with `$<BUILD_LOCAL_INTERFACE:...>`, so the cuco headers are no
+# longer transitively exposed to downstream consumers via `find_package(cudf)`. Several
+# spark-rapids-jni sources (e.g. the hash kernels) include cudf detail headers that pull in
+# `<cuco/hash_functions.cuh>`, so we need to fetch cuco ourselves.
+include(${rapids-cmake-dir}/cpm/cuco.cmake)
+rapids_cpm_cuco()
+
 # Get the compilation flags and definitions from cudf.
 get_target_property(CUDF_CXX_FLAGS cudf::cudf CUDF_CXX_FLAGS)
 get_target_property(CUDF_CUDA_FLAGS cudf::cudf CUDF_CUDA_FLAGS)
@@ -321,6 +330,7 @@ target_link_libraries(
     cudf::cudf
     nvtx3::nvtx3-cpp
   -Wl,--no-whole-archive
+    cuco::cuco
     spdlog::spdlog_header_only
     ${ARROW_LIB}
     ${PARQUET_LIB}


### PR DESCRIPTION
Fixes #4498.

This commit changes CMakeLists.txt to fetch cuco as part of the `spark-rapids-jni` native build.

`spark-rapids-jni` used to depend on `libcudf` for its dependency on `cuco`.  rapidsai/cudf PR #22277 changed the `libcudf` build so as not to expose `cuco` as a transitive dependency for downstream projects.  This commit includes `cuco` explicitly.

(The case can be made that `spark-rapids-jni` should probably have been pulling `cuco` independently of `libcudf`, as soon as there was an explicitly dependency from the `spark-rapids-jni` hashing code.)

This commit also moves the `thirdparty/cudf` dependency to the head of `rapidsai/cudf`.