### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.06 to release/26.06 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -97,7 +97,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "b52ff08416f997fe4ada64a594b1df6af48507ec",
+      "git_tag" : "acc2fb009c8ed14e1dc2c59c5aeda48406ec5370",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.06"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: 3e1a95c0b4bf17c5dc56ee9adf9e6c6fa765a6e0, cudf commit SHA: https://github.com/rapidsai/cudf/commit/2dba3ec1844aba5705798343f092027a9cae73eb

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.