### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.06 to release/26.06 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -97,7 +97,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "5c1b11ec5893a6d4fa4aff53a55b68256e07483d",
+      "git_tag" : "b52ff08416f997fe4ada64a594b1df6af48507ec",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.06"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: 5a5bcb4999e41671de92b56c90a25d47d588e054, cudf commit SHA: https://github.com/rapidsai/cudf/commit/3249ba8eef13179b18c91107f3cc0af70348a196

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.