### PR TITLE
Update CMake to 4.0+

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -31,7 +31,7 @@ FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RE
 # Dependency versions
 # Act as default GCC toolset in the image
 ARG TOOLSET_VERSION=14
-ARG CMAKE_VERSION=3.30.4
+ARG CMAKE_VERSION=4.0.3
 ARG CCACHE_VERSION=4.11.2
 
 # Make it available at runtime and to the inherited images (e.g. Dockerfile.devel)

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
 
 # CUDF_DIR is set from the environment variable, allowing to specify
 # a custom cudf repository other than `thirdparty/cudf`.


### PR DESCRIPTION
Fixes #4556.

This commit updates CMakeLists.txt to use CMake 4.0+, and updates the Dockerfile used in the build.

This is in line with the changes in cuDF, in https://github.com/rapidsai/cudf/pull/22492.