### PR TITLE
Use mirror for internal usage to avoid 429 from maven central

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -71,7 +71,8 @@ pipeline {
         GITHUB_TOKEN = credentials("github-token")
 
         ART_URL = "https://${common.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
-        MVN_MIRROR = '-s ci/settings.xml -P mirror-apache-to-urm'
+        MVN_SETTINGS = 'ci/settings.xml'
+        MVN_MIRROR = '-P mirror-apache-to-urm'
         ART_CREDS = credentials("urm_creds")
         ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME}"
 
@@ -184,7 +185,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     unstash "source_tree"
                     container('cpu') {
                         // Retrieve PROJECT_VER from pom
-                        PROJECT_VER = sh(returnStdout: true, script: "mvn -s ci/settings.xml help:evaluate -q " +
+                        PROJECT_VER = sh(returnStdout: true, script: "mvn -s ${MVN_SETTINGS} help:evaluate -q " +
                             "-Dexpression=project.version -DforceStdout | cut -d'.' -f1,2")
                         echo PROJECT_VER
                     }

--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -184,7 +184,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     unstash "source_tree"
                     container('cpu') {
                         // Retrieve PROJECT_VER from pom
-                        PROJECT_VER = sh(returnStdout: true, script: "mvn help:evaluate -q " +
+                        PROJECT_VER = sh(returnStdout: true, script: "mvn -s ci/settings.xml help:evaluate -q " +
                             "-Dexpression=project.version -DforceStdout | cut -d'.' -f1,2")
                         echo PROJECT_VER
                     }

--- a/ci/fuzz-test.sh
+++ b/ci/fuzz-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ set -ex
 WORKSPACE=${WORKSPACE:-$PWD}
 M2DIR=${M2DIR:-"$HOME/.m2"}
 
-SLF4J_VER=$(mvn help:evaluate -Dexpression=slf4j.version -q -DforceStdout)
+MVN_SETTINGS=${MVN_SETTINGS:-"ci/settings.xml"}
+SLF4J_VER=$(mvn -s "$MVN_SETTINGS" help:evaluate -Dexpression=slf4j.version -q -DforceStdout)
 CLASSPATH=${CLASSPATH:-"$WORKSPACE/target/*:$M2DIR/repository/org/slf4j/slf4j-api/$SLF4J_VER/slf4j-api-$SLF4J_VER.jar"}
 
 java -cp "$CLASSPATH" \

--- a/ci/fuzz-test.sh
+++ b/ci/fuzz-test.sh
@@ -24,7 +24,7 @@ set -ex
 WORKSPACE=${WORKSPACE:-$PWD}
 M2DIR=${M2DIR:-"$HOME/.m2"}
 
-MVN_SETTINGS=${MVN_SETTINGS:-"ci/settings.xml"}
+MVN_SETTINGS=${MVN_SETTINGS:-"$WORKSPACE/ci/settings.xml"}
 SLF4J_VER=$(mvn -s "$MVN_SETTINGS" help:evaluate -Dexpression=slf4j.version -q -DforceStdout)
 CLASSPATH=${CLASSPATH:-"$WORKSPACE/target/*:$M2DIR/repository/org/slf4j/slf4j-api/$SLF4J_VER/slf4j-api-$SLF4J_VER.jar"}
 

--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -21,7 +21,8 @@ nvidia-smi
 
 git submodule update --init --recursive
 
-MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
+MVN_SETTINGS=${MVN_SETTINGS:-"ci/settings.xml"}
+MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B -s $MVN_SETTINGS"
 # cuda12
 CUDA_VER=${CUDA_VER:-cuda`nvcc --version | sed -n 's/^.*release \([0-9]\+\)\..*$/\1/p'`}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ if [ "${CUDA_VER}" == "cuda13" ]; then
   BUILD_PROFILER="OFF"
 fi
 
-MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
+MVN_SETTINGS=${MVN_SETTINGS:-"ci/settings.xml"}
+MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B -s $MVN_SETTINGS"
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 ${MVN} verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,8 @@ else
 fi
 
 echo "Configure libcudf only to update pinned versions..."
-MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B"
+MVN_SETTINGS=${MVN_SETTINGS:-"ci/settings.xml"}
+MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -B -s $MVN_SETTINGS"
 set +e
 # phase 1:
 # Just try to update CUDF and pinned versions with no patches on top of it.


### PR DESCRIPTION
We have seen multiple intermittent mvn ops failures caused by timeouts(or code 429) while downloading mvn plugins from maven central. We suspect this may be related to sonatype applying a more aggressive rate-limiting policy to internal egress IPs.

This change is to mitigate this issue by force internal usage to target internal mirror