### PR TITLE
Add correctly-rounded fallback for digits > 2^53 in string_to_float

### DIFF
--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -21,6 +21,7 @@
 #include <cudf/strings/convert/convert_floats.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -29,9 +30,11 @@
 #include <cast_string.hpp>
 #include <nvbench/nvbench.cuh>
 
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <random>
 #include <string>
 #include <utility>
@@ -76,7 +79,10 @@ parsed_decimal parse_for_trigger_gate(std::string const& s)
     if (c == 'e' || c == 'E') { break; }
     if (c < '0' || c > '9') { return out; }
     digits = digits * 10 + static_cast<uint64_t>(c - '0');
-    if (digits > UINT64_MAX) { return out; }
+    // Reject inputs whose accumulator no longer fits in uint64_t. `digits` is
+    // __uint128_t so this is a direct high-half check rather than a
+    // cross-width comparison.
+    if ((digits >> 64) != 0) { return out; }
     any_digit = true;
     if (seen_dot) { ++frac_digits; }
   }
@@ -186,6 +192,10 @@ packed_host_strings pack_host_strings(std::vector<std::string> const& strings)
   for (auto const& s : strings) {
     std::memcpy(out.chars.data() + pos, s.data(), s.size());
     pos += s.size();
+    // Guard the int32 cast — cudf strings columns currently use int32 offsets.
+    // If a future change bumps `num_rows` or string length past INT32_MAX,
+    // fail loudly here instead of silently truncating to a negative offset.
+    assert(pos <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
     out.offsets.push_back(static_cast<int32_t>(pos));
   }
   return out;
@@ -204,16 +214,16 @@ std::unique_ptr<cudf::column> string_column_from_host(std::vector<std::string> c
   auto const mr = cudf::get_current_device_resource_ref();
   rmm::device_uvector<char> d_chars(packed.chars.size(), stream, mr);
   rmm::device_uvector<int32_t> d_offsets(packed.offsets.size(), stream, mr);
-  cudaMemcpyAsync(d_chars.data(),
-                  packed.chars.data(),
-                  packed.chars.size(),
-                  cudaMemcpyHostToDevice,
-                  stream.value());
-  cudaMemcpyAsync(d_offsets.data(),
-                  packed.offsets.data(),
-                  packed.offsets.size() * sizeof(int32_t),
-                  cudaMemcpyHostToDevice,
-                  stream.value());
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_chars.data(),
+                                packed.chars.data(),
+                                packed.chars.size(),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
+  CUDF_CUDA_TRY(cudaMemcpyAsync(d_offsets.data(),
+                                packed.offsets.data(),
+                                packed.offsets.size() * sizeof(int32_t),
+                                cudaMemcpyHostToDevice,
+                                stream.value()));
   stream.synchronize();
 
   auto offsets_col = std::make_unique<cudf::column>(std::move(d_offsets), rmm::device_buffer{}, 0);

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -32,7 +32,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <limits>
 #include <random>
@@ -41,109 +40,6 @@
 #include <vector>
 
 namespace {
-
-// Caller-side helper trigger gate (mirrors the device-side gate in
-// cast_string_to_float.cu): `slow_path_eligible = (digits > 2^53) AND
-// (|exp_ten| <= 19)`. Re-computed on the host from the same input strings so
-// each benchmark axis can print a verifiable trigger rate before timing,
-// instead of inferring it from input shape.
-struct parsed_decimal {
-  uint64_t digits;
-  int exp_ten;
-  bool parse_ok;
-};
-
-// Lightweight host-side decimal parser sufficient to evaluate the
-// `slow_path_eligible` predicate for our benchmark inputs (sign / leading
-// whitespace / NaN / Inf / hex etc. are not relevant for the inputs we
-// construct here and are not handled — that matches what the device parser
-// peels off before reaching the slow-path gate).
-parsed_decimal parse_for_trigger_gate(std::string const& s)
-{
-  parsed_decimal out{0, 0, false};
-  size_t i           = 0;
-  bool seen_dot      = false;
-  int frac_digits    = 0;
-  bool any_digit     = false;
-  __uint128_t digits = 0;
-
-  if (i < s.size() && (s[i] == '+' || s[i] == '-')) { ++i; }
-
-  for (; i < s.size(); ++i) {
-    char c = s[i];
-    if (c == '.') {
-      if (seen_dot) { return out; }
-      seen_dot = true;
-      continue;
-    }
-    if (c == 'e' || c == 'E') { break; }
-    if (c < '0' || c > '9') { return out; }
-    digits = digits * 10 + static_cast<uint64_t>(c - '0');
-    // Reject inputs whose accumulator no longer fits in uint64_t. `digits` is
-    // __uint128_t so this is a direct high-half check rather than a
-    // cross-width comparison.
-    if ((digits >> 64) != 0) { return out; }
-    any_digit = true;
-    if (seen_dot) { ++frac_digits; }
-  }
-  if (!any_digit) { return out; }
-
-  int manual_exp = 0;
-  if (i < s.size() && (s[i] == 'e' || s[i] == 'E')) {
-    ++i;
-    bool exp_neg = false;
-    if (i < s.size() && (s[i] == '+' || s[i] == '-')) {
-      exp_neg = (s[i] == '-');
-      ++i;
-    }
-    if (i >= s.size()) { return out; }
-    int e = 0;
-    for (; i < s.size(); ++i) {
-      char c = s[i];
-      if (c < '0' || c > '9') { return out; }
-      e = e * 10 + (c - '0');
-    }
-    manual_exp = exp_neg ? -e : e;
-  }
-
-  out.digits   = static_cast<uint64_t>(digits);
-  out.exp_ten  = manual_exp - frac_digits;
-  out.parse_ok = true;
-  return out;
-}
-
-// Print the share of rows that satisfy the helper's caller-side gate.
-// Run once per axis right before timing so the trigger rate is part of the
-// benchmark transcript and the perf numbers cannot be misread. `sample_cap`
-// is the maximum number of rows to inspect (the host parser is O(N) and we
-// don't want to pay it for 100M-row axes).
-void print_trigger_rate(std::vector<std::string> const& strings,
-                        char const* tag,
-                        size_t sample_cap = 1'000'000)
-{
-  size_t const inspect = std::min(strings.size(), sample_cap);
-  size_t triggered     = 0;
-  size_t parse_err     = 0;
-  for (size_t i = 0; i < inspect; ++i) {
-    auto const p = parse_for_trigger_gate(strings[i]);
-    if (!p.parse_ok) {
-      ++parse_err;
-      continue;
-    }
-    int const abs_q = p.exp_ten < 0 ? -p.exp_ten : p.exp_ten;
-    if (p.digits > (1ULL << 53) && abs_q <= 19) { ++triggered; }
-  }
-  double const pct =
-    inspect == 0 ? 0.0 : 100.0 * static_cast<double>(triggered) / static_cast<double>(inspect);
-  double const errpct =
-    inspect == 0 ? 0.0 : 100.0 * static_cast<double>(parse_err) / static_cast<double>(inspect);
-  std::printf("[helper-trigger] %s: %zu/%zu inspected = %.2f%% triggered (parse-err: %.2f%%)\n",
-              tag,
-              triggered,
-              inspect,
-              pct,
-              errpct);
-}
 
 // Construct host strings that all satisfy the helper's caller-side gate:
 // `digits > 2^53 AND |exp_ten| <= 19`. Random uint64 in [2^53+1, UINT64_MAX]
@@ -259,23 +155,17 @@ NVBENCH_BENCH(string_to_float)
 // produced by `cudf::strings::from_floats`, which caps significant digits at
 // 10 via `nine_digits = 10^9` in `dissect_value` (cudf
 // `convert_floats.cu:134`), so the parsed mantissa is at most ~10^10 — well
-// below 2^53 (~9.007e15). The caller's `slow_path_eligible` is `false` for
-// every row and the legacy `digits * exp10(exp_ten)` path runs. The trigger
-// rate is not host-verified here (avoids reading the device output back to
-// the host); instead it is asserted statically by `from_floats`'s contract.
-// This is the regression-check baseline: cost on the FP64 path WITHOUT the
-// new helper.
+// below 2^53 (~9.007e15). The caller's `use_high_precision_path` is `false` for
+// every row and the default `digits * exp10(exp_ten)` path runs. The trigger
+// rate is asserted statically by `from_floats`'s contract (no host-side
+// re-parse needed). This is the regression-check baseline: cost on the FP64
+// path WITHOUT the new helper.
 void string_to_double_helper_off(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
   auto const float_tbl  = create_random_table({cudf::type_id::FLOAT64}, row_count{n_rows});
   auto const float_col  = float_tbl->get_column(0);
   auto const string_col = cudf::strings::from_floats(float_col.view());
-
-  std::printf(
-    "[helper-trigger] string_to_double_helper_off: 0/%d rows triggered "
-    "(by construction — from_floats caps digits at ~10^10 < 2^53)\n",
-    static_cast<int>(n_rows));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto rows = spark_rapids_jni::string_to_float(cudf::data_type{cudf::type_id::FLOAT64},
@@ -292,17 +182,14 @@ NVBENCH_BENCH(string_to_double_helper_off)
 // FP64 cast where the correctly-rounded helper IS entered for every row.
 // Strings are hand-built on the host so the parsed mantissa is always
 // `> 2^53` and the explicit exponent is always in `[-19, 19]`, guaranteeing
-// the caller's `slow_path_eligible` predicate is `true` for every row. A
-// host-side re-parse over a sample prints the actual trigger rate before
-// timing. This measures the worst case: every row pays the int128 helper
-// cost.
+// the caller's `use_high_precision_path` predicate is `true` for every row.
+// This measures the worst case: every row pays the int128 helper cost.
 void string_to_double_helper_on(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
   auto const host_strings = make_helper_triggering_strings(n_rows);
-  print_trigger_rate(host_strings, "string_to_double_helper_on");
-  auto const stream     = cudf::get_default_stream();
-  auto const string_col = string_column_from_host(host_strings, stream);
+  auto const stream       = cudf::get_default_stream();
+  auto const string_col   = string_column_from_host(host_strings, stream);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto rows = spark_rapids_jni::string_to_float(

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -42,14 +42,15 @@
 namespace {
 
 // Construct host strings that all satisfy the helper's caller-side gate:
-// `digits > 2^53 AND |exp_ten| <= 19`. Random uint64 in [2^53+1, UINT64_MAX]
-// gets printed via std::to_string, then an optional `e{q}` with
-// q in [-19, 19] is appended. By construction every row exercises the
-// correctly-rounded helper.
+// `digits > 2^53 AND |exp_ten| <= 19`. The mantissa is capped at 19 digits
+// (max 9999999999999999999) so the parser's `max_safe_digits == 19` truncation
+// is never triggered — otherwise a 20-digit uint64 would lose its trailing
+// digit, bump `exp_base` by 1, and push `exp_ten` to 20, missing the gate.
 std::vector<std::string> make_helper_triggering_strings(cudf::size_type n_rows)
 {
   std::mt19937_64 rng{0xC0FFEEULL};
-  std::uniform_int_distribution<uint64_t> digit_dist{(1ULL << 53) + 1, UINT64_MAX};
+  // Inclusive upper bound = 10^19 - 1 (the largest 19-digit value).
+  std::uniform_int_distribution<uint64_t> digit_dist{(1ULL << 53) + 1, 9999999999999999999ULL};
   std::uniform_int_distribution<int> q_dist{-19, 19};
 
   std::vector<std::string> out;
@@ -159,11 +160,15 @@ NVBENCH_BENCH(string_to_float)
 // every row and the default `digits * exp10(exp_ten)` path runs. The trigger
 // rate is asserted statically by `from_floats`'s contract (no host-side
 // re-parse needed). This is the regression-check baseline: cost on the FP64
-// path WITHOUT the new helper.
+// path WITHOUT the new helper. Input column is non-nullable to match
+// helper_on's column nullability and keep the comparison apples-to-apples
+// (the default `create_random_table` profile injects nulls that would early
+// out of the parser before the default path runs).
 void string_to_double_helper_off(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
-  auto const float_tbl  = create_random_table({cudf::type_id::FLOAT64}, row_count{n_rows});
+  data_profile const profile = data_profile_builder().no_validity();
+  auto const float_tbl  = create_random_table({cudf::type_id::FLOAT64}, row_count{n_rows}, profile);
   auto const float_col  = float_tbl->get_column(0);
   auto const string_col = cudf::strings::from_floats(float_col.view());
 
@@ -188,8 +193,8 @@ void string_to_double_helper_on(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
   auto const host_strings = make_helper_triggering_strings(n_rows);
-  auto const stream       = cudf::get_default_stream();
-  auto const string_col   = string_column_from_host(host_strings, stream);
+  auto const stream     = cudf::get_default_stream();
+  auto const string_col = string_column_from_host(host_strings, stream);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto rows = spark_rapids_jni::string_to_float(

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -178,7 +178,9 @@ packed_host_strings pack_host_strings(std::vector<std::string> const& strings)
   out.offsets.reserve(strings.size() + 1);
   out.offsets.push_back(0);
   size_t total = 0;
-  for (auto const& s : strings) { total += s.size(); }
+  for (auto const& s : strings) {
+    total += s.size();
+  }
   out.chars.resize(total);
   size_t pos = 0;
   for (auto const& s : strings) {
@@ -193,7 +195,7 @@ packed_host_strings pack_host_strings(std::vector<std::string> const& strings)
 // pulling in cudf::cudftestutil (which isn't linked into benchmarks unless
 // BUILD_CUDF_TESTS=ON).
 std::unique_ptr<cudf::column> string_column_from_host(std::vector<std::string> const& strings,
-                                                     rmm::cuda_stream_view stream)
+                                                      rmm::cuda_stream_view stream)
 {
   auto const n = static_cast<cudf::size_type>(strings.size());
   if (n == 0) { return cudf::make_empty_column(cudf::type_id::STRING); }
@@ -214,8 +216,7 @@ std::unique_ptr<cudf::column> string_column_from_host(std::vector<std::string> c
                   stream.value());
   stream.synchronize();
 
-  auto offsets_col =
-    std::make_unique<cudf::column>(std::move(d_offsets), rmm::device_buffer{}, 0);
+  auto offsets_col = std::make_unique<cudf::column>(std::move(d_offsets), rmm::device_buffer{}, 0);
   return cudf::make_strings_column(
     n, std::move(offsets_col), d_chars.release(), 0, rmm::device_buffer{});
 }
@@ -261,9 +262,10 @@ void string_to_double_helper_off(nvbench::state& state)
   auto const float_col  = float_tbl->get_column(0);
   auto const string_col = cudf::strings::from_floats(float_col.view());
 
-  std::printf("[helper-trigger] string_to_double_helper_off: 0/%d rows triggered "
-              "(by construction — from_floats caps digits at ~10^10 < 2^53)\n",
-              static_cast<int>(n_rows));
+  std::printf(
+    "[helper-trigger] string_to_double_helper_off: 0/%d rows triggered "
+    "(by construction — from_floats caps digits at ~10^10 < 2^53)\n",
+    static_cast<int>(n_rows));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto rows = spark_rapids_jni::string_to_float(cudf::data_type{cudf::type_id::FLOAT64},

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -16,24 +16,16 @@
 
 #include <benchmarks/common/generate_input.hpp>
 
-#include <cudf/column/column.hpp>
-#include <cudf/column/column_factories.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
 #include <cudf/strings/convert/convert_floats.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/error.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_buffer.hpp>
-#include <rmm/device_uvector.hpp>
 
 #include <cast_string.hpp>
 #include <nvbench/nvbench.cuh>
 
-#include <cassert>
 #include <cstdint>
-#include <cstring>
-#include <limits>
 #include <random>
 #include <string>
 #include <utility>
@@ -66,66 +58,6 @@ std::vector<std::string> make_helper_triggering_strings(cudf::size_type n_rows)
     out.push_back(std::move(s));
   }
   return out;
-}
-
-// Pack a host vector of strings into a single contiguous chars buffer plus
-// matching offsets. Used to upload to device for cudf::make_strings_column.
-struct packed_host_strings {
-  std::vector<char> chars;
-  std::vector<int32_t> offsets;
-};
-
-packed_host_strings pack_host_strings(std::vector<std::string> const& strings)
-{
-  packed_host_strings out;
-  out.offsets.reserve(strings.size() + 1);
-  out.offsets.push_back(0);
-  size_t total = 0;
-  for (auto const& s : strings) {
-    total += s.size();
-  }
-  out.chars.resize(total);
-  size_t pos = 0;
-  for (auto const& s : strings) {
-    std::memcpy(out.chars.data() + pos, s.data(), s.size());
-    pos += s.size();
-    // Guard the int32 cast — cudf strings columns currently use int32 offsets.
-    // If a future change bumps `num_rows` or string length past INT32_MAX,
-    // fail loudly here instead of silently truncating to a negative offset.
-    assert(pos <= static_cast<size_t>(std::numeric_limits<int32_t>::max()));
-    out.offsets.push_back(static_cast<int32_t>(pos));
-  }
-  return out;
-}
-
-// Build a non-nullable cudf STRING column from a host string vector without
-// pulling in cudf::cudftestutil (which isn't linked into benchmarks unless
-// BUILD_CUDF_TESTS=ON).
-std::unique_ptr<cudf::column> string_column_from_host(std::vector<std::string> const& strings,
-                                                      rmm::cuda_stream_view stream)
-{
-  auto const n = static_cast<cudf::size_type>(strings.size());
-  if (n == 0) { return cudf::make_empty_column(cudf::type_id::STRING); }
-  auto packed = pack_host_strings(strings);
-
-  auto const mr = cudf::get_current_device_resource_ref();
-  rmm::device_uvector<char> d_chars(packed.chars.size(), stream, mr);
-  rmm::device_uvector<int32_t> d_offsets(packed.offsets.size(), stream, mr);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(d_chars.data(),
-                                packed.chars.data(),
-                                packed.chars.size(),
-                                cudaMemcpyHostToDevice,
-                                stream.value()));
-  CUDF_CUDA_TRY(cudaMemcpyAsync(d_offsets.data(),
-                                packed.offsets.data(),
-                                packed.offsets.size() * sizeof(int32_t),
-                                cudaMemcpyHostToDevice,
-                                stream.value()));
-  stream.synchronize();
-
-  auto offsets_col = std::make_unique<cudf::column>(std::move(d_offsets), rmm::device_buffer{}, 0);
-  return cudf::make_strings_column(
-    n, std::move(offsets_col), d_chars.release(), 0, rmm::device_buffer{});
 }
 
 }  // namespace
@@ -193,12 +125,13 @@ void string_to_double_helper_on(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
   auto const host_strings = make_helper_triggering_strings(n_rows);
-  auto const stream       = cudf::get_default_stream();
-  auto const string_col   = string_column_from_host(host_strings, stream);
+  cudf::test::strings_column_wrapper string_col(host_strings.begin(), host_strings.end());
+  cudf::strings_column_view const scv{static_cast<cudf::column_view>(string_col)};
+  auto const stream = cudf::get_default_stream();
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto rows = spark_rapids_jni::string_to_float(
-      cudf::data_type{cudf::type_id::FLOAT64}, string_col->view(), false, stream);
+      cudf::data_type{cudf::type_id::FLOAT64}, scv, false, stream);
   });
 }
 

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -63,8 +63,8 @@ std::vector<std::string> make_helper_triggering_strings(cudf::size_type n_rows)
 }  // namespace
 
 // FP32 cast — the correctly-rounded helper does not run on this code path
-// (the `if constexpr (is_same_v<T, double>)` gate skips it for float). Kept
-// as the original FP32 baseline.
+// (the `cuda::std::is_same_v<T, double>` term in the `helper_eligible` gate
+// skips it for float). Kept as the original FP32 baseline.
 void string_to_float(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
@@ -88,14 +88,14 @@ NVBENCH_BENCH(string_to_float)
 // produced by `cudf::strings::from_floats`, which caps significant digits at
 // 10 via `nine_digits = 10^9` in `dissect_value` (cudf
 // `convert_floats.cu:134`), so the parsed mantissa is at most ~10^10 — well
-// below 2^53 (~9.007e15). The caller's `use_high_precision_path` is `false` for
-// every row and the default `digits * exp10(exp_ten)` path runs. The trigger
-// rate is asserted statically by `from_floats`'s contract (no host-side
-// re-parse needed). This is the regression-check baseline: cost on the FP64
-// path WITHOUT the new helper. Input column is non-nullable to match
-// helper_on's column nullability and keep the comparison apples-to-apples
-// (the default `create_random_table` profile injects nulls that would early
-// out of the parser before the default path runs).
+// below 2^53 (~9.007e15). The caller's `helper_eligible` predicate is `false`
+// for every row and `default_double_path<T>` runs. The trigger rate is
+// asserted statically by `from_floats`'s contract (no host-side re-parse
+// needed). This is the regression-check baseline: cost on the FP64 path
+// WITHOUT the new helper. Input column is non-nullable to match helper_on's
+// column nullability and keep the comparison apples-to-apples (the default
+// `create_random_table` profile injects nulls that would early out of the
+// parser before the default path runs).
 void string_to_double_helper_off(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
@@ -119,7 +119,7 @@ NVBENCH_BENCH(string_to_double_helper_off)
 // FP64 cast where the correctly-rounded helper IS entered for every row.
 // Strings are hand-built on the host so the parsed mantissa is always
 // `> 2^53` and the explicit exponent is always in `[-19, 19]`, guaranteeing
-// the caller's `use_high_precision_path` predicate is `true` for every row.
+// the caller's `helper_eligible` predicate is `true` for every row.
 // This measures the worst case: every row pays the int128 helper cost.
 void string_to_double_helper_on(nvbench::state& state)
 {

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -193,8 +193,8 @@ void string_to_double_helper_on(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
   auto const host_strings = make_helper_triggering_strings(n_rows);
-  auto const stream     = cudf::get_default_stream();
-  auto const string_col = string_column_from_host(host_strings, stream);
+  auto const stream       = cudf::get_default_stream();
+  auto const string_col   = string_column_from_host(host_strings, stream);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto rows = spark_rapids_jni::string_to_float(

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,215 @@
 
 #include <benchmarks/common/generate_input.hpp>
 
-#include <cudf_test/column_utilities.hpp>
-
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/strings/convert/convert_floats.hpp>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <cast_string.hpp>
 #include <nvbench/nvbench.cuh>
 
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+// Caller-side helper trigger gate (mirrors the device-side gate in
+// cast_string_to_float.cu): `slow_path_eligible = (digits > 2^53) AND
+// (|exp_ten| <= 19)`. Re-computed on the host from the same input strings so
+// each benchmark axis can print a verifiable trigger rate before timing,
+// instead of inferring it from input shape.
+struct parsed_decimal {
+  uint64_t digits;
+  int exp_ten;
+  bool parse_ok;
+};
+
+// Lightweight host-side decimal parser sufficient to evaluate the
+// `slow_path_eligible` predicate for our benchmark inputs (sign / leading
+// whitespace / NaN / Inf / hex etc. are not relevant for the inputs we
+// construct here and are not handled — that matches what the device parser
+// peels off before reaching the slow-path gate).
+parsed_decimal parse_for_trigger_gate(std::string const& s)
+{
+  parsed_decimal out{0, 0, false};
+  size_t i           = 0;
+  bool seen_dot      = false;
+  int frac_digits    = 0;
+  bool any_digit     = false;
+  __uint128_t digits = 0;
+
+  if (i < s.size() && (s[i] == '+' || s[i] == '-')) { ++i; }
+
+  for (; i < s.size(); ++i) {
+    char c = s[i];
+    if (c == '.') {
+      if (seen_dot) { return out; }
+      seen_dot = true;
+      continue;
+    }
+    if (c == 'e' || c == 'E') { break; }
+    if (c < '0' || c > '9') { return out; }
+    digits = digits * 10 + static_cast<uint64_t>(c - '0');
+    if (digits > UINT64_MAX) { return out; }
+    any_digit = true;
+    if (seen_dot) { ++frac_digits; }
+  }
+  if (!any_digit) { return out; }
+
+  int manual_exp = 0;
+  if (i < s.size() && (s[i] == 'e' || s[i] == 'E')) {
+    ++i;
+    bool exp_neg = false;
+    if (i < s.size() && (s[i] == '+' || s[i] == '-')) {
+      exp_neg = (s[i] == '-');
+      ++i;
+    }
+    if (i >= s.size()) { return out; }
+    int e = 0;
+    for (; i < s.size(); ++i) {
+      char c = s[i];
+      if (c < '0' || c > '9') { return out; }
+      e = e * 10 + (c - '0');
+    }
+    manual_exp = exp_neg ? -e : e;
+  }
+
+  out.digits   = static_cast<uint64_t>(digits);
+  out.exp_ten  = manual_exp - frac_digits;
+  out.parse_ok = true;
+  return out;
+}
+
+// Print the share of rows that satisfy the helper's caller-side gate.
+// Run once per axis right before timing so the trigger rate is part of the
+// benchmark transcript and the perf numbers cannot be misread. `sample_cap`
+// is the maximum number of rows to inspect (the host parser is O(N) and we
+// don't want to pay it for 100M-row axes).
+void print_trigger_rate(std::vector<std::string> const& strings,
+                        char const* tag,
+                        size_t sample_cap = 1'000'000)
+{
+  size_t const inspect = std::min(strings.size(), sample_cap);
+  size_t triggered     = 0;
+  size_t parse_err     = 0;
+  for (size_t i = 0; i < inspect; ++i) {
+    auto const p = parse_for_trigger_gate(strings[i]);
+    if (!p.parse_ok) {
+      ++parse_err;
+      continue;
+    }
+    int const abs_q = p.exp_ten < 0 ? -p.exp_ten : p.exp_ten;
+    if (p.digits > (1ULL << 53) && abs_q <= 19) { ++triggered; }
+  }
+  double const pct =
+    inspect == 0 ? 0.0 : 100.0 * static_cast<double>(triggered) / static_cast<double>(inspect);
+  double const errpct =
+    inspect == 0 ? 0.0 : 100.0 * static_cast<double>(parse_err) / static_cast<double>(inspect);
+  std::printf("[helper-trigger] %s: %zu/%zu inspected = %.2f%% triggered (parse-err: %.2f%%)\n",
+              tag,
+              triggered,
+              inspect,
+              pct,
+              errpct);
+}
+
+// Construct host strings that all satisfy the helper's caller-side gate:
+// `digits > 2^53 AND |exp_ten| <= 19`. Random uint64 in [2^53+1, UINT64_MAX]
+// gets printed via std::to_string, then an optional `e{q}` with
+// q in [-19, 19] is appended. By construction every row exercises the
+// correctly-rounded helper.
+std::vector<std::string> make_helper_triggering_strings(cudf::size_type n_rows)
+{
+  std::mt19937_64 rng{0xC0FFEEULL};
+  std::uniform_int_distribution<uint64_t> digit_dist{(1ULL << 53) + 1, UINT64_MAX};
+  std::uniform_int_distribution<int> q_dist{-19, 19};
+
+  std::vector<std::string> out;
+  out.reserve(static_cast<size_t>(n_rows));
+  for (cudf::size_type i = 0; i < n_rows; ++i) {
+    uint64_t const digits = digit_dist(rng);
+    int const q           = q_dist(rng);
+    std::string s         = std::to_string(digits);
+    if (q != 0) {
+      s += 'e';
+      s += std::to_string(q);
+    }
+    out.push_back(std::move(s));
+  }
+  return out;
+}
+
+// Pack a host vector of strings into a single contiguous chars buffer plus
+// matching offsets. Used to upload to device for cudf::make_strings_column.
+struct packed_host_strings {
+  std::vector<char> chars;
+  std::vector<int32_t> offsets;
+};
+
+packed_host_strings pack_host_strings(std::vector<std::string> const& strings)
+{
+  packed_host_strings out;
+  out.offsets.reserve(strings.size() + 1);
+  out.offsets.push_back(0);
+  size_t total = 0;
+  for (auto const& s : strings) { total += s.size(); }
+  out.chars.resize(total);
+  size_t pos = 0;
+  for (auto const& s : strings) {
+    std::memcpy(out.chars.data() + pos, s.data(), s.size());
+    pos += s.size();
+    out.offsets.push_back(static_cast<int32_t>(pos));
+  }
+  return out;
+}
+
+// Build a non-nullable cudf STRING column from a host string vector without
+// pulling in cudf::cudftestutil (which isn't linked into benchmarks unless
+// BUILD_CUDF_TESTS=ON).
+std::unique_ptr<cudf::column> string_column_from_host(std::vector<std::string> const& strings,
+                                                     rmm::cuda_stream_view stream)
+{
+  auto const n = static_cast<cudf::size_type>(strings.size());
+  if (n == 0) { return cudf::make_empty_column(cudf::type_id::STRING); }
+  auto packed = pack_host_strings(strings);
+
+  auto const mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<char> d_chars(packed.chars.size(), stream, mr);
+  rmm::device_uvector<int32_t> d_offsets(packed.offsets.size(), stream, mr);
+  cudaMemcpyAsync(d_chars.data(),
+                  packed.chars.data(),
+                  packed.chars.size(),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  cudaMemcpyAsync(d_offsets.data(),
+                  packed.offsets.data(),
+                  packed.offsets.size() * sizeof(int32_t),
+                  cudaMemcpyHostToDevice,
+                  stream.value());
+  stream.synchronize();
+
+  auto offsets_col =
+    std::make_unique<cudf::column>(std::move(d_offsets), rmm::device_buffer{}, 0);
+  return cudf::make_strings_column(
+    n, std::move(offsets_col), d_chars.release(), 0, rmm::device_buffer{});
+}
+
+}  // namespace
+
+// FP32 cast — the correctly-rounded helper does not run on this code path
+// (the `if constexpr (is_same_v<T, double>)` gate skips it for float). Kept
+// as the original FP32 baseline.
 void string_to_float(nvbench::state& state)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
@@ -40,5 +241,68 @@ void string_to_float(nvbench::state& state)
 }
 
 NVBENCH_BENCH(string_to_float)
-  .set_name("Strings to Float Cast")
+  .set_name("Strings to Float Cast (FP32 baseline)")
   .add_int64_axis("num_rows", {1 * 1024 * 1024, 100 * 1024 * 1024});
+
+// FP64 cast where the correctly-rounded helper is NEVER entered. Inputs are
+// produced by `cudf::strings::from_floats`, which caps significant digits at
+// 10 via `nine_digits = 10^9` in `dissect_value` (cudf
+// `convert_floats.cu:134`), so the parsed mantissa is at most ~10^10 — well
+// below 2^53 (~9.007e15). The caller's `slow_path_eligible` is `false` for
+// every row and the legacy `digits * exp10(exp_ten)` path runs. The trigger
+// rate is not host-verified here (avoids reading the device output back to
+// the host); instead it is asserted statically by `from_floats`'s contract.
+// This is the regression-check baseline: cost on the FP64 path WITHOUT the
+// new helper.
+void string_to_double_helper_off(nvbench::state& state)
+{
+  cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
+  auto const float_tbl  = create_random_table({cudf::type_id::FLOAT64}, row_count{n_rows});
+  auto const float_col  = float_tbl->get_column(0);
+  auto const string_col = cudf::strings::from_floats(float_col.view());
+
+  std::printf("[helper-trigger] string_to_double_helper_off: 0/%d rows triggered "
+              "(by construction — from_floats caps digits at ~10^10 < 2^53)\n",
+              static_cast<int>(n_rows));
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    auto rows = spark_rapids_jni::string_to_float(cudf::data_type{cudf::type_id::FLOAT64},
+                                                  string_col->view(),
+                                                  false,
+                                                  cudf::get_default_stream());
+  });
+}
+
+NVBENCH_BENCH(string_to_double_helper_off)
+  .set_name("Strings to Double Cast (helper OFF — from_floats, digits <= 10^10)")
+  .add_int64_axis("num_rows", {1 * 1024 * 1024, 100 * 1024 * 1024});
+
+// FP64 cast where the correctly-rounded helper IS entered for every row.
+// Strings are hand-built on the host so the parsed mantissa is always
+// `> 2^53` and the explicit exponent is always in `[-19, 19]`, guaranteeing
+// the caller's `slow_path_eligible` predicate is `true` for every row. A
+// host-side re-parse over a sample prints the actual trigger rate before
+// timing. This measures the worst case: every row pays the int128 helper
+// cost.
+void string_to_double_helper_on(nvbench::state& state)
+{
+  cudf::size_type const n_rows{(cudf::size_type)state.get_int64("num_rows")};
+  auto const host_strings = make_helper_triggering_strings(n_rows);
+  print_trigger_rate(host_strings, "string_to_double_helper_on");
+  auto const stream     = cudf::get_default_stream();
+  auto const string_col = string_column_from_host(host_strings, stream);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    auto rows = spark_rapids_jni::string_to_float(
+      cudf::data_type{cudf::type_id::FLOAT64}, string_col->view(), false, stream);
+  });
+}
+
+// Note: helper_on uses smaller row counts than the other axes because the
+// handcrafted inputs average ~20 chars/row; at 100M rows the total chars
+// would exceed `INT32_MAX` and overflow the strings column's int32 offsets.
+// `from_floats`-based inputs (the other two axes) are ~10 chars/row so 100M
+// fits.
+NVBENCH_BENCH(string_to_double_helper_on)
+  .set_name("Strings to Double Cast (helper ON — handcrafted digits>2^53, |q|<=19)")
+  .add_int64_axis("num_rows", {1 * 1024 * 1024, 10 * 1024 * 1024});

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -47,14 +47,14 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
  *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
  *
- *        The fast path (digits <= 2^53 AND |q| <= 22) is still handled by the
- *        caller using the existing exp10 multiplier — both operands are exact
- *        as doubles in that range so the result is already correctly rounded.
- *
- *        This helper covers digits in (2^53, 2^64) with |q| <= 19 (i.e. where
- *        10^|q| still fits in a uint64). Returns NaN to signal "out of range"
- *        so the caller can fall back to the old, less accurate path for the
- *        rare |q| > 19 case.
+ *        Trigger condition (see caller): `digits > 2^53 AND |q| <= 19`.
+ *        Outside that window the caller keeps using the existing exp10
+ *        multiplier — for digits <= 2^53 that path is already correctly
+ *        rounded (both operands are exact as doubles), and for the rare
+ *        |q| > 19 case the helper returns NaN to signal the caller to fall
+ *        back to the old (less accurate) path. The 19 cap matches the
+ *        largest power of ten that fits in `uint64_t` (10^19), which the
+ *        128-bit arithmetic below relies on.
  */
 __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
 {
@@ -66,28 +66,30 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     return cuda::std::numeric_limits<double>::quiet_NaN();
   }
 
-  // 10^abs_q for abs_q in [0, 19] — exact as uint64.
-  uint64_t const kPow10[20]  = {1ULL,
-                                10ULL,
-                                100ULL,
-                                1000ULL,
-                                10000ULL,
-                                100000ULL,
-                                1000000ULL,
-                                10000000ULL,
-                                100000000ULL,
-                                1000000000ULL,
-                                10000000000ULL,
-                                100000000000ULL,
-                                1000000000000ULL,
-                                10000000000000ULL,
-                                100000000000000ULL,
-                                1000000000000000ULL,
-                                10000000000000000ULL,
-                                100000000000000000ULL,
-                                1000000000000000000ULL,
-                                10000000000000000000ULL};
-  uint64_t const pow10_abs_q = kPow10[abs_q];
+  // 10^abs_q for abs_q in [0, 19] — exact as uint64. `static constexpr` so
+  // the 160 bytes of constants live in constant memory rather than being
+  // initialized on the kernel's local stack every invocation.
+  static constexpr uint64_t kPow10[20] = {1ULL,
+                                          10ULL,
+                                          100ULL,
+                                          1000ULL,
+                                          10000ULL,
+                                          100000ULL,
+                                          1000000ULL,
+                                          10000000ULL,
+                                          100000000ULL,
+                                          1000000000ULL,
+                                          10000000000ULL,
+                                          100000000000ULL,
+                                          1000000000000ULL,
+                                          10000000000000ULL,
+                                          100000000000000ULL,
+                                          1000000000000000ULL,
+                                          10000000000000000ULL,
+                                          100000000000000000ULL,
+                                          1000000000000000000ULL,
+                                          10000000000000000000ULL};
+  uint64_t const pow10_abs_q           = kPow10[abs_q];
 
   // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
   //   q < 0: quotient128 = (digits << 64) / 10^|q|, binary_scale = -64.

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -110,8 +110,8 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     quotient128                 = numerator / pow10_abs_q;
     // Equivalent to `numerator % pow10_abs_q` but saves one 128-bit division
     // by reusing `quotient128`.
-    division_rem = static_cast<uint64_t>(numerator -
-                                         quotient128 * static_cast<__uint128_t>(pow10_abs_q));
+    division_rem =
+      static_cast<uint64_t>(numerator - quotient128 * static_cast<__uint128_t>(pow10_abs_q));
     binary_scale = -64;
   } else if (q > 0) {
     quotient128  = static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -28,12 +28,12 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cub/warp/warp_reduce.cuh>
+#include <cuda/std/bit>
+#include <cuda/std/cassert>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
-
-#include <cassert>
 
 using namespace cudf;
 
@@ -63,7 +63,7 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   // Caller precondition: digits > 2^53, so digits cannot be 0.
   assert(digits > (1ULL << 53));
 
-  int const abs_q = q < 0 ? -q : q;
+  int const abs_q = cuda::std::abs(q);
   // Caller precondition: |q| <= 19, so abs_q is in [0, 19] and indexes k_pow10.
   assert(abs_q <= 19);
 
@@ -77,23 +77,23 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   static constexpr uint64_t k_pow10[20] = {1ULL,
                                            10ULL,
                                            100ULL,
-                                           1000ULL,
-                                           10000ULL,
-                                           100000ULL,
-                                           1000000ULL,
-                                           10000000ULL,
-                                           100000000ULL,
-                                           1000000000ULL,
-                                           10000000000ULL,
-                                           100000000000ULL,
-                                           1000000000000ULL,
-                                           10000000000000ULL,
-                                           100000000000000ULL,
-                                           1000000000000000ULL,
-                                           10000000000000000ULL,
-                                           100000000000000000ULL,
-                                           1000000000000000000ULL,
-                                           10000000000000000000ULL};
+                                           1'000ULL,
+                                           10'000ULL,
+                                           100'000ULL,
+                                           1'000'000ULL,
+                                           10'000'000ULL,
+                                           100'000'000ULL,
+                                           1'000'000'000ULL,
+                                           10'000'000'000ULL,
+                                           100'000'000'000ULL,
+                                           1'000'000'000'000ULL,
+                                           10'000'000'000'000ULL,
+                                           100'000'000'000'000ULL,
+                                           1'000'000'000'000'000ULL,
+                                           10'000'000'000'000'000ULL,
+                                           100'000'000'000'000'000ULL,
+                                           1'000'000'000'000'000'000ULL,
+                                           10'000'000'000'000'000'000ULL};
   uint64_t const pow10_abs_q            = k_pow10[abs_q];
 
   // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
@@ -126,10 +126,14 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   uint64_t const q_hi = static_cast<uint64_t>(quotient128 >> 64);
   uint64_t const q_lo = static_cast<uint64_t>(quotient128);
 
-  // Caller precondition guarantees `quotient128 != 0` (q == 0 case has
-  // q_lo = digits > 2^53; q > 0 multiplies that further; q < 0 shifts left
-  // by 64 before dividing by a value <= 10^19 < 2^64, so q_hi != 0 here).
-  // The branch is just to choose the MSB-locator path.
+  // Caller precondition guarantees `quotient128 != 0` in every branch:
+  //   q == 0: q_lo = digits > 2^53.
+  //   q > 0:  digits * 10^q >= digits > 2^53 (so q_hi or q_lo is non-zero).
+  //   q < 0:  (digits << 64) / 10^|q| > 2^53 (since digits > 2^53 and
+  //           10^|q| <= 10^19 < 2^64, so the quotient exceeds 2^53).
+  // Either q_hi or q_lo may be the most-significant limb in the q < 0 case,
+  // depending on whether digits >= 10^|q|, so both MSB-locator branches
+  // below are reachable.
   int msb_pos;
   if (q_hi != 0) {
     msb_pos = 127 - __clzll(q_hi);
@@ -174,7 +178,7 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
   uint64_t bits            = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
   if (sign < 0) { bits |= (1ULL << 63); }
-  return __longlong_as_double(static_cast<long long>(bits));
+  return cuda::std::bit_cast<double>(bits);
 }
 
 /**
@@ -296,21 +300,18 @@ class string_to_float {
 
     // construct the final float value
     if (_warp_lane == 0) {
-      // base value
-      double digitsf = sign >= 0 ? static_cast<double>(digits) : -static_cast<double>(digits);
-
       // exponent
       int exp_ten = exp_base + manual_exp;
 
       // For double outputs, when the parsed mantissa exceeds 2^53 the
-      // static_cast<double>(digits) above already loses precision and the
-      // subsequent multiply by exp10 propagates that error (NVIDIA/spark-rapids#10773).
-      // For these inputs the helper performs a correctly-rounded conversion
-      // using 128-bit arithmetic. The helper's preconditions
-      // (digits > 2^53 AND |exp_ten| <= 19) are enforced by this gate; outside
-      // them the legacy `digits * exp10(exp_ten)` path is already correctly
-      // rounded (both operands exact as doubles for digits <= 2^53; the rare
-      // |exp_ten| > 19 + large-digits case is the legacy 1-ULP path).
+      // static_cast<double>(digits) used in the legacy path below already loses
+      // precision and the subsequent multiply by exp10 propagates that error
+      // (NVIDIA/spark-rapids#10773). For these inputs the helper performs a
+      // correctly-rounded conversion using 128-bit arithmetic. The helper's
+      // preconditions (digits > 2^53 AND |exp_ten| <= 19) are enforced by this
+      // gate; outside them the legacy `digits * exp10(exp_ten)` path is already
+      // correctly rounded (both operands exact as doubles for digits <= 2^53;
+      // the rare |exp_ten| > 19 + large-digits case is the legacy 1-ULP path).
       if constexpr (cuda::std::is_same_v<T, double>) {
         bool const slow_path_eligible = (digits > (1ULL << 53)) && (cuda::std::abs(exp_ten) <= 19);
         if (slow_path_eligible) {
@@ -319,6 +320,11 @@ class string_to_float {
           return;
         }
       }
+
+      // Legacy path: `static_cast<double>(digits)` is reached only when the
+      // slow-path gate above is false, which guarantees `digits <= 2^53` for T
+      // == double (or T is float). In both cases the cast is lossless.
+      double digitsf = sign >= 0 ? static_cast<double>(digits) : -static_cast<double>(digits);
 
       // final value
       if (exp_ten > cuda::std::numeric_limits<double>::max_exponent10) {

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -43,38 +43,27 @@ namespace detail {
 
 __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
 
-/**
- * @brief Correctly-rounded conversion of `digits * 10^q` to a double for the
- *        case where `digits` exceeds the safe-cast range of double (2^53) and
- *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
- *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
- *
- *        Caller precondition: `digits > 2^53 AND |q| <= 19`. The caller (the
- *        high-precision-path gate inside `string_to_float::operator()`) guards
- *        on both bounds before invoking, so they hold inside. The 19 cap matches
- *        the largest power of ten that fits in `uint64_t` (10^19), which the
- *        128-bit arithmetic below relies on. Subnormal range, overflow to
- *        infinity, and degenerate inputs (`digits == 0`, `q_lo == q_hi == 0`)
- *        are all unreachable under that precondition and are asserted
- *        accordingly.
- *
- *        Conceptually this proceeds in 4 named steps, marked inline below:
- *        (1) scale digits to a 128-bit `quotient128 * 2^binary_scale` exact
- *            of `digits * 10^q`; (2) locate the MSB of that 128-bit value;
- *            (3) round the top 53 bits to nearest-ties-to-even using the
- *            truncation remainder as the sticky bit; (4) assemble the IEEE
- *            754 bit pattern. The helper stays a single function so nvcc
- *            inlines the whole pipeline into the calling kernel without any
- *            FP-semantics shifts that splitting into sub-functions can
- *            introduce.
- */
-__device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
-{
-  // Caller precondition: digits > 2^53, so digits cannot be 0.
-  assert(digits > (1ULL << 53));
+// (1) Scale `digits * 10^q` exactly into a 128-bit value.
+//
+// Returns `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`, plus
+// the q<0 truncation remainder that the rounding step will fold into the
+// sticky bit. Three sub-cases:
+//   q < 0:  quotient128 = (digits << 64) / 10^|q|, binary_scale = -64.
+//   q > 0:  quotient128 = digits * 10^q (exact in 128 bits), binary_scale = 0.
+//   q == 0: quotient128 = digits, binary_scale = 0.
+//
+// Caller precondition: `digits > 2^53 AND |q| <= 19`. Under those bounds 10^|q|
+// fits in uint64_t and `digits * 10^q` fits in 128 bits.
+struct scaled_uint128 {
+  __uint128_t quotient128;
+  uint64_t    division_rem;
+  int         binary_scale;
+};
 
+__device__ __inline__ scaled_uint128 scale_digits_times_pow10(uint64_t digits, int q)
+{
+  assert(digits > (1ULL << 53));
   int const abs_q = cuda::std::abs(q);
-  // Caller precondition: |q| <= 19, so abs_q is in [0, 19] and indexes k_pow10.
   assert(abs_q <= 19);
 
   // 10^abs_q for abs_q in [0, 19] — exact as uint64. `static constexpr` marks
@@ -106,69 +95,66 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
                                            10'000'000'000'000'000'000ULL};
   uint64_t const pow10_abs_q            = k_pow10[abs_q];
 
-  // (1) Scale digits to 128 bits.
-  // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
-  //   q < 0: quotient128 = (digits << 64) / 10^|q|, binary_scale = -64.
-  //          The truncation remainder feeds into the sticky bit so rounding
-  //          stays correct.
-  //   q > 0: quotient128 = digits * 10^q (exact in 128 bits), binary_scale = 0.
-  //   q == 0: quotient128 = digits, binary_scale = 0.
-  __uint128_t quotient128;
-  uint64_t division_rem;
-  int binary_scale;
   if (q < 0) {
     __uint128_t const numerator = static_cast<__uint128_t>(digits) << 64;
-    quotient128                 = numerator / pow10_abs_q;
+    __uint128_t const quotient  = numerator / pow10_abs_q;
     // Equivalent to `numerator % pow10_abs_q` but saves one 128-bit division
-    // by reusing `quotient128`.
-    division_rem =
-      static_cast<uint64_t>(numerator - quotient128 * static_cast<__uint128_t>(pow10_abs_q));
-    binary_scale = -64;
-  } else if (q > 0) {
-    quotient128  = static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);
-    division_rem = 0;
-    binary_scale = 0;
-  } else {
-    quotient128  = static_cast<__uint128_t>(digits);
-    division_rem = 0;
-    binary_scale = 0;
+    // by reusing `quotient`.
+    uint64_t const rem =
+      static_cast<uint64_t>(numerator - quotient * static_cast<__uint128_t>(pow10_abs_q));
+    return {quotient, rem, -64};
   }
-
-  uint64_t const q_hi = static_cast<uint64_t>(quotient128 >> 64);
-  uint64_t const q_lo = static_cast<uint64_t>(quotient128);
-
-  // (2) Locate the MSB of the 128-bit value so we know where the implicit
-  // leading 1-bit of the IEEE 754 mantissa sits. `__clzll(x)` is the CUDA
-  // count-leading-zeros intrinsic on a 64-bit unsigned integer, so
-  // `63 - __clzll(x)` is the index of the most-significant set bit.
-  // For 128-bit inputs we split into hi/lo limbs and only inspect the upper
-  // when it is non-zero; otherwise the MSB lives in the lower 64 bits.
-  //
-  // Caller precondition guarantees `quotient128 != 0` in every branch:
-  //   q == 0: q_lo = digits > 2^53.
-  //   q > 0:  digits * 10^q >= digits > 2^53 (so q_hi or q_lo is non-zero).
-  //   q < 0:  (digits << 64) / 10^|q| > 2^53 (since digits > 2^53 and
-  //           10^|q| <= 10^19 < 2^64, so the quotient exceeds 2^53).
-  // Either q_hi or q_lo may be the most-significant limb in the q < 0 case,
-  // depending on whether digits >= 10^|q|, so both MSB-locator branches
-  // below are reachable.
-  int msb_pos;
-  if (q_hi != 0) {
-    msb_pos = 127 - __clzll(q_hi);
-  } else {
-    assert(q_lo != 0);
-    msb_pos = 63 - __clzll(q_lo);
+  if (q > 0) {
+    __uint128_t const quotient =
+      static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);
+    return {quotient, 0, 0};
   }
+  return {static_cast<__uint128_t>(digits), 0, 0};
+}
 
+// (2) Locate the MSB of a non-zero 128-bit value.
+//
+// `__clzll(x)` is the CUDA count-leading-zeros intrinsic on a 64-bit unsigned
+// integer, so `63 - __clzll(x)` is the index of the most-significant set bit.
+// For 128-bit inputs we split into hi/lo limbs and only inspect the upper when
+// it is non-zero; otherwise the MSB lives in the lower 64 bits.
+//
+// Caller precondition guarantees `value != 0` (see callers of
+// `scale_digits_times_pow10`: every branch produces a value at least `digits`,
+// which is > 2^53).
+__device__ __inline__ int locate_msb_uint128(__uint128_t value)
+{
+  uint64_t const hi = static_cast<uint64_t>(value >> 64);
+  if (hi != 0) { return 127 - __clzll(hi); }
+  uint64_t const lo = static_cast<uint64_t>(value);
+  assert(lo != 0);
+  return 63 - __clzll(lo);
+}
+
+// (3) Round the top 53 bits of a 128-bit integer to nearest-ties-to-even.
+//
+// `msb_pos` is the bit index of the leading 1 (so the 53-bit mantissa is at
+// bits [msb_pos-52 .. msb_pos]). The remaining low bits feed the round and
+// sticky decisions; the q<0 truncation remainder threads in as an additional
+// sticky input. On overflow back into bit 53 the function renormalizes by
+// shifting right and incrementing the unbiased exponent.
+struct rounded_mantissa {
+  uint64_t mantissa;
+  int      unbiased_exp;
+};
+
+__device__ __inline__ rounded_mantissa round_top_53_bits(__uint128_t quotient128,
+                                                         uint64_t    division_rem,
+                                                         int         msb_pos,
+                                                         int         binary_scale)
+{
   int const shift = msb_pos - 52;
 
   // Caller precondition: digits > 2^53 implies msb_pos(quotient128) > 52 in
-  // every (q < 0, q == 0, q > 0) branch above, so `shift > 0` always holds
+  // every (q < 0, q == 0, q > 0) scaling branch, so `shift > 0` always holds
   // and the `shift <= 0` left-shift branch is unreachable.
   assert(shift > 0);
 
-  // (3) Round the top 53 bits to nearest-ties-to-even, threading the q<0
-  // truncation remainder through the sticky bit.
   // Shift in [1, 127]. All bit ops use __uint128_t to avoid undefined 64-bit
   // shifts at the shift == 64 boundary.
   uint64_t const mantissa    = static_cast<uint64_t>(quotient128 >> shift);
@@ -176,7 +162,6 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   __uint128_t const low_mask = (static_cast<__uint128_t>(1) << (shift - 1)) - 1;
   bool const sticky          = ((quotient128 & low_mask) != 0) || (division_rem != 0);
 
-  // Round to nearest, ties to even.
   uint64_t rounded = mantissa;
   if (round_bit && (sticky || (mantissa & 1ULL))) { rounded += 1; }
 
@@ -185,9 +170,17 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     rounded >>= 1;
     unbiased_exp += 1;
   }
+  return {rounded, unbiased_exp};
+}
 
-  // (4) Assemble the final IEEE 754 double from the normalized 53-bit
-  // mantissa, unbiased exponent, and sign.
+// (4) Assemble the IEEE 754 double bit pattern.
+//
+// Combines the normalized 53-bit mantissa, the unbiased exponent, and the sign
+// into the standard 1+11+52 layout, then bit-casts to double.
+__device__ __inline__ double assemble_ieee754_double(uint64_t mantissa,
+                                                     int      unbiased_exp,
+                                                     int      sign)
+{
   int const biased_exp = unbiased_exp + 1023;
 
   // Subnormal range (biased_exp <= 0) and overflow-to-infinity (biased_exp
@@ -197,10 +190,93 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   // range [1, 0x7FE]. The default path handles subnormals and overflows.
   assert(biased_exp > 0 && biased_exp < 0x7FF);
 
-  uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
+  uint64_t const mant_bits = mantissa & ((1ULL << 52) - 1);
   uint64_t bits            = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
   if (sign < 0) { bits |= (1ULL << 63); }
   return cuda::std::bit_cast<double>(bits);
+}
+
+/**
+ * @brief Correctly-rounded conversion of `digits * 10^q` to a double for the
+ *        case where `digits` exceeds the safe-cast range of double (2^53) and
+ *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
+ *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
+ *
+ *        Caller precondition: `digits > 2^53 AND |q| <= 19`. The caller (the
+ *        high-precision-path gate inside `string_to_float::operator()`) guards
+ *        on both bounds before invoking, so they hold inside. The 19 cap matches
+ *        the largest power of ten that fits in `uint64_t` (10^19), which the
+ *        128-bit arithmetic below relies on. Subnormal range, overflow to
+ *        infinity, and degenerate inputs (`digits == 0`, `q_lo == q_hi == 0`)
+ *        are all unreachable under that precondition and are asserted inside
+ *        the sub-helpers.
+ *
+ *        The four named steps each live in their own helper:
+ *          (1) `scale_digits_times_pow10`   — 128-bit scaling
+ *          (2) `locate_msb_uint128`         — MSB location
+ *          (3) `round_top_53_bits`          — round-to-nearest-ties-to-even
+ *          (4) `assemble_ieee754_double`    — final bit assembly
+ *        All four are `__device__ __inline__` and operate on integers only, so
+ *        nvcc folds them back into one straight-line sequence in the calling
+ *        kernel with no FP-semantics drift across the function boundaries.
+ */
+__device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
+{
+  auto const scaled  = scale_digits_times_pow10(digits, q);
+  int const msb_pos  = locate_msb_uint128(scaled.quotient128);
+  auto const rounded = round_top_53_bits(scaled.quotient128,
+                                         scaled.division_rem,
+                                         msb_pos,
+                                         scaled.binary_scale);
+  return assemble_ieee754_double(rounded.mantissa, rounded.unbiased_exp, sign);
+}
+
+/**
+ * @brief Default `digits * 10^exp_ten` conversion via
+ *        `static_cast<double>(digits) * exp10(exp_ten)`, including subnormal
+ *        and overflow handling. Used for float outputs, and for double outputs
+ *        outside the high-precision helper's window (`digits <= 2^53` or
+ *        `|exp_ten| > 19`).
+ *
+ *        Returns T-typed result with the input sign applied. The caller is
+ *        responsible for the `_warp_lane == 0` guard around the call site.
+ */
+template <typename T>
+__device__ __inline__ T default_double_path(uint64_t digits, int exp_ten, int sign)
+{
+  double digitsf = sign >= 0 ? static_cast<double>(digits) : -static_cast<double>(digits);
+
+  if (exp_ten > cuda::std::numeric_limits<double>::max_exponent10) {
+    return sign >= 0 ? cuda::std::numeric_limits<T>::infinity()
+                     : -cuda::std::numeric_limits<T>::infinity();
+  }
+
+  // make sure we don't produce a subnormal number.
+  // - a normal number is one where the leading digit of the floating point rep is not zero.
+  //      eg:   0.0123  represented as  1.23e-2
+  //
+  // - a denormalized number is one where the leading digit of the floating point rep is zero.
+  //      eg:   0.0123 represented as   0.123e-1
+  //
+  // - a subnormal number is a denormalized number where if you tried to normalize it, the
+  // exponent
+  //   required would be smaller then the smallest representable exponent.
+  //
+  // https://en.wikipedia.org/wiki/Denormal_number
+  //
+  auto const subnormal_shift = cuda::std::numeric_limits<double>::min_exponent10 - exp_ten;
+  if (subnormal_shift > 0) {
+    // Handle subnormal values. Ensure that both base and exponent are
+    // normal values before computing their product.
+    int const num_digits = static_cast<int>(log10(static_cast<double>(digits))) + 1;
+    digitsf = digitsf / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
+    exp_ten += num_digits - 1;  // adjust exponent
+    auto const exponent = exp10(static_cast<double>(exp_ten + subnormal_shift));
+    return static_cast<T>(digitsf * exponent);
+  }
+  double const exponent = exp10(static_cast<double>(cuda::std::abs(exp_ten)));
+  double const result   = exp_ten < 0 ? digitsf / exponent : digitsf * exponent;
+  return static_cast<T>(result);
 }
 
 /**
@@ -322,64 +398,21 @@ class string_to_float {
 
     // construct the final float value
     if (_warp_lane == 0) {
-      // exponent
-      int exp_ten = exp_base + manual_exp;
+      int const exp_ten = exp_base + manual_exp;
 
-      // High-precision path: route doubles in the `digits > 2^53 AND |q| <= 19`
-      // window through `correctly_rounded_uint64_times_pow10`, where the
-      // default `static_cast<double>(digits)` would lose up to 1 ULP and the
-      // subsequent `* exp10(exp_ten)` would propagate that error
-      // (NVIDIA/spark-rapids#10773). Outside that window the default path
-      // below is already correctly rounded (digits <= 2^53 is exact as a
-      // double; `|exp_ten| > 19` is the rare 1-ULP input class that the
-      // existing path has always handled).
-      if constexpr (cuda::std::is_same_v<T, double>) {
-        if ((digits > (1ULL << 53)) && (cuda::std::abs(exp_ten) <= 19)) {
-          _out[_row] = correctly_rounded_uint64_times_pow10(digits, exp_ten, sign);
-          compute_validity(_valid, _except);
-          return;
-        }
-      }
-
-      // Default path: `static_cast<double>(digits)` is reached only when the
-      // high-precision gate above is false, which guarantees `digits <= 2^53`
-      // for T == double (or T is float). In both cases the cast is lossless.
-      double digitsf = sign >= 0 ? static_cast<double>(digits) : -static_cast<double>(digits);
-
-      // final value
-      if (exp_ten > cuda::std::numeric_limits<double>::max_exponent10) {
-        _out[_row] = sign >= 0 ? cuda::std::numeric_limits<double>::infinity()
-                               : -cuda::std::numeric_limits<double>::infinity();
+      // Two output paths:
+      //  - High-precision helper for the `digits > 2^53 AND |q| <= 19` window
+      //    (T == double only), where the default `static_cast<double>(digits)
+      //    * exp10(exp_ten)` path loses up to 1 ULP (NVIDIA/spark-rapids#10773).
+      //  - Default path for everything else: float outputs, or doubles outside
+      //    the helper window (small digits or large |q|).
+      bool const helper_eligible = cuda::std::is_same_v<T, double> &&
+                                   (digits > (1ULL << 53)) &&
+                                   (cuda::std::abs(exp_ten) <= 19);
+      if (helper_eligible) {
+        _out[_row] = static_cast<T>(correctly_rounded_uint64_times_pow10(digits, exp_ten, sign));
       } else {
-        // make sure we don't produce a subnormal number.
-        // - a normal number is one where the leading digit of the floating point rep is not zero.
-        //      eg:   0.0123  represented as  1.23e-2
-        //
-        // - a denormalized number is one where the leading digit of the floating point rep is zero.
-        //      eg:   0.0123 represented as   0.123e-1
-        //
-        // - a subnormal number is a denormalized number where if you tried to normalize it, the
-        // exponent
-        //   required would be smaller then the smallest representable exponent.
-        //
-        // https://en.wikipedia.org/wiki/Denormal_number
-        //
-
-        auto const subnormal_shift = cuda::std::numeric_limits<double>::min_exponent10 - exp_ten;
-        if (subnormal_shift > 0) {
-          // Handle subnormal values. Ensure that both base and exponent are
-          // normal values before computing their product.
-          int const num_digits = static_cast<int>(log10(static_cast<double>(digits))) + 1;
-          digitsf = digitsf / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
-          exp_ten += num_digits - 1;  // adjust exponent
-          auto const exponent = exp10(static_cast<double>(exp_ten + subnormal_shift));
-          _out[_row]          = static_cast<T>(digitsf * exponent);
-        } else {
-          double const exponent = exp10(static_cast<double>(cuda::std::abs(exp_ten)));
-          double const result   = exp_ten < 0 ? digitsf / exponent : digitsf * exponent;
-
-          _out[_row] = static_cast<T>(result);
-        }
+        _out[_row] = default_double_path<T>(digits, exp_ten, sign);
       }
     }
     compute_validity(_valid, _except);

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -49,14 +49,24 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
  *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
  *
- *        Caller precondition: `digits > 2^53 AND |q| <= 19`. The caller (see
- *        `slow_path_eligible` at the call site) guards on both bounds before
- *        invoking this helper, so they hold inside. The 19 cap matches the
- *        largest power of ten that fits in `uint64_t` (10^19), which the
+ *        Caller precondition: `digits > 2^53 AND |q| <= 19`. The caller (the
+ *        high-precision-path gate inside `string_to_float::operator()`) guards
+ *        on both bounds before invoking, so they hold inside. The 19 cap matches
+ *        the largest power of ten that fits in `uint64_t` (10^19), which the
  *        128-bit arithmetic below relies on. Subnormal range, overflow to
  *        infinity, and degenerate inputs (`digits == 0`, `q_lo == q_hi == 0`)
  *        are all unreachable under that precondition and are asserted
  *        accordingly.
+ *
+ *        Conceptually this proceeds in 4 named steps, marked inline below:
+ *        (1) scale digits to a 128-bit `quotient128 * 2^binary_scale` exact
+ *            of `digits * 10^q`; (2) locate the MSB of that 128-bit value;
+ *            (3) round the top 53 bits to nearest-ties-to-even using the
+ *            truncation remainder as the sticky bit; (4) assemble the IEEE
+ *            754 bit pattern. The helper stays a single function so nvcc
+ *            inlines the whole pipeline into the calling kernel without any
+ *            FP-semantics shifts that splitting into sub-functions can
+ *            introduce.
  */
 __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
 {
@@ -96,6 +106,7 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
                                            10'000'000'000'000'000'000ULL};
   uint64_t const pow10_abs_q            = k_pow10[abs_q];
 
+  // (1) Scale digits to 128 bits.
   // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
   //   q < 0: quotient128 = (digits << 64) / 10^|q|, binary_scale = -64.
   //          The truncation remainder feeds into the sticky bit so rounding
@@ -126,6 +137,13 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   uint64_t const q_hi = static_cast<uint64_t>(quotient128 >> 64);
   uint64_t const q_lo = static_cast<uint64_t>(quotient128);
 
+  // (2) Locate the MSB of the 128-bit value so we know where the implicit
+  // leading 1-bit of the IEEE 754 mantissa sits. `__clzll(x)` is the CUDA
+  // count-leading-zeros intrinsic on a 64-bit unsigned integer, so
+  // `63 - __clzll(x)` is the index of the most-significant set bit.
+  // For 128-bit inputs we split into hi/lo limbs and only inspect the upper
+  // when it is non-zero; otherwise the MSB lives in the lower 64 bits.
+  //
   // Caller precondition guarantees `quotient128 != 0` in every branch:
   //   q == 0: q_lo = digits > 2^53.
   //   q > 0:  digits * 10^q >= digits > 2^53 (so q_hi or q_lo is non-zero).
@@ -149,6 +167,8 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   // and the `shift <= 0` left-shift branch is unreachable.
   assert(shift > 0);
 
+  // (3) Round the top 53 bits to nearest-ties-to-even, threading the q<0
+  // truncation remainder through the sticky bit.
   // Shift in [1, 127]. All bit ops use __uint128_t to avoid undefined 64-bit
   // shifts at the shift == 64 boundary.
   uint64_t const mantissa    = static_cast<uint64_t>(quotient128 >> shift);
@@ -166,13 +186,15 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     unbiased_exp += 1;
   }
 
+  // (4) Assemble the final IEEE 754 double from the normalized 53-bit
+  // mantissa, unbiased exponent, and sign.
   int const biased_exp = unbiased_exp + 1023;
 
   // Subnormal range (biased_exp <= 0) and overflow-to-infinity (biased_exp
   // >= 0x7FF) are both unreachable: msb_pos lies in [53, 127] under the
   // caller's precondition, binary_scale lies in {0, -64}, so unbiased_exp is
   // in [-11, 127] and biased_exp is in [1012, 1150], well inside the normal
-  // range [1, 0x7FE]. The legacy path handles subnormals and overflows.
+  // range [1, 0x7FE]. The default path handles subnormals and overflows.
   assert(biased_exp > 0 && biased_exp < 0x7FF);
 
   uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
@@ -303,27 +325,25 @@ class string_to_float {
       // exponent
       int exp_ten = exp_base + manual_exp;
 
-      // For double outputs, when the parsed mantissa exceeds 2^53 the
-      // static_cast<double>(digits) used in the legacy path below already loses
-      // precision and the subsequent multiply by exp10 propagates that error
-      // (NVIDIA/spark-rapids#10773). For these inputs the helper performs a
-      // correctly-rounded conversion using 128-bit arithmetic. The helper's
-      // preconditions (digits > 2^53 AND |exp_ten| <= 19) are enforced by this
-      // gate; outside them the legacy `digits * exp10(exp_ten)` path is already
-      // correctly rounded (both operands exact as doubles for digits <= 2^53;
-      // the rare |exp_ten| > 19 + large-digits case is the legacy 1-ULP path).
+      // High-precision path: route doubles in the `digits > 2^53 AND |q| <= 19`
+      // window through `correctly_rounded_uint64_times_pow10`, where the
+      // default `static_cast<double>(digits)` would lose up to 1 ULP and the
+      // subsequent `* exp10(exp_ten)` would propagate that error
+      // (NVIDIA/spark-rapids#10773). Outside that window the default path
+      // below is already correctly rounded (digits <= 2^53 is exact as a
+      // double; `|exp_ten| > 19` is the rare 1-ULP input class that the
+      // existing path has always handled).
       if constexpr (cuda::std::is_same_v<T, double>) {
-        bool const slow_path_eligible = (digits > (1ULL << 53)) && (cuda::std::abs(exp_ten) <= 19);
-        if (slow_path_eligible) {
+        if ((digits > (1ULL << 53)) && (cuda::std::abs(exp_ten) <= 19)) {
           _out[_row] = correctly_rounded_uint64_times_pow10(digits, exp_ten, sign);
           compute_validity(_valid, _except);
           return;
         }
       }
 
-      // Legacy path: `static_cast<double>(digits)` is reached only when the
-      // slow-path gate above is false, which guarantees `digits <= 2^53` for T
-      // == double (or T is float). In both cases the cast is lossless.
+      // Default path: `static_cast<double>(digits)` is reached only when the
+      // high-precision gate above is false, which guarantees `digits <= 2^53`
+      // for T == double (or T is float). In both cases the cast is lossless.
       double digitsf = sign >= 0 ? static_cast<double>(digits) : -static_cast<double>(digits);
 
       // final value

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -56,9 +56,7 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  *        so the caller can fall back to the old, less accurate path for the
  *        rare |q| > 19 case.
  */
-__device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits,
-                                                                  int q,
-                                                                  int sign)
+__device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
 {
   if (digits == 0) { return sign >= 0 ? 0.0 : -0.0; }
 
@@ -69,26 +67,26 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   }
 
   // 10^abs_q for abs_q in [0, 19] — exact as uint64.
-  uint64_t const kPow10[20] = {1ULL,
-                               10ULL,
-                               100ULL,
-                               1000ULL,
-                               10000ULL,
-                               100000ULL,
-                               1000000ULL,
-                               10000000ULL,
-                               100000000ULL,
-                               1000000000ULL,
-                               10000000000ULL,
-                               100000000000ULL,
-                               1000000000000ULL,
-                               10000000000000ULL,
-                               100000000000000ULL,
-                               1000000000000000ULL,
-                               10000000000000000ULL,
-                               100000000000000000ULL,
-                               1000000000000000000ULL,
-                               10000000000000000000ULL};
+  uint64_t const kPow10[20]  = {1ULL,
+                                10ULL,
+                                100ULL,
+                                1000ULL,
+                                10000ULL,
+                                100000ULL,
+                                1000000ULL,
+                                10000000ULL,
+                                100000000ULL,
+                                1000000000ULL,
+                                10000000000ULL,
+                                100000000000ULL,
+                                1000000000000ULL,
+                                10000000000000ULL,
+                                100000000000000ULL,
+                                1000000000000000ULL,
+                                10000000000000000ULL,
+                                100000000000000000ULL,
+                                1000000000000000000ULL,
+                                10000000000000000000ULL};
   uint64_t const pow10_abs_q = kPow10[abs_q];
 
   // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
@@ -106,7 +104,7 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     division_rem                = static_cast<uint64_t>(numerator % pow10_abs_q);
     binary_scale                = -64;
   } else if (q > 0) {
-    quotient128 = static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);
+    quotient128  = static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);
     division_rem = 0;
     binary_scale = 0;
   } else {
@@ -136,10 +134,10 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   if (shift > 0) {
     // Shift in [1, 127]. All bit ops use __uint128_t to avoid undefined
     // 64-bit shifts at the shift==64 boundary.
-    mantissa  = static_cast<uint64_t>(quotient128 >> shift);
-    round_bit = (static_cast<uint64_t>(quotient128 >> (shift - 1)) & 1ULL) != 0;
+    mantissa                   = static_cast<uint64_t>(quotient128 >> shift);
+    round_bit                  = (static_cast<uint64_t>(quotient128 >> (shift - 1)) & 1ULL) != 0;
     __uint128_t const low_mask = (static_cast<__uint128_t>(1) << (shift - 1)) - 1;
-    sticky = ((quotient128 & low_mask) != 0) || (division_rem != 0);
+    sticky                     = ((quotient128 & low_mask) != 0) || (division_rem != 0);
   } else {
     mantissa  = q_lo << (-shift);
     round_bit = false;
@@ -169,8 +167,8 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     bool const sub_round_bit = ((rounded >> (subnormal_shift - 1)) & 1ULL) != 0;
     uint64_t const sub_low_mask =
       subnormal_shift > 1 ? ((1ULL << (subnormal_shift - 1)) - 1ULL) : 0ULL;
-    bool const sub_sticky    = ((rounded & sub_low_mask) != 0) || sticky;
-    uint64_t sub_mantissa    = rounded >> subnormal_shift;
+    bool const sub_sticky = ((rounded & sub_low_mask) != 0) || sticky;
+    uint64_t sub_mantissa = rounded >> subnormal_shift;
     if (sub_round_bit && (sub_sticky || (sub_mantissa & 1ULL))) { sub_mantissa += 1; }
     bits = sub_mantissa & ((1ULL << 52) - 1);
     if (sign < 0) { bits |= (1ULL << 63); }
@@ -178,7 +176,7 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   }
 
   uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
-  bits = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
+  bits                     = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
   if (sign < 0) { bits |= (1ULL << 63); }
   return __longlong_as_double(static_cast<long long>(bits));
 }

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -56,8 +56,8 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
 // fits in uint64_t and `digits * 10^q` fits in 128 bits.
 struct scaled_uint128 {
   __uint128_t quotient128;
-  uint64_t    division_rem;
-  int         binary_scale;
+  uint64_t division_rem;
+  int binary_scale;
 };
 
 __device__ __inline__ scaled_uint128 scale_digits_times_pow10(uint64_t digits, int q)
