### PR TITLE
Harden the `noexcept` `deallocate()` path for SparkResourceAdaptorJNI

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -2865,7 +2865,7 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_shutdownLoggerNative(JNIEn
 }
 
 /**
- * Test utility for RmmSparkDeallocationFailureTest.
+ * Test utility for RmmSparkDeallocationFailureTest.Child.
  *
  * This deliberately drives spark_resource_adaptor_impl::deallocate() into its fatal exception path.
  * It installs a test logger that throws when the normal DEALLOC status is logged, constructs a
@@ -2877,7 +2877,7 @@ Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_shutdownLoggerNative(JNIEn
  * terminates.
  */
 JNIEXPORT void JNICALL
-Java_com_nvidia_spark_rapids_jni_RmmSparkDeallocationFailureTest_triggerDeallocationFailureForTesting(
+Java_com_nvidia_spark_rapids_jni_RmmSparkDeallocationFailureTest_00024Child_triggerDeallocationFailureForTesting(
   JNIEnv* env, jclass)
 {
   JNI_TRY

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -22,6 +22,7 @@
 #include <jni_cccl_any_resource.hpp>
 #include <pthread.h>
 #include <spdlog/common.h>
+#include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
@@ -33,10 +34,13 @@
 #include <chrono>
 #include <exception>
 #include <format>
+#include <iostream>
 #include <map>
 #include <optional>
 #include <set>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -2303,6 +2307,62 @@ inline spark_resource_adaptor get_spark_adaptor(jlong handle)
   return it->second;  // Returning by value, while under lock.
 }
 
+// Support for RmmSparkDeallocationFailureTest. The test runs this in a child JVM so the
+// intentional std::terminate() does not kill the JUnit process.
+class test_deallocate_noop_resource {
+ public:
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t = alignof(std::max_align_t))
+  {
+    return nullptr;
+  }
+
+  void deallocate(cuda::stream_ref,
+                  void*,
+                  std::size_t,
+                  std::size_t = alignof(std::max_align_t)) noexcept
+  {
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+  {
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  bool operator==(test_deallocate_noop_resource const&) const noexcept { return true; }
+
+  bool operator!=(test_deallocate_noop_resource const&) const noexcept { return false; }
+
+  friend void get_property(test_deallocate_noop_resource const&,
+                           cuda::mr::device_accessible) noexcept
+  {
+  }
+};
+static_assert(cuda::mr::resource_with<test_deallocate_noop_resource, cuda::mr::device_accessible>);
+
+class throw_on_dealloc_log_sink : public spdlog::sinks::base_sink<std::mutex> {
+ protected:
+  void sink_it_(spdlog::details::log_msg const& msg) override
+  {
+    auto const payload = std::string(msg.payload.data(), msg.payload.size());
+    if (payload.rfind("DEALLOC", 0) == 0) {
+      throw std::runtime_error("injected deallocate failure");
+    }
+
+    spdlog::memory_buf_t formatted;
+    formatter_->format(msg, formatted);
+    std::cerr.write(formatted.data(), static_cast<std::streamsize>(formatted.size()));
+  }
+
+  void flush_() override { std::cerr.flush(); }
+};
+
 }  // namespace
 
 extern "C" {
@@ -2801,6 +2861,39 @@ JNIEXPORT void JNICALL
 Java_com_nvidia_spark_rapids_jni_SparkResourceAdaptor_shutdownLoggerNative(JNIEnv* env, jclass)
 {
   JNI_TRY { shutdown_global_logger(); }
+  JNI_CATCH(env, );
+}
+
+/**
+ * Test utility for RmmSparkDeallocationFailureTest.
+ *
+ * This deliberately drives spark_resource_adaptor_impl::deallocate() into its fatal exception path.
+ * It installs a test logger that throws when the normal DEALLOC status is logged, constructs a
+ * spark_resource_adaptor_impl around a no-op upstream resource, registers the current thread as a
+ * task thread, then calls deallocate(). The injected logging exception is caught by deallocate()'s
+ * noexcept guard, which should log the deallocation failure and call std::terminate().
+ *
+ * This must only be called from a subprocess death-style test, because success means the process
+ * terminates.
+ */
+JNIEXPORT void JNICALL
+Java_com_nvidia_spark_rapids_jni_RmmSparkDeallocationFailureTest_triggerDeallocationFailureForTesting(
+  JNIEnv* env, jclass)
+{
+  JNI_TRY
+  {
+    auto logger = std::make_shared<spdlog::logger>("SPARK_RMM_TEST",
+                                                   std::make_shared<throw_on_dealloc_log_sink>());
+    logger->set_error_handler([](std::string const& msg) { throw std::runtime_error(msg); });
+    set_global_logger(std::make_shared<spark_resource_adaptor_logger>(logger, true));
+
+    auto adaptor = cuda::mr::make_shared_resource<spark_resource_adaptor_impl>(
+      env, cuda::mr::any_resource<cuda::mr::device_accessible>{test_deallocate_noop_resource{}});
+
+    auto const tid = static_cast<long>(pthread_self());
+    adaptor->start_dedicated_task_thread(tid, 1);
+    adaptor->deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, reinterpret_cast<void*>(0x1), 1);
+  }
   JNI_CATCH(env, );
 }
 }

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -2185,16 +2185,52 @@ class spark_resource_adaptor_impl {
     wake_next_highest_priority_blocked(lock, is_for_cpu);
   }
 