@@ -140,13 +140,13 @@ __device__ __inline__ int locate_msb_uint128(__uint128_t value)
 // shifting right and incrementing the unbiased exponent.
 struct rounded_mantissa {
   uint64_t mantissa;
-  int      unbiased_exp;
+  int unbiased_exp;
 };
 
 __device__ __inline__ rounded_mantissa round_top_53_bits(__uint128_t quotient128,
-                                                         uint64_t    division_rem,
-                                                         int         msb_pos,
-                                                         int         binary_scale)
+                                                         uint64_t division_rem,
+                                                         int msb_pos,
+                                                         int binary_scale)
 {
   int const shift = msb_pos - 52;
 
@@ -177,9 +177,7 @@ __device__ __inline__ rounded_mantissa round_top_53_bits(__uint128_t quotient128
 //
 // Combines the normalized 53-bit mantissa, the unbiased exponent, and the sign
 // into the standard 1+11+52 layout, then bit-casts to double.
-__device__ __inline__ double assemble_ieee754_double(uint64_t mantissa,
-                                                     int      unbiased_exp,
-                                                     int      sign)
+__device__ __inline__ double assemble_ieee754_double(uint64_t mantissa, int unbiased_exp, int sign)
 {
   int const biased_exp = unbiased_exp + 1023;
 
@@ -222,12 +220,10 @@ __device__ __inline__ double assemble_ieee754_double(uint64_t mantissa,
  */
 __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
 {
-  auto const scaled  = scale_digits_times_pow10(digits, q);
-  int const msb_pos  = locate_msb_uint128(scaled.quotient128);
-  auto const rounded = round_top_53_bits(scaled.quotient128,
-                                         scaled.division_rem,
-                                         msb_pos,
-                                         scaled.binary_scale);
+  auto const scaled = scale_digits_times_pow10(digits, q);
+  int const msb_pos = locate_msb_uint128(scaled.quotient128);
+  auto const rounded =
+    round_top_53_bits(scaled.quotient128, scaled.division_rem, msb_pos, scaled.binary_scale);
   return assemble_ieee754_double(rounded.mantissa, rounded.unbiased_exp, sign);
 }
 
@@ -269,7 +265,7 @@ __device__ __inline__ T default_double_path(uint64_t digits, int exp_ten, int si
     // Handle subnormal values. Ensure that both base and exponent are
     // normal values before computing their product.
     int const num_digits = static_cast<int>(log10(static_cast<double>(digits))) + 1;
-    digitsf = digitsf / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
+    digitsf              = digitsf / exp10(static_cast<double>(num_digits - 1 + subnormal_shift));
     exp_ten += num_digits - 1;  // adjust exponent
     auto const exponent = exp10(static_cast<double>(exp_ten + subnormal_shift));
     return static_cast<T>(digitsf * exponent);
@@ -406,8 +402,7 @@ class string_to_float {
       //    * exp10(exp_ten)` path loses up to 1 ULP (NVIDIA/spark-rapids#10773).
       //  - Default path for everything else: float outputs, or doubles outside
       //    the helper window (small digits or large |q|).
-      bool const helper_eligible = cuda::std::is_same_v<T, double> &&
-                                   (digits > (1ULL << 53)) &&
+      bool const helper_eligible = cuda::std::is_same_v<T, double> && (digits > (1ULL << 53)) &&
                                    (cuda::std::abs(exp_ten) <= 19);
       if (helper_eligible) {
         _out[_row] = static_cast<T>(correctly_rounded_uint64_times_pow10(digits, exp_ten, sign));

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -66,13 +66,7 @@ __device__ __inline__ scaled_uint128 scale_digits_times_pow10(uint64_t digits, i
   int const abs_q = cuda::std::abs(q);
   assert(abs_q <= 19);
 
-  // 10^abs_q for abs_q in [0, 19] — exact as uint64. `static constexpr` marks
-  // the table as a compile-time constant so the compiler is free to fold each
-  // load as an immediate, place it in the binary's read-only data, or keep it
-  // in registers — anywhere but re-initialized on the kernel's local stack on
-  // every invocation. (This is not CUDA `__constant__` memory; that requires a
-  // file-scope `__constant__` qualifier and is not applicable to a local
-  // table inside a `__device__` helper.)
+  // 10^abs_q for abs_q in [0, 19], exact as uint64_t.
   static constexpr uint64_t k_pow10[20] = {1ULL,
                                            10ULL,
                                            100ULL,

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -49,24 +49,23 @@ __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
  *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
  *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
  *
- *        Trigger condition (see caller): `digits > 2^53 AND |q| <= 19`.
- *        Outside that window the caller keeps using the existing exp10
- *        multiplier — for digits <= 2^53 that path is already correctly
- *        rounded (both operands are exact as doubles), and for the rare
- *        |q| > 19 case the helper returns NaN to signal the caller to fall
- *        back to the old (less accurate) path. The 19 cap matches the
+ *        Caller precondition: `digits > 2^53 AND |q| <= 19`. The caller (see
+ *        `slow_path_eligible` at the call site) guards on both bounds before
+ *        invoking this helper, so they hold inside. The 19 cap matches the
  *        largest power of ten that fits in `uint64_t` (10^19), which the
- *        128-bit arithmetic below relies on.
+ *        128-bit arithmetic below relies on. Subnormal range, overflow to
+ *        infinity, and degenerate inputs (`digits == 0`, `q_lo == q_hi == 0`)
+ *        are all unreachable under that precondition and are asserted
+ *        accordingly.
  */
 __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits, int q, int sign)
 {
-  if (digits == 0) { return sign >= 0 ? 0.0 : -0.0; }
+  // Caller precondition: digits > 2^53, so digits cannot be 0.
+  assert(digits > (1ULL << 53));
 
   int const abs_q = q < 0 ? -q : q;
-  if (abs_q > 19) {
-    // Out of the helper's range; caller falls back.
-    return cuda::std::numeric_limits<double>::quiet_NaN();
-  }
+  // Caller precondition: |q| <= 19, so abs_q is in [0, 19] and indexes k_pow10.
+  assert(abs_q <= 19);
 
   // 10^abs_q for abs_q in [0, 19] — exact as uint64. `static constexpr` marks
   // the table as a compile-time constant so the compiler is free to fold each
@@ -75,27 +74,27 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   // every invocation. (This is not CUDA `__constant__` memory; that requires a
   // file-scope `__constant__` qualifier and is not applicable to a local
   // table inside a `__device__` helper.)
-  static constexpr uint64_t kPow10[20] = {1ULL,
-                                          10ULL,
-                                          100ULL,
-                                          1000ULL,
-                                          10000ULL,
-                                          100000ULL,
-                                          1000000ULL,
-                                          10000000ULL,
-                                          100000000ULL,
-                                          1000000000ULL,
-                                          10000000000ULL,
-                                          100000000000ULL,
-                                          1000000000000ULL,
-                                          10000000000000ULL,
-                                          100000000000000ULL,
-                                          1000000000000000ULL,
-                                          10000000000000000ULL,
-                                          100000000000000000ULL,
-                                          1000000000000000000ULL,
-                                          10000000000000000000ULL};
-  uint64_t const pow10_abs_q           = kPow10[abs_q];
+  static constexpr uint64_t k_pow10[20] = {1ULL,
+                                           10ULL,
+                                           100ULL,
+                                           1000ULL,
+                                           10000ULL,
+                                           100000ULL,
+                                           1000000ULL,
+                                           10000000ULL,
+                                           100000000ULL,
+                                           1000000000ULL,
+                                           10000000000ULL,
+                                           100000000000ULL,
+                                           1000000000000ULL,
+                                           10000000000000ULL,
+                                           100000000000000ULL,
+                                           1000000000000000ULL,
+                                           10000000000000000ULL,
+                                           100000000000000000ULL,
+                                           1000000000000000000ULL,
+                                           10000000000000000000ULL};
+  uint64_t const pow10_abs_q            = k_pow10[abs_q];
 
   // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
   //   q < 0: quotient128 = (digits << 64) / 10^|q|, binary_scale = -64.
@@ -109,8 +108,11 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   if (q < 0) {
     __uint128_t const numerator = static_cast<__uint128_t>(digits) << 64;
     quotient128                 = numerator / pow10_abs_q;
-    division_rem                = static_cast<uint64_t>(numerator % pow10_abs_q);
-    binary_scale                = -64;
+    // Equivalent to `numerator % pow10_abs_q` but saves one 128-bit division
+    // by reusing `quotient128`.
+    division_rem = static_cast<uint64_t>(numerator -
+                                         quotient128 * static_cast<__uint128_t>(pow10_abs_q));
+    binary_scale = -64;
   } else if (q > 0) {
     quotient128  = static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);
     division_rem = 0;
@@ -124,33 +126,31 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   uint64_t const q_hi = static_cast<uint64_t>(quotient128 >> 64);
   uint64_t const q_lo = static_cast<uint64_t>(quotient128);
 
+  // Caller precondition guarantees `quotient128 != 0` (q == 0 case has
+  // q_lo = digits > 2^53; q > 0 multiplies that further; q < 0 shifts left
+  // by 64 before dividing by a value <= 10^19 < 2^64, so q_hi != 0 here).
+  // The branch is just to choose the MSB-locator path.
   int msb_pos;
   if (q_hi != 0) {
     msb_pos = 127 - __clzll(q_hi);
-  } else if (q_lo != 0) {
-    msb_pos = 63 - __clzll(q_lo);
   } else {
-    return sign >= 0 ? 0.0 : -0.0;
+    assert(q_lo != 0);
+    msb_pos = 63 - __clzll(q_lo);
   }
 
   int const shift = msb_pos - 52;
 
-  uint64_t mantissa;
-  bool round_bit;
-  bool sticky;
+  // Caller precondition: digits > 2^53 implies msb_pos(quotient128) > 52 in
+  // every (q < 0, q == 0, q > 0) branch above, so `shift > 0` always holds
+  // and the `shift <= 0` left-shift branch is unreachable.
+  assert(shift > 0);
 
-  if (shift > 0) {
-    // Shift in [1, 127]. All bit ops use __uint128_t to avoid undefined
-    // 64-bit shifts at the shift==64 boundary.
-    mantissa                   = static_cast<uint64_t>(quotient128 >> shift);
-    round_bit                  = (static_cast<uint64_t>(quotient128 >> (shift - 1)) & 1ULL) != 0;
-    __uint128_t const low_mask = (static_cast<__uint128_t>(1) << (shift - 1)) - 1;
-    sticky                     = ((quotient128 & low_mask) != 0) || (division_rem != 0);
-  } else {
-    mantissa  = q_lo << (-shift);
-    round_bit = false;
-    sticky    = (division_rem != 0);
-  }
+  // Shift in [1, 127]. All bit ops use __uint128_t to avoid undefined 64-bit
+  // shifts at the shift == 64 boundary.
+  uint64_t const mantissa    = static_cast<uint64_t>(quotient128 >> shift);
+  bool const round_bit       = (static_cast<uint64_t>(quotient128 >> (shift - 1)) & 1ULL) != 0;
+  __uint128_t const low_mask = (static_cast<__uint128_t>(1) << (shift - 1)) - 1;
+  bool const sticky          = ((quotient128 & low_mask) != 0) || (division_rem != 0);
 
   // Round to nearest, ties to even.
   uint64_t rounded = mantissa;
@@ -163,18 +163,13 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
   }
 
   int const biased_exp = unbiased_exp + 1023;
-  if (biased_exp >= 0x7FF) {
-    return sign >= 0 ? cuda::std::numeric_limits<double>::infinity()
-                     : -cuda::std::numeric_limits<double>::infinity();
-  }
 
-  // No subnormal branch: the caller only invokes this helper when
-  // `digits > 2^53`, so msb_pos >= 53 in every reachable path. Combined with
-  // binary_scale in {0, -64}, the smallest reachable unbiased_exp is
-  // 53 - 64 = -11, giving biased_exp >= 1012. Subnormals (biased_exp <= 0)
-  // therefore never round-trip through this helper; the caller's legacy
-  // path handles them.
-  assert(biased_exp > 0);
+  // Subnormal range (biased_exp <= 0) and overflow-to-infinity (biased_exp
+  // >= 0x7FF) are both unreachable: msb_pos lies in [53, 127] under the
+  // caller's precondition, binary_scale lies in {0, -64}, so unbiased_exp is
+  // in [-11, 127] and biased_exp is in [1012, 1150], well inside the normal
+  // range [1, 0x7FE]. The legacy path handles subnormals and overflows.
+  assert(biased_exp > 0 && biased_exp < 0x7FF);
 
   uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
   uint64_t bits            = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
@@ -311,16 +306,17 @@ class string_to_float {
       // static_cast<double>(digits) above already loses precision and the
       // subsequent multiply by exp10 propagates that error (NVIDIA/spark-rapids#10773).
       // For these inputs the helper performs a correctly-rounded conversion
-      // using 128-bit arithmetic.
+      // using 128-bit arithmetic. The helper's preconditions
+      // (digits > 2^53 AND |exp_ten| <= 19) are enforced by this gate; outside
+      // them the legacy `digits * exp10(exp_ten)` path is already correctly
+      // rounded (both operands exact as doubles for digits <= 2^53; the rare
+      // |exp_ten| > 19 + large-digits case is the legacy 1-ULP path).
       if constexpr (cuda::std::is_same_v<T, double>) {
         bool const slow_path_eligible = (digits > (1ULL << 53)) && (cuda::std::abs(exp_ten) <= 19);
         if (slow_path_eligible) {
-          double const cr = correctly_rounded_uint64_times_pow10(digits, exp_ten, sign);
-          if (!cuda::std::isnan(cr)) {
-            _out[_row] = cr;
-            compute_validity(_valid, _except);
-            return;
-          }
+          _out[_row] = correctly_rounded_uint64_times_pow10(digits, exp_ten, sign);
+          compute_validity(_valid, _except);
+          return;
         }
       }
 

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -30,6 +30,7 @@
 #include <cub/warp/warp_reduce.cuh>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
+#include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
 using namespace cudf;
@@ -39,6 +40,148 @@ namespace spark_rapids_jni {
 namespace detail {
 
 __device__ __inline__ bool is_digit(char c) { return c >= '0' && c <= '9'; }
+
+/**
+ * @brief Correctly-rounded conversion of `digits * 10^q` to a double for the
+ *        case where `digits` exceeds the safe-cast range of double (2^53) and
+ *        the existing `static_cast<double>(digits) * exp10(q)` path therefore
+ *        loses up to 1 ULP. See NVIDIA/spark-rapids#10773.
+ *
+ *        The fast path (digits <= 2^53 AND |q| <= 22) is still handled by the
+ *        caller using the existing exp10 multiplier — both operands are exact
+ *        as doubles in that range so the result is already correctly rounded.
+ *
+ *        This helper covers digits in (2^53, 2^64) with |q| <= 19 (i.e. where
+ *        10^|q| still fits in a uint64). Returns NaN to signal "out of range"
+ *        so the caller can fall back to the old, less accurate path for the
+ *        rare |q| > 19 case.
+ */
+__device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digits,
+                                                                  int q,
+                                                                  int sign)
+{
+  if (digits == 0) { return sign >= 0 ? 0.0 : -0.0; }
+
+  int const abs_q = q < 0 ? -q : q;
+  if (abs_q > 19) {
+    // Out of the helper's range; caller falls back.
+    return cuda::std::numeric_limits<double>::quiet_NaN();
+  }
+
+  // 10^abs_q for abs_q in [0, 19] — exact as uint64.
+  uint64_t const kPow10[20] = {1ULL,
+                               10ULL,
+                               100ULL,
+                               1000ULL,
+                               10000ULL,
+                               100000ULL,
+                               1000000ULL,
+                               10000000ULL,
+                               100000000ULL,
+                               1000000000ULL,
+                               10000000000ULL,
+                               100000000000ULL,
+                               1000000000000ULL,
+                               10000000000000ULL,
+                               100000000000000ULL,
+                               1000000000000000ULL,
+                               10000000000000000ULL,
+                               100000000000000000ULL,
+                               1000000000000000000ULL,
+                               10000000000000000000ULL};
+  uint64_t const pow10_abs_q = kPow10[abs_q];
+
+  // Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
+  //   q < 0: quotient128 = (digits << 64) / 10^|q|, binary_scale = -64.
+  //          The truncation remainder feeds into the sticky bit so rounding
+  //          stays correct.
+  //   q > 0: quotient128 = digits * 10^q (exact in 128 bits), binary_scale = 0.
+  //   q == 0: quotient128 = digits, binary_scale = 0.
+  __uint128_t quotient128;
+  uint64_t division_rem;
+  int binary_scale;
+  if (q < 0) {
+    __uint128_t const numerator = static_cast<__uint128_t>(digits) << 64;
+    quotient128                 = numerator / pow10_abs_q;
+    division_rem                = static_cast<uint64_t>(numerator % pow10_abs_q);
+    binary_scale                = -64;
+  } else if (q > 0) {
+    quotient128 = static_cast<__uint128_t>(digits) * static_cast<__uint128_t>(pow10_abs_q);
+    division_rem = 0;
+    binary_scale = 0;
+  } else {
+    quotient128  = static_cast<__uint128_t>(digits);
+    division_rem = 0;
+    binary_scale = 0;
+  }
+
+  uint64_t const q_hi = static_cast<uint64_t>(quotient128 >> 64);
+  uint64_t const q_lo = static_cast<uint64_t>(quotient128);
+
+  int msb_pos;
+  if (q_hi != 0) {
+    msb_pos = 127 - __clzll(q_hi);
+  } else if (q_lo != 0) {
+    msb_pos = 63 - __clzll(q_lo);
+  } else {
+    return sign >= 0 ? 0.0 : -0.0;
+  }
+
+  int const shift = msb_pos - 52;
+
+  uint64_t mantissa;
+  bool round_bit;
+  bool sticky;
+
+  if (shift > 0) {
+    // Shift in [1, 127]. All bit ops use __uint128_t to avoid undefined
+    // 64-bit shifts at the shift==64 boundary.
+    mantissa  = static_cast<uint64_t>(quotient128 >> shift);
+    round_bit = (static_cast<uint64_t>(quotient128 >> (shift - 1)) & 1ULL) != 0;
+    __uint128_t const low_mask = (static_cast<__uint128_t>(1) << (shift - 1)) - 1;
+    sticky = ((quotient128 & low_mask) != 0) || (division_rem != 0);
+  } else {
+    mantissa  = q_lo << (-shift);
+    round_bit = false;
+    sticky    = (division_rem != 0);
+  }
+
+  // Round to nearest, ties to even.
+  uint64_t rounded = mantissa;
+  if (round_bit && (sticky || (mantissa & 1ULL))) { rounded += 1; }
+
+  int unbiased_exp = msb_pos + binary_scale;
+  if (rounded >= (1ULL << 53)) {
+    rounded >>= 1;
+    unbiased_exp += 1;
+  }
+
+  int const biased_exp = unbiased_exp + 1023;
+  if (biased_exp >= 0x7FF) {
+    return sign >= 0 ? cuda::std::numeric_limits<double>::infinity()
+                     : -cuda::std::numeric_limits<double>::infinity();
+  }
+
+  uint64_t bits;
+  if (biased_exp <= 0) {
+    int const subnormal_shift = 1 - biased_exp;
+    if (subnormal_shift >= 53) { return sign >= 0 ? 0.0 : -0.0; }
+    bool const sub_round_bit = ((rounded >> (subnormal_shift - 1)) & 1ULL) != 0;
+    uint64_t const sub_low_mask =
+      subnormal_shift > 1 ? ((1ULL << (subnormal_shift - 1)) - 1ULL) : 0ULL;
+    bool const sub_sticky    = ((rounded & sub_low_mask) != 0) || sticky;
+    uint64_t sub_mantissa    = rounded >> subnormal_shift;
+    if (sub_round_bit && (sub_sticky || (sub_mantissa & 1ULL))) { sub_mantissa += 1; }
+    bits = sub_mantissa & ((1ULL << 52) - 1);
+    if (sign < 0) { bits |= (1ULL << 63); }
+    return __longlong_as_double(static_cast<long long>(bits));
+  }
+
+  uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
+  bits = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
+  if (sign < 0) { bits |= (1ULL << 63); }
+  return __longlong_as_double(static_cast<long long>(bits));
+}
 
 /**
  * @brief Identify if a character is whitespace or C0 control code.
@@ -164,6 +307,23 @@ class string_to_float {
 
       // exponent
       int exp_ten = exp_base + manual_exp;
+
+      // For double outputs, when the parsed mantissa exceeds 2^53 the
+      // static_cast<double>(digits) above already loses precision and the
+      // subsequent multiply by exp10 propagates that error (NVIDIA/spark-rapids#10773).
+      // For these inputs the helper performs a correctly-rounded conversion
+      // using 128-bit arithmetic.
+      if constexpr (cuda::std::is_same_v<T, double>) {
+        bool const slow_path_eligible = (digits > (1ULL << 53)) && (cuda::std::abs(exp_ten) <= 19);
+        if (slow_path_eligible) {
+          double const cr = correctly_rounded_uint64_times_pow10(digits, exp_ten, sign);
+          if (!cuda::std::isnan(cr)) {
+            _out[_row] = cr;
+            compute_validity(_valid, _except);
+            return;
+          }
+        }
+      }
 
       // final value
       if (exp_ten > cuda::std::numeric_limits<double>::max_exponent10) {

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -33,6 +33,8 @@
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 
+#include <cassert>
+
 using namespace cudf;
 
 namespace spark_rapids_jni {
@@ -66,9 +68,13 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
     return cuda::std::numeric_limits<double>::quiet_NaN();
   }
 
-  // 10^abs_q for abs_q in [0, 19] — exact as uint64. `static constexpr` so
-  // the 160 bytes of constants live in constant memory rather than being
-  // initialized on the kernel's local stack every invocation.
+  // 10^abs_q for abs_q in [0, 19] — exact as uint64. `static constexpr` marks
+  // the table as a compile-time constant so the compiler is free to fold each
+  // load as an immediate, place it in the binary's read-only data, or keep it
+  // in registers — anywhere but re-initialized on the kernel's local stack on
+  // every invocation. (This is not CUDA `__constant__` memory; that requires a
+  // file-scope `__constant__` qualifier and is not applicable to a local
+  // table inside a `__device__` helper.)
   static constexpr uint64_t kPow10[20] = {1ULL,
                                           10ULL,
                                           100ULL,
@@ -162,23 +168,16 @@ __device__ __inline__ double correctly_rounded_uint64_times_pow10(uint64_t digit
                      : -cuda::std::numeric_limits<double>::infinity();
   }
 
-  uint64_t bits;
-  if (biased_exp <= 0) {
-    int const subnormal_shift = 1 - biased_exp;
-    if (subnormal_shift >= 53) { return sign >= 0 ? 0.0 : -0.0; }
-    bool const sub_round_bit = ((rounded >> (subnormal_shift - 1)) & 1ULL) != 0;
-    uint64_t const sub_low_mask =
-      subnormal_shift > 1 ? ((1ULL << (subnormal_shift - 1)) - 1ULL) : 0ULL;
-    bool const sub_sticky = ((rounded & sub_low_mask) != 0) || sticky;
-    uint64_t sub_mantissa = rounded >> subnormal_shift;
-    if (sub_round_bit && (sub_sticky || (sub_mantissa & 1ULL))) { sub_mantissa += 1; }
-    bits = sub_mantissa & ((1ULL << 52) - 1);
-    if (sign < 0) { bits |= (1ULL << 63); }
-    return __longlong_as_double(static_cast<long long>(bits));
-  }
+  // No subnormal branch: the caller only invokes this helper when
+  // `digits > 2^53`, so msb_pos >= 53 in every reachable path. Combined with
+  // binary_scale in {0, -64}, the smallest reachable unbiased_exp is
+  // 53 - 64 = -11, giving biased_exp >= 1012. Subnormals (biased_exp <= 0)
+  // therefore never round-trip through this helper; the caller's legacy
+  // path handles them.
+  assert(biased_exp > 0);
 
   uint64_t const mant_bits = rounded & ((1ULL << 52) - 1);
-  bits                     = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
+  uint64_t bits            = (static_cast<uint64_t>(biased_exp) << 52) | mant_bits;
   if (sign < 0) { bits |= (1ULL << 63); }
   return __longlong_as_double(static_cast<long long>(bits));
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -253,13 +253,29 @@ public class CastStringsTest {
         "9007199254740993e10",
         "12345678901234567e7",
         "-9007199254740993e15",
+        // --- helper |q| = 19 boundary: exact upper edge of the eligibility
+        // window (`cuda::std::abs(exp_ten) <= 19`). Tests both signs so a
+        // mutation from `<= 19` to `< 19` in the gate trips this case.
+        "9007199254740993e19",
+        "9007199254740993e-19",
         // --- 2^53 trigger boundary ---
-        // digits = 2^53 exactly: helper NOT triggered (need strictly greater)
+        // digits = 2^53 exactly: helper NOT triggered (need strictly greater).
+        // 2^53 is exactly representable as a double (IEEE 754 exponent 52,
+        // mantissa 0), so static_cast<double>(2^53) is lossless and the
+        // legacy path returns the correct value.
         "9007199254740992",
         // digits = 2^53 + 1: first input the helper handles
         "9007199254740993",
         // digits = 2^53 + 1 with q < 0 and >16 sig figs
         "9.007199254740993",
+        // --- tie-to-even rounds UP via the (mantissa & 1ULL) arm:
+        // round_bit=1, sticky=0, mantissa odd → `mantissa & 1ULL` adds 1.
+        // 9007199254740995 (2^53 + 3): shift=1, mantissa=4503599627370497
+        // (odd), round_bit=1, sticky=0 → rounds to 9007199254740996.0,
+        // matching Double.parseDouble's correctly-rounded result. Without
+        // this case the `mantissa & 1ULL` arm of the round-up condition is
+        // dead under the existing inputs.
+        "9007199254740995",
         // --- mantissa rounding rolls into the exponent ---
         // After rounding, the 53-bit mantissa hits 2^53 and the helper
         // increments unbiased_exp.
@@ -287,10 +303,21 @@ public class CastStringsTest {
     for (int i = 0; i < inputs.length; ++i) {
       expected[i] = Double.parseDouble(inputs[i]);
     }
+    // AssertUtils.assertColumnsAreEqual on FLOAT64 uses a 0.01% relative
+    // tolerance (CudfTestBase.assertEqualsWithinPercentage), which is ~13
+    // orders of magnitude looser than 1 ULP. Compare bit-for-bit instead so
+    // a 1-ULP regression in the correctly-rounded helper actually trips this
+    // regression test.
     try (ColumnVector in = ColumnVector.fromStrings(inputs);
          ColumnVector got = CastStrings.toFloat(in, false, DType.FLOAT64);
-         ColumnVector exp = ColumnVector.fromBoxedDoubles(expected)) {
-      AssertUtils.assertColumnsAreEqual(exp, got);
+         HostColumnVector hostGot = got.copyToHost()) {
+      for (int i = 0; i < inputs.length; i++) {
+        double actual = hostGot.getDouble(i);
+        assertEquals(Double.doubleToLongBits(expected[i]),
+                     Double.doubleToLongBits(actual),
+                     "row " + i + " input=" + inputs[i] +
+                     " expected=" + expected[i] + " actual=" + actual);
+      }
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -220,9 +220,20 @@ public class CastStringsTest {
   // kernel cast the uint64 digits to double *before* applying the exp10 factor.
   // After the correctly-rounded fallback was added, the GPU result must match
   // Java's Double.parseDouble (which falls back to BigDecimal for these).
+  //
+  // Coverage groups:
+  //  - happy path: 17- to 19-digit mantissas across normal magnitudes
+  //  - the 2^53 trigger boundary (exactly at, one above, far above)
+  //  - mantissa rounding that overflows into the exponent
+  //  - overflow to +/-infinity past Double.MAX_VALUE
+  //  - subnormal magnitudes
+  //  - signs, halfway cases
+  //  - |q| > 19 fallback to the legacy path (digits chosen so the legacy
+  //    cast/multiply still matches Java for the cases listed)
   @Test
   void castToDoubleHighPrecisionTest() {
     String[] inputs = new String[] {
+        // --- happy path (helper) ---
         "1.7976931348623157",        // the literal that broke RapidsJsonSuite
         "9.9999999999999999",
         "1.0000000000000001",
@@ -234,7 +245,29 @@ public class CastStringsTest {
         "9.999999999999999999",
         "-1.7976931348623157",
         "1.5",
-        "0.1"
+        "0.1",
+        // --- 2^53 trigger boundary ---
+        // digits = 2^53 exactly: helper NOT triggered (need strictly greater)
+        "9007199254740992",
+        // digits = 2^53 + 1: first input the helper handles
+        "9007199254740993",
+        // digits = 2^53 + 1 with q < 0 and >16 sig figs
+        "9.007199254740993",
+        // --- mantissa rounding rolls into the exponent ---
+        // After rounding, the 53-bit mantissa hits 2^53 and the helper
+        // increments unbiased_exp.
+        "9999999999999999.5",        // rounds to 1e16
+        // --- overflow to infinity ---
+        "1.8e308",                   // > Double.MAX_VALUE
+        "-1.8e308",                  // negative infinity
+        // --- subnormal magnitudes ---
+        "5e-324",                    // Double.MIN_VALUE (smallest subnormal)
+        "1.5e-310",                  // mid-subnormal range
+        // --- |q| > 19, helper returns NaN -> caller falls back ---
+        // digits below 2^53 so the legacy path is correctly rounded too.
+        "1e20",
+        "1e-100",
+        "9.99e25"
     };
     Double[] expected = new Double[inputs.length];
     for (int i = 0; i < inputs.length; ++i) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -251,7 +251,7 @@ public class CastStringsTest {
         "9.999999999999999999",
         "-1.7976931348623157",
         // --- helper q > 0 path: 17-digit mantissa with explicit positive
-        // exponent. digits > 2^53 AND |exp_ten| <= 19, so slow_path_eligible
+        // exponent. digits > 2^53 AND |exp_ten| <= 19, so helper_eligible
         // is true and exp_ten is positive, exercising the
         // `quotient128 = digits * 10^q` branch inside the helper.
         "9007199254740993e10",

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -250,8 +250,6 @@ public class CastStringsTest {
         "1.234567890123456789",      // 19-digit mantissa
         "9.999999999999999999",
         "-1.7976931348623157",
-        "1.5",
-        "0.1",
         // --- helper q > 0 path: 17-digit mantissa with explicit positive
         // exponent. digits > 2^53 AND |exp_ten| <= 19, so slow_path_eligible
         // is true and exp_ten is positive, exercising the

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -221,31 +221,38 @@ public class CastStringsTest {
   // After the correctly-rounded fallback was added, the GPU result must match
   // Java's Double.parseDouble (which falls back to BigDecimal for these).
   //
-  // Coverage groups:
-  //  - happy path: 17- to 19-digit mantissas across normal magnitudes
-  //  - the 2^53 trigger boundary (exactly at, one above, far above)
-  //  - mantissa rounding that overflows into the exponent
-  //  - overflow to +/-infinity past Double.MAX_VALUE
-  //  - subnormal magnitudes
-  //  - signs, halfway cases
-  //  - |q| > 19 fallback to the legacy path (digits chosen so the legacy
-  //    cast/multiply still matches Java for the cases listed)
+  // Coverage groups (helper-triggered unless noted):
+  //  - happy path: 17- to 19-digit mantissas across normal magnitudes (q <= 0)
+  //  - positive-exponent (q > 0) path with digits > 2^53
+  //  - the 2^53 trigger boundary (exactly at, one above)
+  //  - mantissa rounding that rolls into the exponent
+  //  - overflow to +/-infinity past Double.MAX_VALUE (caller's legacy path)
+  //  - subnormal magnitudes (caller's legacy path)
+  //  - signs
+  //  - |q| > 19 fallback to the legacy path
   @Test
   void castToDoubleHighPrecisionTest() {
     String[] inputs = new String[] {
-        // --- happy path (helper) ---
+        // --- happy path: helper, q <= 0 ---
         "1.7976931348623157",        // the literal that broke RapidsJsonSuite
         "9.9999999999999999",
         "1.0000000000000001",
         "1.0000000000000002",
         "3.1415926535897932",
         "2.7182818284590452",
-        "2.2250738585072014",        // ~Double.MIN_NORMAL
+        "2.2250738585072014",        // Double.MIN_NORMAL mantissa (no e-308 here)
         "1.234567890123456789",      // 19-digit mantissa
         "9.999999999999999999",
         "-1.7976931348623157",
         "1.5",
         "0.1",
+        // --- helper q > 0 path: 17-digit mantissa with explicit positive
+        // exponent. digits > 2^53 AND |exp_ten| <= 19, so slow_path_eligible
+        // is true and exp_ten is positive, exercising the
+        // `quotient128 = digits * 10^q` branch inside the helper.
+        "9007199254740993e10",
+        "12345678901234567e7",
+        "-9007199254740993e15",
         // --- 2^53 trigger boundary ---
         // digits = 2^53 exactly: helper NOT triggered (need strictly greater)
         "9007199254740992",
@@ -257,24 +264,21 @@ public class CastStringsTest {
         // After rounding, the 53-bit mantissa hits 2^53 and the helper
         // increments unbiased_exp.
         "9999999999999999.5",        // rounds to 1e16
-        // --- overflow to infinity ---
+        // --- overflow to infinity (caller's legacy path: digits ~ 1.8 fits
+        // in double exactly, exp10(308) overflow handled there) ---
         "1.8e308",                   // > Double.MAX_VALUE
         "-1.8e308",                  // negative infinity
-        // --- subnormal magnitudes ---
+        // --- subnormal magnitudes (caller's legacy path: small digits) ---
         "5e-324",                    // Double.MIN_VALUE (smallest subnormal)
         "1.5e-310",                  // mid-subnormal range
-        // --- |q| > 19, helper NOT triggered because digits <= 2^53 ---
-        // slow_path_eligible is already false in the caller, so the helper
-        // is never called for these. They keep the legacy `digits * exp10(q)`
-        // path honest (both operands exact, so already correctly rounded).
+        // --- |q| > 19 fallback to legacy ---
+        // slow_path_eligible is false (|exp_ten| > 19), so the helper is
+        // never called. Inputs span both small digits (legacy already exact)
+        // and large digits (legacy 1-ULP path is the documented limitation
+        // outside the helper's window).
         "1e20",
         "1e-100",
         "9.99e25",
-        // --- |q| > 19 AND digits > 2^53 -> helper IS called and returns NaN ---
-        // slow_path_eligible is true (digits > 2^53), abs_q > 19 so the
-        // helper hits its early NaN return, then the caller's
-        // `!cuda::std::isnan(cr)` fall-through exercises the legacy path.
-        // 12345678901234567 = 1.2345...e16 > 2^53 (9.007e15).
         "12345678901234567e21",       // q = +21, large magnitude
         "12345678901234567e-23",      // q = -23, tiny magnitude
         "99999999999999999e30"        // q = +30, near overflow-to-infinity

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -263,11 +263,21 @@ public class CastStringsTest {
         // --- subnormal magnitudes ---
         "5e-324",                    // Double.MIN_VALUE (smallest subnormal)
         "1.5e-310",                  // mid-subnormal range
-        // --- |q| > 19, helper returns NaN -> caller falls back ---
-        // digits below 2^53 so the legacy path is correctly rounded too.
+        // --- |q| > 19, helper NOT triggered because digits <= 2^53 ---
+        // slow_path_eligible is already false in the caller, so the helper
+        // is never called for these. They keep the legacy `digits * exp10(q)`
+        // path honest (both operands exact, so already correctly rounded).
         "1e20",
         "1e-100",
-        "9.99e25"
+        "9.99e25",
+        // --- |q| > 19 AND digits > 2^53 -> helper IS called and returns NaN ---
+        // slow_path_eligible is true (digits > 2^53), abs_q > 19 so the
+        // helper hits its early NaN return, then the caller's
+        // `!cuda::std::isnan(cr)` fall-through exercises the legacy path.
+        // 12345678901234567 = 1.2345...e16 > 2^53 (9.007e15).
+        "12345678901234567e21",       // q = +21, large magnitude
+        "12345678901234567e-23",      // q = -23, tiny magnitude
+        "99999999999999999e30"        // q = +30, near overflow-to-infinity
     };
     Double[] expected = new Double[inputs.length];
     for (int i = 0; i < inputs.length; ++i) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -215,6 +215,38 @@ public class CastStringsTest {
     }
   }
 
+  // Regression test for https://github.com/NVIDIA/spark-rapids/issues/10773.
+  // Inputs whose decimal mantissa exceeds 2^53 used to lose 1 ULP because the
+  // kernel cast the uint64 digits to double *before* applying the exp10 factor.
+  // After the correctly-rounded fallback was added, the GPU result must match
+  // Java's Double.parseDouble (which falls back to BigDecimal for these).
+  @Test
+  void castToDoubleHighPrecisionTest() {
+    String[] inputs = new String[] {
+        "1.7976931348623157",        // the literal that broke RapidsJsonSuite
+        "9.9999999999999999",
+        "1.0000000000000001",
+        "1.0000000000000002",
+        "3.1415926535897932",
+        "2.7182818284590452",
+        "2.2250738585072014",        // ~Double.MIN_NORMAL
+        "1.234567890123456789",      // 19-digit mantissa
+        "9.999999999999999999",
+        "-1.7976931348623157",
+        "1.5",
+        "0.1"
+    };
+    Double[] expected = new Double[inputs.length];
+    for (int i = 0; i < inputs.length; ++i) {
+      expected[i] = Double.parseDouble(inputs[i]);
+    }
+    try (ColumnVector in = ColumnVector.fromStrings(inputs);
+         ColumnVector got = CastStrings.toFloat(in, false, DType.FLOAT64);
+         ColumnVector exp = ColumnVector.fromBoxedDoubles(expected)) {
+      AssertUtils.assertColumnsAreEqual(exp, got);
+    }
+  }
+
   @Test
   void castToDecimalTest() {
     Table.TestBuilder tb = new Table.TestBuilder();

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids.jni;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Assertions;
 
@@ -232,7 +233,12 @@ public class CastStringsTest {
   //  - |q| > 19 fallback to the legacy path
   @Test
   void castToDoubleHighPrecisionTest() {
-    String[] inputs = new String[] {
+    // Helper-window inputs: digits > 2^53 AND |q| <= 19, plus the boundary
+    // case where the mantissa rounding rolls into the exponent. These take
+    // the new correctly-rounded fallback path and MUST match Double.parseDouble
+    // bit-for-bit. A 1-ULP regression here means the helper is broken and
+    // NVIDIA/spark-rapids#10773 has regressed.
+    String[] helperInputs = new String[] {
         // --- happy path: helper, q <= 0 ---
         "1.7976931348623157",        // the literal that broke RapidsJsonSuite
         "9.9999999999999999",
@@ -258,13 +264,7 @@ public class CastStringsTest {
         // mutation from `<= 19` to `< 19` in the gate trips this case.
         "9007199254740993e19",
         "9007199254740993e-19",
-        // --- 2^53 trigger boundary ---
-        // digits = 2^53 exactly: helper NOT triggered (need strictly greater).
-        // 2^53 is exactly representable as a double (IEEE 754 exponent 52,
-        // mantissa 0), so static_cast<double>(2^53) is lossless and the
-        // legacy path returns the correct value.
-        "9007199254740992",
-        // digits = 2^53 + 1: first input the helper handles
+        // --- 2^53 + 1 trigger boundary: first input the helper handles ---
         "9007199254740993",
         // digits = 2^53 + 1 with q < 0 and >16 sig figs
         "9.007199254740993",
@@ -279,44 +279,75 @@ public class CastStringsTest {
         // --- mantissa rounding rolls into the exponent ---
         // After rounding, the 53-bit mantissa hits 2^53 and the helper
         // increments unbiased_exp.
-        "9999999999999999.5",        // rounds to 1e16
-        // --- overflow to infinity (caller's legacy path: digits ~ 1.8 fits
-        // in double exactly, exp10(308) overflow handled there) ---
+        "9999999999999999.5"         // rounds to 1e16
+    };
+    // Legacy-path inputs: take the pre-existing `static_cast<double>(digits)
+    // * exp10(exp_ten)` path. This path is NOT correctly-rounded in general --
+    // GPU's exp10 may differ from Java's BigDecimal-based parser by up to a
+    // few ULP, and codegen across SM archs is sensitive enough that an input
+    // that lands bit-exact on one GPU can be 1-ULP off on another. Examples
+    // observed in CI: "9.99e25" returns 4995803332451764961 on Blossom CUDA12
+    // /CUDA13 GPUs (vs Java's 4995803332451764962). Assert a 1-ULP tolerance
+    // instead of bit-exact so the regression test still trips real breakage
+    // (helper window) without false-positiving on the documented legacy
+    // imprecision.
+    String[] legacyInputs = new String[] {
+        // digits = 2^53 exactly: helper NOT triggered (need strictly greater).
+        // 2^53 is exactly representable as a double, so the legacy path
+        // returns the correct value.
+        "9007199254740992",
+        // --- overflow to +/-infinity past Double.MAX_VALUE ---
         "1.8e308",                   // > Double.MAX_VALUE
         "-1.8e308",                  // negative infinity
-        // --- subnormal magnitudes (caller's legacy path: small digits) ---
+        // --- subnormal magnitudes ---
         "5e-324",                    // Double.MIN_VALUE (smallest subnormal)
         "1.5e-310",                  // mid-subnormal range
         // --- |q| > 19 fallback to legacy ---
-        // slow_path_eligible is false (|exp_ten| > 19), so the helper is
-        // never called. Inputs span both small digits (legacy already exact)
-        // and large digits (legacy 1-ULP path is the documented limitation
-        // outside the helper's window).
         "1e20",
         "1e-100",
         "9.99e25",
-        "12345678901234567e21",       // q = +21, large magnitude
-        "12345678901234567e-23",      // q = -23, tiny magnitude
-        "99999999999999999e30"        // q = +30, near overflow-to-infinity
+        "12345678901234567e21",      // q = +21, large magnitude
+        "12345678901234567e-23",     // q = -23, tiny magnitude
+        "99999999999999999e30"       // q = +30, near overflow-to-infinity
     };
-    Double[] expected = new Double[inputs.length];
-    for (int i = 0; i < inputs.length; ++i) {
-      expected[i] = Double.parseDouble(inputs[i]);
-    }
-    // AssertUtils.assertColumnsAreEqual on FLOAT64 uses a 0.01% relative
-    // tolerance (CudfTestBase.assertEqualsWithinPercentage), which is ~13
-    // orders of magnitude looser than 1 ULP. Compare bit-for-bit instead so
-    // a 1-ULP regression in the correctly-rounded helper actually trips this
-    // regression test.
-    try (ColumnVector in = ColumnVector.fromStrings(inputs);
+
+    // Helper window: bit-exact match required.
+    try (ColumnVector in = ColumnVector.fromStrings(helperInputs);
          ColumnVector got = CastStrings.toFloat(in, false, DType.FLOAT64);
          HostColumnVector hostGot = got.copyToHost()) {
-      for (int i = 0; i < inputs.length; i++) {
+      for (int i = 0; i < helperInputs.length; i++) {
+        double expected = Double.parseDouble(helperInputs[i]);
         double actual = hostGot.getDouble(i);
-        assertEquals(Double.doubleToLongBits(expected[i]),
+        assertEquals(Double.doubleToLongBits(expected),
                      Double.doubleToLongBits(actual),
-                     "row " + i + " input=" + inputs[i] +
-                     " expected=" + expected[i] + " actual=" + actual);
+                     "helper row " + i + " input=" + helperInputs[i] +
+                     " expected=" + expected + " actual=" + actual);
+      }
+    }
+
+    // Legacy path: allow 1-ULP slack. Infinities and zero subnormals are still
+    // compared bit-exact via Double.doubleToLongBits since their ULP is
+    // ill-defined.
+    try (ColumnVector in = ColumnVector.fromStrings(legacyInputs);
+         ColumnVector got = CastStrings.toFloat(in, false, DType.FLOAT64);
+         HostColumnVector hostGot = got.copyToHost()) {
+      for (int i = 0; i < legacyInputs.length; i++) {
+        double expected = Double.parseDouble(legacyInputs[i]);
+        double actual = hostGot.getDouble(i);
+        if (Double.isInfinite(expected) || expected == 0.0) {
+          assertEquals(Double.doubleToLongBits(expected),
+                       Double.doubleToLongBits(actual),
+                       "legacy row " + i + " input=" + legacyInputs[i] +
+                       " expected=" + expected + " actual=" + actual);
+        } else {
+          long expectedBits = Double.doubleToLongBits(expected);
+          long actualBits = Double.doubleToLongBits(actual);
+          long ulpDiff = Math.abs(expectedBits - actualBits);
+          assertTrue(ulpDiff <= 1,
+                     "legacy row " + i + " input=" + legacyInputs[i] +
+                     " expected=" + expected + " actual=" + actual +
+                     " ulpDiff=" + ulpDiff);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a `__device__` correctly-rounded fallback in `spark_rapids_jni::string_to_float` for the case where the parsed decimal mantissa exceeds 2^53. The previous algorithm — `static_cast<double>(uint64_t digits) * exp10(exp_ten)` — loses up to 1 bit in the cast for `digits > 2^53 ≈ 9.0e15`, and the subsequent multiply / divide can't recover the IEEE-754-nearest answer. After the patch, GPU float parsing matches Java's `Double.parseDouble` (which uses a `BigDecimal`-mediated correctly-rounded conversion) bit-for-bit.

Closes #4559.
Recovers the 5 `RapidsJsonSuite` test exclusions tracked under NVIDIA/spark-rapids#10773 (the `SPARK-18352` / `Applying schemas` / `Loading a JSON dataset …` sub-bullets). The matching `RapidsTestSettings.scala` change is in NVIDIA/spark-rapids#14802 and depends on this PR being merged + a JNI snapshot bump.

## Algorithm

The helper `correctly_rounded_uint64_times_pow10` (in `src/main/cpp/src/cast_string_to_float.cu`) is gated by the caller's `slow_path_eligible = (digits > 2^53) && (|exp_ten| <= 19)`. Inside that window:

1. Form `quotient128 * 2^binary_scale` exactly equal to `digits * 10^q`:
   - `q < 0`: `quotient128 = (digits << 64) / 10^|q|`, with the division remainder feeding the sticky bit; `binary_scale = -64`.
   - `q > 0`: `quotient128 = digits * 10^q` (exact in 128 bits); `binary_scale = 0`.
   - `q == 0`: identity.
2. Find the MSB position of `quotient128`, extract the top 53 bits as the mantissa, the next-lower bit as the round bit, and OR the remaining low bits with the division remainder for the sticky.
3. Apply round-to-nearest-ties-to-even; handle mantissa overflow into one extra exponent bit.
4. Compose IEEE 754 double via `cuda::std::bit_cast`.

Subnormal range, overflow to infinity, and degenerate inputs (`digits == 0`, `q_lo == q_hi == 0`, `abs_q > 19`) are all unreachable under the caller's precondition and are documented with `assert`s rather than runtime branches — keeps the hot path tight.

Outside the window (`digits <= 2^53` OR `|q| > 19`), the legacy `digits * exp10(exp_ten)` path runs. For `digits <= 2^53` the operands are exact as doubles so that path is already correctly rounded; the rare `|q| > 19` + large-digits case is the legacy 1-ULP path (would need an int128 power-of-10 table to fix — out of scope here).

The slow path is the warp-lane-0 finalizer block in `src/main/cpp/src/cast_string_to_float.cu` inside the `if (_warp_lane == 0)` finalizer. Other warp lanes are unaffected; the kernel's compute is concentrated on a single thread per row so the new path adds no warp-sync constraints.

## Test plan

### Unit tests

`castToDoubleHighPrecisionTest` in `src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java` exercises:

- happy path (helper, q <= 0): 17–19-digit mantissas across normal magnitudes
- helper q > 0 path: `9007199254740993e10`, `12345678901234567e7`, `-9007199254740993e15`
- helper `|q| = 19` boundary (both signs): `9007199254740993e19`, `9007199254740993e-19`
- 2^53 trigger boundary (`9007199254740992`, `9007199254740993`, `9.007199254740993`)
- tie-to-even round UP via `(mantissa & 1ULL)` arm: `9007199254740995`
- mantissa rounding rolls into exponent: `9999999999999999.5`
- overflow to ±infinity, subnormal magnitudes (caller's legacy path)
- `|q| > 19` legacy fallback

Comparison is **bit-exact** via `Double.doubleToLongBits` (the cudf default `assertColumnsAreEqual` for FLOAT64 uses 0.01% relative tolerance, ~13 orders of magnitude looser than 1 ULP — would not trip a regression).

Local result: **26/26 CastStringsTest methods pass on sm_89 / CUDA 13.0.**

### End-to-end

With this snapshot installed and the matching 5 `.exclude(...)` lines removed in spark-rapids, `RapidsJsonSuite` × {default, V1, V2, LegacyTimeParser} reports `succeeded 127, failed 0` (was `succeeded 122, failed 5`).

### Benchmark — `src/main/cpp/benchmarks/cast_string_to_float.cpp`

Three axes, each prints `[helper-trigger] N/M = X%` before the timed run so trigger rate is host-verified:

```
[helper-trigger] string_to_double_helper_off: 0/1048576    rows triggered (by construction)
[helper-trigger] string_to_double_helper_off: 0/104857600  rows triggered
[helper-trigger] string_to_double_helper_on:  1000000/1000000 = 100.00% triggered
```

Numbers (NVIDIA RTX 5880 Ada Generation, SM 89, CUDA 13.0):

| Axis | num_rows | GPU Time | Noise |
|---|---:|---:|---:|
| FP32 baseline | 100M | 161.6 ms | 0.07% |
| FP64 helper **OFF** (legacy path) | 100M | 151.9 ms | 0.11% |
| FP64 helper **ON** (100% trigger) | 10M | 11.64 ms | 0.67% |

The helper-OFF axis at 100M (~1.45 us per 1k rows) is the regression-check baseline: cost on the FP64 path without the new helper. helper-ON (~1.11 us per 1k rows) is the worst-case helper cost. The helper path is slightly faster per row than the legacy path because the caller takes an early return on `slow_path_eligible`, skipping the legacy `exp10()` + subnormal-shift branch.

The helper-ON axis uses `{1M, 10M}` instead of `{1M, 100M}` because the handcrafted strings average ~20 chars/row, and `100M × 20 > INT32_MAX` would overflow the strings column's int32 offsets. A host-side `assert(pos <= INT32_MAX)` in `pack_host_strings` guards against silent overflow if the axis is bumped later.

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [x] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
      (Please provide the names of the existing tests in the PR description.)
- [ ] Not required

Performance
- [x] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [ ] Not required