+ private:
+  [[noreturn]] static void log_deallocate_failure_and_terminate(std::exception_ptr failure) noexcept
+  {
+    try {
+      auto const tid = static_cast<long>(pthread_self());
+      try {
+        if (failure) { std::rethrow_exception(failure); }
+        LOG_STATUS("ERROR",
+                   tid,
+                   -2,
+                   thread_state::UNKNOWN,
+                   "deallocate failed with unknown exception; terminating");
+      } catch (std::exception const& e) {
+        LOG_STATUS(
+          "ERROR", tid, -2, thread_state::UNKNOWN, "deallocate failed; terminating: {}", e.what());
+      } catch (...) {
+        LOG_STATUS("ERROR",
+                   tid,
+                   -2,
+                   thread_state::UNKNOWN,
+                   "deallocate failed with unknown exception; terminating");
+      }
+    } catch (...) {
+      // Logging is best-effort here. This function must not allow any exception to escape.
+    }
+    std::terminate();
+  }
+
+ public:
   void deallocate(cuda::stream_ref stream,
                   void* p,
                   std::size_t size,
                   std::size_t alignment = alignof(std::max_align_t)) noexcept
   {
-    resource.deallocate(stream, p, size, alignment);
-    // deallocate success
-    if (size > 0) {
-      std::unique_lock<std::mutex> lock(state_mutex);
-      dealloc_core(false, lock, size);
+    try {
+      resource.deallocate(stream, p, size, alignment);
+      // deallocate success
+      if (size > 0) {
+        std::unique_lock<std::mutex> lock(state_mutex);
+        dealloc_core(false, lock, size);
+      }
+    } catch (...) {
+      // This deallocator is part of the RMM/CCCL memory-resource contract and is called through
+      // noexcept wrappers such as cuda::mr::shared_resource. If an exception escaped, the wrapper
+      // would likely call std::terminate() anyway; doing it here makes that fatal path explicit.
+      log_deallocate_failure_and_terminate(std::current_exception());
     }
   }
 
@@ -2220,6 +2256,8 @@ class spark_resource_adaptor_impl {
 
   friend void get_property(spark_resource_adaptor_impl const&, cuda::mr::device_accessible) noexcept
   {
+    // Empty by design: CCCL/RMM finds this overload via ADL as a marker that allocations
+    // from this resource are device-accessible.
   }
 };
 

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -2186,29 +2186,42 @@ class spark_resource_adaptor_impl {
   }
 
  private:
-  [[noreturn]] static void log_deallocate_failure_and_terminate(std::exception_ptr failure) noexcept
+  static void try_log_exception(long const tid, std::exception_ptr failure)
   {
     try {
-      auto const tid = static_cast<long>(pthread_self());
-      try {
-        if (failure) { std::rethrow_exception(failure); }
-        LOG_STATUS("ERROR",
-                   tid,
-                   -2,
-                   thread_state::UNKNOWN,
-                   "deallocate failed with unknown exception; terminating");
-      } catch (std::exception const& e) {
-        LOG_STATUS(
-          "ERROR", tid, -2, thread_state::UNKNOWN, "deallocate failed; terminating: {}", e.what());
-      } catch (...) {
-        LOG_STATUS("ERROR",
-                   tid,
-                   -2,
-                   thread_state::UNKNOWN,
-                   "deallocate failed with unknown exception; terminating");
-      }
+      std::rethrow_exception(failure);
+    } catch (std::exception const& e) {
+      // If the exception is a std::exception, we can log what() it is.
+      LOG_STATUS(
+        "ERROR", tid, -2, thread_state::UNKNOWN, "deallocate failed; terminating: {}", e.what());
     } catch (...) {
+      // If what's thrown is not a std::exception, log a generic message.
+      LOG_STATUS("ERROR",
+                 tid,
+                 -2,
+                 thread_state::UNKNOWN,
+                 "deallocate failed with unknown exception; terminating");
+    }
+  }
+
+  /**
+   * Best-effort logging for failures caught by deallocate()'s noexcept guard.
+   *
+   * The original deallocate failure is handled separately from the logging calls by
+   * try_log_exception() so that a logging exception cannot be mistaken for the exception thrown by
+   * deallocate(). Either way, this helper must not return or allow any exception to escape. The
+   * caller passes std::current_exception() from inside a catch block, so failure is expected to be
+   * non-null.
+   */
+  [[noreturn]] static void log_deallocation_failure_and_terminate(
+    std::exception_ptr failure) noexcept
+  {
+    try {
+      try_log_exception(static_cast<long>(pthread_self()), failure);
+    } catch (...) {
+      // At this point, logging the error itself threw.
       // Logging is best-effort here. This function must not allow any exception to escape.
+      // Just terminate.
     }
     std::terminate();
   }
@@ -2230,7 +2243,7 @@ class spark_resource_adaptor_impl {
       // This deallocator is part of the RMM/CCCL memory-resource contract and is called through
       // noexcept wrappers such as cuda::mr::shared_resource. If an exception escaped, the wrapper
       // would likely call std::terminate() anyway; doing it here makes that fatal path explicit.
-      log_deallocate_failure_and_terminate(std::current_exception());
+      log_deallocation_failure_and_terminate(std::current_exception());
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the child exited with a nonzero status and that the expected failure log was emitted.
  */
 public class RmmSparkDeallocationFailureTest {
-  private static final String CHILD_ARG = "--trigger-deallocation-failure";
+  private static final String[] CHILD_ARGS = {"--trigger-deallocation-failure"};
   private static final String EXPECTED_LOG =
       "deallocate failed; terminating: injected deallocate failure";
 
@@ -71,7 +72,7 @@ public class RmmSparkDeallocationFailureTest {
     command.add("-cp");
     command.add(testClassPath());
     command.add(Child.class.getName());
-    command.add(CHILD_ARG);
+    command.addAll(Arrays.asList(CHILD_ARGS));
     return command;
   }
 
@@ -81,10 +82,10 @@ public class RmmSparkDeallocationFailureTest {
 
   private static String testClassPath() {
     String classPath = System.getProperty("surefire.test.class.path");
-    if (classPath == null || classPath.isEmpty()) {
-      classPath = System.getProperty("java.class.path");
+    if (classPath != null && !classPath.isEmpty()) {
+      return classPath;
     }
-    return classPath;
+    return System.getProperty("java.class.path");
   }
 
   private static String readFully(InputStream stream) throws IOException {
@@ -103,7 +104,7 @@ public class RmmSparkDeallocationFailureTest {
     }
 
     public static void main(String[] args) {
-      if (args.length != 1 || !CHILD_ARG.equals(args[0])) {
+      if (!Arrays.equals(CHILD_ARGS, args)) {
         throw new IllegalArgumentException("unexpected child arguments");
       }
       triggerDeallocationFailureForTesting();

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.NativeDepsLoader;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the fatal native error handling path for SparkResourceAdaptor deallocation.
+ *
+ * The native test hook intentionally reaches a path that calls std::terminate(), so this test
+ * cannot invoke it in the JUnit JVM. Instead, the test launches a child JVM running this class'
+ * main method. The child loads the native library, invokes the hook, and is expected to terminate
+ * after logging the deallocation failure. The parent JUnit test asserts that the child exited with
+ * a nonzero status and that the expected failure log was emitted.
+ */
+public class RmmSparkDeallocationFailureTest {
+  private static final String CHILD_ARG = "--trigger-deallocation-failure";
+  private static final String EXPECTED_LOG =
+      "deallocate failed; terminating: injected deallocate failure";
+
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  @Test
+  public void testDeallocateFailureLogsAndTerminates() throws Exception {
+    Process process = new ProcessBuilder(childCommand()).redirectErrorStream(true).start();
+    boolean exited = process.waitFor(30, TimeUnit.SECONDS);
+    if (!exited) {
+      process.destroyForcibly();
+      process.waitFor();
+    }
+
+    String output = readFully(process.getInputStream());
+    assertTrue(exited, "child JVM did not exit; output:\n" + output);
+    assertNotEquals(0, process.exitValue(), "child JVM unexpectedly succeeded; output:\n" + output);
+    assertTrue(output.contains(EXPECTED_LOG), "expected log line missing; output:\n" + output);
+  }
+
+  public static void main(String[] args) {
+    if (args.length != 1 || !CHILD_ARG.equals(args[0])) {
+      throw new IllegalArgumentException("unexpected child arguments");
+    }
+    triggerDeallocationFailureForTesting();
+  }
+
+  private static List<String> childCommand() {
+    List<String> command = new ArrayList<>();
+    command.add(javaExecutable());
+
+    String libraryPath = System.getProperty("java.library.path");
+    if (libraryPath != null && !libraryPath.isEmpty()) {
+      command.add("-Djava.library.path=" + libraryPath);
+    }
+
+    command.add("-cp");
+    command.add(testClassPath());
+    command.add(RmmSparkDeallocationFailureTest.class.getName());
+    command.add(CHILD_ARG);
+    return command;
+  }
+
+  private static String javaExecutable() {
+    return System.getProperty("java.home") + "/bin/java";
+  }
+
+  private static String testClassPath() {
+    String classPath = System.getProperty("surefire.test.class.path");
+    if (classPath == null || classPath.isEmpty()) {
+      classPath = System.getProperty("java.class.path");
+    }
+    return classPath;
+  }
+
+  private static String readFully(InputStream stream) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    byte[] buffer = new byte[8192];
+    int amountRead;
+    while ((amountRead = stream.read(buffer)) != -1) {
+      output.write(buffer, 0, amountRead);
+    }
+    return output.toString("UTF-8");
+  }
+
+  private static native void triggerDeallocationFailureForTesting();
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,7 +78,7 @@ public class RmmSparkDeallocationFailureTest {
   }
 
   private static String javaExecutable() {
-    return System.getProperty("java.home") + "/bin/java";
+    return Paths.get(System.getProperty("java.home"), "bin", "java").toString();
   }
 
   private static String testClassPath() {

--- a/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/RmmSparkDeallocationFailureTest.java
@@ -34,19 +34,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Verifies the fatal native error handling path for SparkResourceAdaptor deallocation.
  *
  * The native test hook intentionally reaches a path that calls std::terminate(), so this test
- * cannot invoke it in the JUnit JVM. Instead, the test launches a child JVM running this class'
- * main method. The child loads the native library, invokes the hook, and is expected to terminate
- * after logging the deallocation failure. The parent JUnit test asserts that the child exited with
- * a nonzero status and that the expected failure log was emitted.
+ * cannot invoke it in the JUnit JVM. Instead, the test launches a child JVM running the nested
+ * Child class' main method. Only the child loads the native library, invokes the hook, and is
+ * expected to terminate after logging the deallocation failure. The parent JUnit test asserts that
+ * the child exited with a nonzero status and that the expected failure log was emitted.
  */
 public class RmmSparkDeallocationFailureTest {
   private static final String CHILD_ARG = "--trigger-deallocation-failure";
   private static final String EXPECTED_LOG =
       "deallocate failed; terminating: injected deallocate failure";
-
-  static {
-    NativeDepsLoader.loadNativeDeps();
-  }
 
   @Test
   public void testDeallocateFailureLogsAndTerminates() throws Exception {
@@ -63,13 +59,6 @@ public class RmmSparkDeallocationFailureTest {
     assertTrue(output.contains(EXPECTED_LOG), "expected log line missing; output:\n" + output);
   }
 
-  public static void main(String[] args) {
-    if (args.length != 1 || !CHILD_ARG.equals(args[0])) {
-      throw new IllegalArgumentException("unexpected child arguments");
-    }
-    triggerDeallocationFailureForTesting();
-  }
-
   private static List<String> childCommand() {
     List<String> command = new ArrayList<>();
     command.add(javaExecutable());
@@ -81,7 +70,7 @@ public class RmmSparkDeallocationFailureTest {
 
     command.add("-cp");
     command.add(testClassPath());
-    command.add(RmmSparkDeallocationFailureTest.class.getName());
+    command.add(Child.class.getName());
     command.add(CHILD_ARG);
     return command;
   }
@@ -108,5 +97,18 @@ public class RmmSparkDeallocationFailureTest {
     return output.toString("UTF-8");
   }
 
-  private static native void triggerDeallocationFailureForTesting();
+  public static class Child {
+    static {
+      NativeDepsLoader.loadNativeDeps();
+    }
+
+    public static void main(String[] args) {
+      if (args.length != 1 || !CHILD_ARG.equals(args[0])) {
+        throw new IllegalArgumentException("unexpected child arguments");
+      }
+      triggerDeallocationFailureForTesting();
+    }
+
+    private static native void triggerDeallocationFailureForTesting();
+  }
 }


### PR DESCRIPTION
This commit hardens `spark_resource_adaptor_impl::deallocate()` against unexpected exceptions in its noexcept path. Instead of allowing an exception to escape and implicitly trigger termination through the RMM/CCCL wrapper stack, the code now catches unexpected failures, attempts best-effort logging, and then explicitly calls `std::terminate()`.

As an aside, this commit also documents why `get_property(..., cuda::mr::device_accessible)` has an empty definition.  (It has to do with tagging the resource as returning device accessible memory.)