### PR TITLE
Fix row_conversion data corruption, races, and resource bugs

### DIFF
--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -156,8 +156,23 @@ struct tile_info {
     // we are not losing data we are just not as efficient as we could be with shared memory. This
     // may be a problem if the tile is computed without regard to variable width offset/length sizes
     // in that we overrun shared memory.
+    //
+    // This rounded-up size is used for the per-row stride inside the shared memory tile only —
+    // global writes use get_actual_row_size() so adjacent tiles do not race on the padding bytes.
     return cudf::util::round_up_unsafe(
       col_offsets[end_col] + col_sizes[end_col] - col_offsets[start_col], JCUDF_ROW_ALIGNMENT);
+  }
+
+  // Real, un-padded data width spanned by this tile. Used as the memcpy_async length when
+  // writing the shared tile out to global memory (and when reading it in for the from-rows
+  // direction). Writing only the actual bytes prevents the JCUDF_ROW_ALIGNMENT rounding in
+  // get_shared_row_size() from spilling into the next tile's output region — a race that can
+  // corrupt data non-deterministically when the cumulative size at the tile boundary is not
+  // an 8-byte multiple (e.g. an odd number of INT32 columns in the first tile).
+  __device__ inline size_type get_actual_row_size(size_type const* const col_offsets,
+                                                  size_type const* const col_sizes) const
+  {
+    return col_offsets[end_col] + col_sizes[end_col] - col_offsets[start_col];
   }
 
   __device__ inline size_type num_cols() const { return end_col - start_col + 1; }
@@ -603,6 +618,7 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_
   auto const num_tile_cols          = tile.num_cols();
   auto const num_tile_rows          = tile.num_rows();
   auto const tile_row_size          = tile.get_shared_row_size(col_offsets, col_sizes);
+  auto const actual_row_size        = tile.get_actual_row_size(col_offsets, col_sizes);
   auto const starting_column_offset = col_offsets[tile.start_col];
 
   // to do the copy we need to do n column copies followed by m element copies OR we have to do m
@@ -658,8 +674,10 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_
         }
         case 1: shared_data[shared_offset] = *input_src; break;
         default: {
+          // Wide fixed-width types (e.g. DECIMAL128). Both destination and source must be
+          // indexed by byte; the original loop wrote to the same byte col_size times.
           for (int i = 0; i < col_size; ++i) {
-            shared_data[shared_offset] = *input_src;
+            shared_data[shared_offset + i] = input_src[i];
           }
           break;
         }
@@ -680,7 +698,9 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_
     auto const src = &shared_data[tile_row_size * copy_row];
     auto const dst = tile_output_buffer + row_offsets(copy_row + tile.start_row, row_batch_start) +
                      starting_column_offset;
-    cuda::memcpy_async(warp, dst, src, tile_row_size, tile_barrier);
+    // Use actual_row_size (un-padded) so the JCUDF_ROW_ALIGNMENT rounding inside the shared
+    // tile never reaches into the next tile's output region — see tile_info::get_actual_row_size.
+    cuda::memcpy_async(warp, dst, src, actual_row_size, tile_barrier);
   }
 
   // wait on the last copies to complete
@@ -802,7 +822,9 @@ __launch_bounds__(block_size) CUDF_KERNEL
  *
  * @tparam block_size number of threads in a block.
  * @tparam RowOffsetFunctor iterator for row offsets into the destination data
- * @param num_rows number of rows in this portion of the table
+ * @param num_rows absolute end-row bound (== batch_row_offset + per-batch row count); the
+ *                 inner loop's `row < num_rows` guard treats this as the exclusive upper
+ *                 bound on absolute row indices for this batch.
  * @param num_variable_columns number of columns of variable-width data
  * @param variable_input_data variable width data column pointers
  * @param variable_col_output_offsets output offset information for variable-width columns
@@ -831,7 +853,14 @@ __launch_bounds__(block_size) CUDF_KERNEL
   // memcpy of the string data.
   auto const my_block = cooperative_groups::this_thread_block();
   auto const warp     = cooperative_groups::tiled_partition<cudf::detail::warp_size>(my_block);
-  cuda::barrier<cuda::thread_scope_block> block_barrier;
+
+  // The barrier must be __shared__ (so all threads in the block share one instance), explicitly
+  // initialized, and waited on before the kernel exits — otherwise cuda::memcpy_async issued
+  // through it on Ampere+ may still be in-flight when the kernel returns, racing with whatever
+  // reads the output next.
+  __shared__ cuda::barrier<cuda::thread_scope_block> block_barrier;
+  if (my_block.thread_rank() == 0) { init(&block_barrier, my_block.size()); }
+  my_block.sync();
 
   auto const start_row =
     blockIdx.x * NUM_STRING_ROWS_PER_BLOCK_TO_ROWS + warp.meta_group_rank() + batch_row_offset;
@@ -858,6 +887,9 @@ __launch_bounds__(block_size) CUDF_KERNEL
       offset += string_length;
     }
   }
+
+  // Ensure all cp.async copies issued through the barrier are complete before the kernel exits.
+  block_barrier.arrive_and_wait();
 }
 /**
  * @brief copy data from row-based format to cudf columns
@@ -910,10 +942,11 @@ __launch_bounds__(block_size) CUDF_KERNEL
   group.sync();
 
   {
-    auto const fetch_tile           = tile_infos[blockIdx.x];
-    auto const fetch_tile_start_row = fetch_tile.start_row;
-    auto const starting_col_offset  = col_offsets[fetch_tile.start_col];
-    auto const fetch_tile_row_size  = fetch_tile.get_shared_row_size(col_offsets, col_sizes);
+    auto const fetch_tile            = tile_infos[blockIdx.x];
+    auto const fetch_tile_start_row  = fetch_tile.start_row;
+    auto const starting_col_offset   = col_offsets[fetch_tile.start_col];
+    auto const fetch_tile_row_size   = fetch_tile.get_shared_row_size(col_offsets, col_sizes);
+    auto const fetch_actual_row_size = fetch_tile.get_actual_row_size(col_offsets, col_sizes);
     auto const row_batch_start =
       fetch_tile.batch_number == 0 ? 0 : batch_row_boundaries[fetch_tile.batch_number];
 
@@ -924,8 +957,9 @@ __launch_bounds__(block_size) CUDF_KERNEL
       auto shared_offset = (absolute_row - fetch_tile_start_row) * fetch_tile_row_size;
       auto dst           = &shared[shared_offset];
       auto src = &input_data[row_offsets(absolute_row, row_batch_start) + starting_col_offset];
-      // copy the data
-      cuda::memcpy_async(warp, dst, src, fetch_tile_row_size, tile_barrier);
+      // Shared stride stays padded (8-aligned for fast access); only fetch the bytes that
+      // actually belong to this tile so we never reach past the tile's column range.
+      cuda::memcpy_async(warp, dst, src, fetch_actual_row_size, tile_barrier);
     }
   }
 
@@ -1123,7 +1157,12 @@ __launch_bounds__(block_size) CUDF_KERNEL
   // Traversing in row-major order to coalesce the offsets and size reads.
   auto my_block = cooperative_groups::this_thread_block();
   auto warp     = cooperative_groups::tiled_partition<cudf::detail::warp_size>(my_block);
-  cuda::barrier<cuda::thread_scope_block> block_barrier;
+
+  // The barrier must be __shared__, initialized, and waited on; see the matching comment in
+  // copy_strings_to_rows.
+  __shared__ cuda::barrier<cuda::thread_scope_block> block_barrier;
+  if (my_block.thread_rank() == 0) { init(&block_barrier, my_block.size()); }
+  my_block.sync();
 
   // workaround for not being able to take a reference to a constexpr host variable
   auto const ROWS_PER_BLOCK = NUM_STRING_ROWS_PER_BLOCK_FROM_ROWS;
@@ -1147,6 +1186,8 @@ __launch_bounds__(block_size) CUDF_KERNEL
       cuda::memcpy_async(warp, dst, src, str_len[row], block_barrier);
     }
   }
+
+  block_barrier.arrive_and_wait();
 }
 
 /**
@@ -1511,6 +1552,13 @@ batch_data build_batches(size_type num_rows,
     auto const lb =
       thrust::lower_bound(rmm::exec_policy(stream), search_start, search_end, MAX_BATCH_SIZE);
     size_type const batch_size = lb - search_start;
+
+    // If fewer than 32 rows already exceed MAX_BATCH_SIZE, round_down_safe(batch_size, 32)
+    // would yield zero, and last_row_end would never advance — producing an infinite loop.
+    // Surface this as an exception instead.
+    CUDF_EXPECTS(lb == search_end || cudf::util::round_down_safe(batch_size, 32) > 0,
+                 "Row too large: cumulative encoded size of fewer than 32 rows exceeds 2 GiB. "
+                 "Reduce per-row data volume.");
 
     size_type const row_end = lb == search_end
                                 ? batch_size + last_row_end
@@ -1935,9 +1983,13 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
         MAX_STRING_BLOCKS,
         cudf::util::div_rounding_up_unsafe(batch_num_rows, NUM_STRING_ROWS_PER_BLOCK_TO_ROWS)));
 
+      // The kernel computes start_row as (blockIdx.x * stride + warp_rank + batch_row_offset),
+      // i.e. an absolute row index. Pass the absolute end-row bound (batch_row_offset +
+      // batch_num_rows) so the inner loop guard `row < num_rows` works for every batch,
+      // including batches whose start lies past per-batch row_count.
       detail::copy_strings_to_rows<NUM_STRING_ROWS_PER_BLOCK_TO_ROWS>
         <<<string_blocks, NUM_STRING_ROWS_PER_BLOCK_TO_ROWS, 0, stream.value()>>>(
-          batch_num_rows,
+          batch_row_offset + batch_num_rows,
           variable_width_table.num_columns(),
           dev_variable_input_data.data(),
           dev_variable_col_output_offsets.data(),
@@ -1983,6 +2035,33 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
 }  // namespace detail
 
+namespace {
+
+// Only fixed-width and STRING columns are supported by the row_conversion kernels. Nested
+// types (LIST / STRUCT / MAP) and DURATION/INTERVAL types have no row-layout encoding and
+// would silently corrupt data if allowed through.
+inline bool is_supported_row_conversion_type(data_type t)
+{
+  return is_fixed_width(t) || t.id() == type_id::STRING;
+}
+
+inline void check_supported_columns(table_view const& tbl)
+{
+  for (auto const& c : tbl) {
+    CUDF_EXPECTS(is_supported_row_conversion_type(c.type()),
+                 "Unsupported column type for row conversion. Only fixed-width and STRING "
+                 "columns are accepted.");
+    // The row_conversion kernels assume column_view::offset() == 0 throughout. A non-zero
+    // offset would make data<int8_t>() return a byte-misaligned pointer (head + offset
+    // bytes instead of head + offset * sizeof(T)) and would also misalign the null_mask.
+    CUDF_EXPECTS(c.offset() == 0,
+                 "Sliced columns (column_view::offset() != 0) are not supported by row "
+                 "conversion. The caller must materialize a contiguous copy first.");
+  }
+}
+
+}  // namespace
+
 /**
  * @brief convert a cudf table to JCUDF row format
  *
@@ -1995,6 +2074,8 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
                                                      rmm::cuda_stream_view stream,
                                                      rmm::device_async_resource_ref mr)
 {
+  check_supported_columns(tbl);
+
   auto const num_columns = tbl.num_columns();
   auto const num_rows    = tbl.num_rows();
 
@@ -2057,6 +2138,8 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
 std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
   table_view const& tbl, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
+  check_supported_columns(tbl);
+
   auto const num_columns = tbl.num_columns();
 
   std::vector<data_type> schema;
@@ -2156,6 +2239,13 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   auto const list_type = child.type().id();
   CUDF_EXPECTS(list_type == type_id::INT8 || list_type == type_id::UINT8,
                "Only a list of bytes is supported as input");
+  for (auto const& t : schema) {
+    CUDF_EXPECTS(is_supported_row_conversion_type(t),
+                 "Unsupported schema type for row conversion. Only fixed-width and STRING "
+                 "are accepted.");
+  }
+  CUDF_EXPECTS(input.parent().offset() == 0,
+               "Sliced row list (offset != 0) is not supported by row conversion.");
 
   // convert any strings in the schema to two int32 columns
   // This allows us to leverage the fixed-width copy code to fill in our offset and string length
@@ -2450,6 +2540,13 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   auto const list_type = child.type().id();
   CUDF_EXPECTS(list_type == type_id::INT8 || list_type == type_id::UINT8,
                "Only a list of bytes is supported as input");
+  for (auto const& t : schema) {
+    CUDF_EXPECTS(is_supported_row_conversion_type(t),
+                 "Unsupported schema type for row conversion. Only fixed-width and STRING "
+                 "are accepted.");
+  }
+  CUDF_EXPECTS(input.parent().offset() == 0,
+               "Sliced row list (offset != 0) is not supported by row conversion.");
 
   auto const num_columns = schema.size();
 

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -1542,25 +1542,27 @@ batch_data build_batches(size_type num_rows,
     auto offset_row_sizes = cuda::make_transform_iterator(
       cumulative_row_sizes.begin(),
       cuda::proclaim_return_type<uint64_t>(
-        [last_row_end, cumulative_row_sizes = cumulative_row_sizes.data()] __device__(auto i) {
-          return i - cumulative_row_sizes[last_row_end];
+        [last_row_end,
+         cumulative_row_sizes = cumulative_row_sizes.data()] __device__(auto cumulative_size) {
+          auto const previous_batch_size =
+            last_row_end == 0 ? uint64_t{0} : cumulative_row_sizes[last_row_end - 1];
+          return cumulative_size - previous_batch_size;
         }));
     auto search_start = offset_row_sizes + last_row_end;
     auto search_end   = offset_row_sizes + num_rows;
 
-    // find the next MAX_BATCH_SIZE boundary
-    auto const lb =
-      thrust::lower_bound(rmm::exec_policy(stream), search_start, search_end, MAX_BATCH_SIZE);
-    size_type const batch_size = lb - search_start;
+    // find the first row that would exceed MAX_BATCH_SIZE
+    auto const ub =
+      thrust::upper_bound(rmm::exec_policy(stream), search_start, search_end, MAX_BATCH_SIZE);
+    size_type const batch_size = ub - search_start;
 
-    // If fewer than 32 rows already exceed MAX_BATCH_SIZE, round_down_safe(batch_size, 32)
-    // would yield zero, and last_row_end would never advance — producing an infinite loop.
-    // Surface this as an exception instead.
-    CUDF_EXPECTS(lb == search_end || cudf::util::round_down_safe(batch_size, 32) > 0,
-                 "Row too large: cumulative encoded size of fewer than 32 rows exceeds 2 GiB. "
+    // If fewer than 32 rows fit before exceeding MAX_BATCH_SIZE, round_down_safe(batch_size, 32)
+    // would yield zero, and last_row_end would never advance. Surface this as an exception instead.
+    CUDF_EXPECTS(ub == search_end || cudf::util::round_down_safe(batch_size, 32) > 0,
+                 "Row too large: fewer than 32 rows fit in the 2 GiB row batch limit. "
                  "Reduce per-row data volume.");
 
-    size_type const row_end = lb == search_end
+    size_type const row_end = ub == search_end
                                 ? batch_size + last_row_end
                                 : last_row_end + cudf::util::round_down_safe(batch_size, 32);
 
@@ -2037,10 +2039,10 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
 namespace {
 
-// The general row_conversion kernels accept fixed-width and STRING columns. Nested types
-// (LIST / STRUCT / MAP) and DURATION/INTERVAL types have no row-layout encoding and would
-// silently corrupt data if allowed through. The "_fixed_width_optimized" variants reject
-// STRING outright, so callers that pass `fixed_width_only = true` get a single up-front
+// The general row_conversion kernels accept fixed-width columns (including chrono/fixed-point)
+// and STRING columns. Other compound layouts (LIST / STRUCT / MAP) have no row-layout encoding
+// here and would silently corrupt data if allowed through. The "_fixed_width_optimized" variants
+// reject STRING outright, so callers that pass `fixed_width_only = true` get a single up-front
 // error instead of the deeper "Only fixed width types are currently supported" later on.
 inline bool is_supported_row_conversion_type(data_type t, bool fixed_width_only)
 {

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "nvtx_ranges.hpp"
 #include "row_conversion.hpp"
 #include "utilities/iterator.cuh"
 
@@ -159,8 +160,8 @@ struct tile_info {
     //
     // This rounded-up size is used for the per-row stride inside the shared memory tile only —
     // global writes use get_actual_row_size() so adjacent tiles do not race on the padding bytes.
-    return cudf::util::round_up_unsafe(
-      col_offsets[end_col] + col_sizes[end_col] - col_offsets[start_col], JCUDF_ROW_ALIGNMENT);
+    return cudf::util::round_up_unsafe(get_actual_row_size(col_offsets, col_sizes),
+                                       JCUDF_ROW_ALIGNMENT);
   }
 
   // Real, un-padded data width spanned by this tile. Used as the memcpy_async length when
@@ -1305,12 +1306,6 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
                            rmm::device_buffer{0, cudf::get_default_stream(), mr});
 }
 
-static inline bool are_all_fixed_width(std::vector<data_type> const& schema)
-{
-  return std::all_of(
-    schema.begin(), schema.end(), [](const data_type& t) { return is_fixed_width(t); });
-}
-
 /**
  * @brief Given a set of fixed width columns, calculate how the data will be laid out in memory.
  *
@@ -1558,13 +1553,16 @@ batch_data build_batches(size_type num_rows,
 
     // If fewer than 32 rows fit before exceeding MAX_BATCH_SIZE, round_down_safe(batch_size, 32)
     // would yield zero, and last_row_end would never advance. Surface this as an exception instead.
-    CUDF_EXPECTS(ub == search_end || cudf::util::round_down_safe(batch_size, 32) > 0,
+    CUDF_EXPECTS(ub == search_end || batch_size >= 32,
                  "Row too large: fewer than 32 rows fit in the 2 GiB row batch limit. "
                  "Reduce per-row data volume.");
 
     size_type const row_end = ub == search_end
                                 ? batch_size + last_row_end
                                 : last_row_end + cudf::util::round_down_safe(batch_size, 32);
+    // Defensive invariant: the while-loop only terminates if last_row_end strictly advances.
+    CUDF_EXPECTS(row_end > last_row_end,
+                 "build_batches did not make positive progress (row_end did not advance).");
 
     // build offset list for each row in this batch
     auto const num_rows_in_batch = row_end - last_row_end;
@@ -1587,10 +1585,11 @@ batch_data build_batches(size_type num_rows,
     // needs to be individually allocated, but the kernel needs a contiguous array of offsets or
     // more global lookups are necessary.
     if (!all_fixed_width) {
-      cudaMemcpy(batch_row_offsets.data() + last_row_end,
-                 output_batch_row_offsets.data(),
-                 num_rows_in_batch * sizeof(size_type),
-                 cudaMemcpyDeviceToDevice);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(batch_row_offsets.data() + last_row_end,
+                                    output_batch_row_offsets.data(),
+                                    num_rows_in_batch * sizeof(size_type),
+                                    cudaMemcpyDeviceToDevice,
+                                    stream.value()));
     }
 
     batch_row_boundaries.push_back(row_end);
@@ -2050,7 +2049,9 @@ inline bool is_supported_row_conversion_type(data_type t, bool fixed_width_only)
   return is_fixed_width(t) || t.id() == type_id::STRING;
 }
 
-inline void check_supported_columns(table_view const& tbl, bool fixed_width_only)
+// Validates input columns and returns whether every column in `tbl` is fixed-width. Returning
+// the fact lets callers avoid a second std::all_of walk over the same table_view.
+inline bool check_supported_columns(table_view const& tbl, bool fixed_width_only)
 {
   char const* const type_msg =
     fixed_width_only
@@ -2058,14 +2059,29 @@ inline void check_supported_columns(table_view const& tbl, bool fixed_width_only
         "accepts fixed-width columns."
       : "Unsupported column type for row conversion. Only fixed-width and STRING columns "
         "are accepted.";
+  bool all_fixed_width = true;
   for (auto const& c : tbl) {
     CUDF_EXPECTS(is_supported_row_conversion_type(c.type(), fixed_width_only), type_msg);
+    all_fixed_width = all_fixed_width && is_fixed_width(c.type());
     // The row_conversion kernels assume column_view::offset() == 0 throughout. A non-zero
     // offset would make data<int8_t>() return a byte-misaligned pointer (head + offset
     // bytes instead of head + offset * sizeof(T)) and would also misalign the null_mask.
     CUDF_EXPECTS(c.offset() == 0,
                  "Sliced columns (column_view::offset() != 0) are not supported by row "
                  "conversion. The caller must materialize a contiguous copy first.");
+  }
+  return all_fixed_width;
+}
+
+inline void check_supported_schema(std::vector<data_type> const& schema, bool fixed_width_only)
+{
+  char const* const type_msg =
+    fixed_width_only
+      ? "Unsupported schema type for row conversion. The fixed-width-optimized path only "
+        "accepts fixed-width columns."
+      : "Unsupported schema type for row conversion. Only fixed-width and STRING are accepted.";
+  for (auto const& t : schema) {
+    CUDF_EXPECTS(is_supported_row_conversion_type(t, fixed_width_only), type_msg);
   }
 }
 
@@ -2083,13 +2099,11 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
                                                      rmm::cuda_stream_view stream,
                                                      rmm::device_async_resource_ref mr)
 {
-  check_supported_columns(tbl, /*fixed_width_only=*/false);
+  SRJ_FUNC_RANGE();
+  auto const fixed_width_only = check_supported_columns(tbl, /*fixed_width_only=*/false);
 
   auto const num_columns = tbl.num_columns();
   auto const num_rows    = tbl.num_rows();
-
-  auto const fixed_width_only = std::all_of(
-    tbl.begin(), tbl.end(), [](column_view const& c) { return is_fixed_width(c.type()); });
 
   // Break up the work into tiles, which are a starting and ending row/col #. This tile size is
   // calculated based on the shared memory size available we want a single tile to fill up the
@@ -2147,6 +2161,9 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
 std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
   table_view const& tbl, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
+  SRJ_FUNC_RANGE();
+  // check_supported_columns rejects non-fixed-width columns up front, so the body below does not
+  // need a redundant fixed-width branch.
   check_supported_columns(tbl, /*fixed_width_only=*/true);
 
   auto const num_columns = tbl.num_columns();
@@ -2156,64 +2173,60 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
   std::transform(
     tbl.begin(), tbl.end(), schema.begin(), [](auto i) -> data_type { return i.type(); });
 
-  if (detail::are_all_fixed_width(schema)) {
-    std::vector<size_type> column_start;
-    std::vector<size_type> column_size;
+  std::vector<size_type> column_start;
+  std::vector<size_type> column_size;
 
-    int32_t const size_per_row =
-      detail::compute_fixed_width_layout(schema, column_start, column_size);
-    auto dev_column_start = make_device_uvector_async(column_start, stream, mr);
-    auto dev_column_size  = make_device_uvector_async(column_size, stream, mr);
+  int32_t const size_per_row =
+    detail::compute_fixed_width_layout(schema, column_start, column_size);
+  auto dev_column_start = make_device_uvector_async(column_start, stream, mr);
+  auto dev_column_size  = make_device_uvector_async(column_size, stream, mr);
 
-    // Make the number of rows per batch a multiple of 32 so we don't have to worry about splitting
-    // validity at a specific row offset.  This might change in the future.
-    auto const max_rows_per_batch =
-      cudf::util::round_down_safe(std::numeric_limits<size_type>::max() / size_per_row, 32);
+  // Make the number of rows per batch a multiple of 32 so we don't have to worry about splitting
+  // validity at a specific row offset.  This might change in the future.
+  auto const max_rows_per_batch =
+    cudf::util::round_down_safe(std::numeric_limits<size_type>::max() / size_per_row, 32);
 
-    auto const num_rows = tbl.num_rows();
+  auto const num_rows = tbl.num_rows();
 
-    // Get the pointers to the input columnar data ready
-    std::vector<const int8_t*> input_data;
-    std::vector<bitmask_type const*> input_nm;
-    for (size_type column_number = 0; column_number < num_columns; column_number++) {
-      column_view cv = tbl.column(column_number);
-      input_data.emplace_back(cv.data<int8_t>());
-      input_nm.emplace_back(cv.null_mask());
-    }
-    auto dev_input_data = make_device_uvector_async(input_data, stream, mr);
-    auto dev_input_nm   = make_device_uvector_async(input_nm, stream, mr);
-
-    using ScalarType = scalar_type_t<size_type>;
-    auto zero        = make_numeric_scalar(data_type(type_id::INT32), stream.value());
-    zero->set_valid_async(true, stream);
-    static_cast<ScalarType*>(zero.get())->set_value(0, stream);
-
-    auto step = make_numeric_scalar(data_type(type_id::INT32), stream.value());
-    step->set_valid_async(true, stream);
-    static_cast<ScalarType*>(step.get())->set_value(static_cast<size_type>(size_per_row), stream);
-
-    std::vector<std::unique_ptr<column>> ret;
-    for (size_type row_start = 0; row_start < num_rows; row_start += max_rows_per_batch) {
-      size_type row_count = num_rows - row_start;
-      row_count           = row_count > max_rows_per_batch ? max_rows_per_batch : row_count;
-      ret.emplace_back(detail::fixed_width_convert_to_rows(row_start,
-                                                           row_count,
-                                                           num_columns,
-                                                           size_per_row,
-                                                           dev_column_start,
-                                                           dev_column_size,
-                                                           dev_input_data,
-                                                           dev_input_nm,
-                                                           *zero,
-                                                           *step,
-                                                           stream,
-                                                           mr));
-    }
-
-    return ret;
-  } else {
-    CUDF_FAIL("Only fixed width types are currently supported");
+  // Get the pointers to the input columnar data ready
+  std::vector<const int8_t*> input_data;
+  std::vector<bitmask_type const*> input_nm;
+  for (size_type column_number = 0; column_number < num_columns; column_number++) {
+    column_view cv = tbl.column(column_number);
+    input_data.emplace_back(cv.data<int8_t>());
+    input_nm.emplace_back(cv.null_mask());
   }
+  auto dev_input_data = make_device_uvector_async(input_data, stream, mr);
+  auto dev_input_nm   = make_device_uvector_async(input_nm, stream, mr);
+
+  using ScalarType = scalar_type_t<size_type>;
+  auto zero        = make_numeric_scalar(data_type(type_id::INT32), stream.value());
+  zero->set_valid_async(true, stream);
+  static_cast<ScalarType*>(zero.get())->set_value(0, stream);
+
+  auto step = make_numeric_scalar(data_type(type_id::INT32), stream.value());
+  step->set_valid_async(true, stream);
+  static_cast<ScalarType*>(step.get())->set_value(static_cast<size_type>(size_per_row), stream);
+
+  std::vector<std::unique_ptr<column>> ret;
+  for (size_type row_start = 0; row_start < num_rows; row_start += max_rows_per_batch) {
+    size_type row_count = num_rows - row_start;
+    row_count           = row_count > max_rows_per_batch ? max_rows_per_batch : row_count;
+    ret.emplace_back(detail::fixed_width_convert_to_rows(row_start,
+                                                         row_count,
+                                                         num_columns,
+                                                         size_per_row,
+                                                         dev_column_start,
+                                                         dev_column_size,
+                                                         dev_input_data,
+                                                         dev_input_nm,
+                                                         *zero,
+                                                         *step,
+                                                         stream,
+                                                         mr));
+  }
+
+  return ret;
 }
 
 namespace {
@@ -2243,18 +2256,18 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
+  SRJ_FUNC_RANGE();
   // verify that the types are what we expect
   column_view child    = input.child();
   auto const list_type = child.type().id();
   CUDF_EXPECTS(list_type == type_id::INT8 || list_type == type_id::UINT8,
                "Only a list of bytes is supported as input");
-  for (auto const& t : schema) {
-    CUDF_EXPECTS(is_supported_row_conversion_type(t, /*fixed_width_only=*/false),
-                 "Unsupported schema type for row conversion. Only fixed-width and STRING "
-                 "are accepted.");
-  }
-  CUDF_EXPECTS(input.parent().offset() == 0,
-               "Sliced row list (offset != 0) is not supported by row conversion.");
+  check_supported_schema(schema, /*fixed_width_only=*/false);
+  // The kernels assume both the parent list and its byte child carry no slice offset; otherwise
+  // child.data<int8_t>() and the null_mask would point into the middle of the underlying buffers.
+  CUDF_EXPECTS(input.parent().offset() == 0 && child.offset() == 0,
+               "Sliced row list (parent or child offset != 0) is not supported by row "
+               "conversion.");
 
   // convert any strings in the schema to two int32 columns
   // This allows us to leverage the fixed-width copy code to fill in our offset and string length
@@ -2544,77 +2557,72 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
                                                                rmm::cuda_stream_view stream,
                                                                rmm::device_async_resource_ref mr)
 {
+  SRJ_FUNC_RANGE();
   // verify that the types are what we expect
   column_view child    = input.child();
   auto const list_type = child.type().id();
   CUDF_EXPECTS(list_type == type_id::INT8 || list_type == type_id::UINT8,
                "Only a list of bytes is supported as input");
-  for (auto const& t : schema) {
-    CUDF_EXPECTS(is_supported_row_conversion_type(t, /*fixed_width_only=*/true),
-                 "Unsupported schema type for row conversion. The fixed-width-optimized "
-                 "path only accepts fixed-width columns.");
-  }
-  CUDF_EXPECTS(input.parent().offset() == 0,
-               "Sliced row list (offset != 0) is not supported by row conversion.");
+  check_supported_schema(schema, /*fixed_width_only=*/true);
+  CUDF_EXPECTS(input.parent().offset() == 0 && child.offset() == 0,
+               "Sliced row list (parent or child offset != 0) is not supported by row "
+               "conversion.");
 
   auto const num_columns = schema.size();
 
-  if (detail::are_all_fixed_width(schema)) {
-    std::vector<size_type> column_start;
-    std::vector<size_type> column_size;
+  // check_supported_schema guarantees every type is fixed-width, so the body below does not need
+  // a redundant fixed-width branch.
+  std::vector<size_type> column_start;
+  std::vector<size_type> column_size;
 
-    auto const num_rows     = input.parent().size();
-    auto const size_per_row = detail::compute_fixed_width_layout(schema, column_start, column_size);
+  auto const num_rows     = input.parent().size();
+  auto const size_per_row = detail::compute_fixed_width_layout(schema, column_start, column_size);
 
-    // Ideally we would check that the offsets are all the same, etc. but for now this is probably
-    // fine
-    CUDF_EXPECTS(size_per_row * num_rows == child.size(),
-                 "The layout of the data appears to be off");
-    auto dev_column_start =
-      make_device_uvector_async(column_start, stream, rmm::mr::get_current_device_resource_ref());
-    auto dev_column_size =
-      make_device_uvector_async(column_size, stream, rmm::mr::get_current_device_resource_ref());
+  // Ideally we would check that the offsets are all the same, etc. but for now this is probably
+  // fine
+  CUDF_EXPECTS(size_per_row * num_rows == child.size(), "The layout of the data appears to be off");
+  auto dev_column_start =
+    make_device_uvector_async(column_start, stream, rmm::mr::get_current_device_resource_ref());
+  auto dev_column_size =
+    make_device_uvector_async(column_size, stream, rmm::mr::get_current_device_resource_ref());
 
-    // Allocate the columns we are going to write into
-    std::vector<std::unique_ptr<column>> output_columns;
-    std::vector<int8_t*> output_data;
-    std::vector<bitmask_type*> output_nm;
-    for (int i = 0; i < static_cast<int>(num_columns); i++) {
-      auto column =
-        make_fixed_width_column(schema[i], num_rows, mask_state::UNINITIALIZED, stream, mr);
-      auto mut = column->mutable_view();
-      output_data.emplace_back(mut.data<int8_t>());
-      output_nm.emplace_back(mut.null_mask());
-      output_columns.emplace_back(std::move(column));
-    }
-
-    auto dev_output_data = make_device_uvector_async(output_data, stream, mr);
-    auto dev_output_nm   = make_device_uvector_async(output_nm, stream, mr);
-
-    dim3 blocks;
-    dim3 threads;
-    int shared_size =
-      detail::calc_fixed_width_kernel_dims(num_columns, num_rows, size_per_row, blocks, threads);
-
-    detail::copy_from_rows_fixed_width_optimized<<<blocks, threads, shared_size, stream.value()>>>(
-      num_rows,
-      num_columns,
-      size_per_row,
-      dev_column_start.data(),
-      dev_column_size.data(),
-      dev_output_data.data(),
-      dev_output_nm.data(),
-      child.data<int8_t>());
-
-    // Set null counts, because output_columns are modified via mutable-view,
-    // in the kernel above.
-    // TODO(future): Consider setting null count in the kernel itself.
-    fixup_null_counts(output_columns, stream);
-
-    return std::make_unique<table>(std::move(output_columns));
-  } else {
-    CUDF_FAIL("Only fixed width types are currently supported");
+  // Allocate the columns we are going to write into
+  std::vector<std::unique_ptr<column>> output_columns;
+  std::vector<int8_t*> output_data;
+  std::vector<bitmask_type*> output_nm;
+  for (int i = 0; i < static_cast<int>(num_columns); i++) {
+    auto column =
+      make_fixed_width_column(schema[i], num_rows, mask_state::UNINITIALIZED, stream, mr);
+    auto mut = column->mutable_view();
+    output_data.emplace_back(mut.data<int8_t>());
+    output_nm.emplace_back(mut.null_mask());
+    output_columns.emplace_back(std::move(column));
   }
+
+  auto dev_output_data = make_device_uvector_async(output_data, stream, mr);
+  auto dev_output_nm   = make_device_uvector_async(output_nm, stream, mr);
+
+  dim3 blocks;
+  dim3 threads;
+  int shared_size =
+    detail::calc_fixed_width_kernel_dims(num_columns, num_rows, size_per_row, blocks, threads);
+
+  detail::copy_from_rows_fixed_width_optimized<<<blocks, threads, shared_size, stream.value()>>>(
+    num_rows,
+    num_columns,
+    size_per_row,
+    dev_column_start.data(),
+    dev_column_size.data(),
+    dev_output_data.data(),
+    dev_output_nm.data(),
+    child.data<int8_t>());
+
+  // Set null counts, because output_columns are modified via mutable-view,
+  // in the kernel above.
+  // TODO(future): Consider setting null count in the kernel itself.
+  fixup_null_counts(output_columns, stream);
+
+  return std::make_unique<table>(std::move(output_columns));
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -675,8 +675,6 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_
         }
         case 1: shared_data[shared_offset] = *input_src; break;
         default: {
-          // Wide fixed-width types (e.g. DECIMAL128). Both destination and source must be
-          // indexed by byte; the original loop wrote to the same byte col_size times.
           for (int i = 0; i < col_size; ++i) {
             shared_data[shared_offset + i] = input_src[i];
           }

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -2037,20 +2037,27 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
 
 namespace {
 
-// Only fixed-width and STRING columns are supported by the row_conversion kernels. Nested
-// types (LIST / STRUCT / MAP) and DURATION/INTERVAL types have no row-layout encoding and
-// would silently corrupt data if allowed through.
-inline bool is_supported_row_conversion_type(data_type t)
+// The general row_conversion kernels accept fixed-width and STRING columns. Nested types
+// (LIST / STRUCT / MAP) and DURATION/INTERVAL types have no row-layout encoding and would
+// silently corrupt data if allowed through. The "_fixed_width_optimized" variants reject
+// STRING outright, so callers that pass `fixed_width_only = true` get a single up-front
+// error instead of the deeper "Only fixed width types are currently supported" later on.
+inline bool is_supported_row_conversion_type(data_type t, bool fixed_width_only)
 {
+  if (fixed_width_only) return is_fixed_width(t);
   return is_fixed_width(t) || t.id() == type_id::STRING;
 }
 
-inline void check_supported_columns(table_view const& tbl)
+inline void check_supported_columns(table_view const& tbl, bool fixed_width_only)
 {
+  char const* const type_msg =
+    fixed_width_only
+      ? "Unsupported column type for row conversion. The fixed-width-optimized path only "
+        "accepts fixed-width columns."
+      : "Unsupported column type for row conversion. Only fixed-width and STRING columns "
+        "are accepted.";
   for (auto const& c : tbl) {
-    CUDF_EXPECTS(is_supported_row_conversion_type(c.type()),
-                 "Unsupported column type for row conversion. Only fixed-width and STRING "
-                 "columns are accepted.");
+    CUDF_EXPECTS(is_supported_row_conversion_type(c.type(), fixed_width_only), type_msg);
     // The row_conversion kernels assume column_view::offset() == 0 throughout. A non-zero
     // offset would make data<int8_t>() return a byte-misaligned pointer (head + offset
     // bytes instead of head + offset * sizeof(T)) and would also misalign the null_mask.
@@ -2074,7 +2081,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
                                                      rmm::cuda_stream_view stream,
                                                      rmm::device_async_resource_ref mr)
 {
-  check_supported_columns(tbl);
+  check_supported_columns(tbl, /*fixed_width_only=*/false);
 
   auto const num_columns = tbl.num_columns();
   auto const num_rows    = tbl.num_rows();
@@ -2138,7 +2145,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows(table_view const& tbl,
 std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
   table_view const& tbl, rmm::cuda_stream_view stream, rmm::device_async_resource_ref mr)
 {
-  check_supported_columns(tbl);
+  check_supported_columns(tbl, /*fixed_width_only=*/true);
 
   auto const num_columns = tbl.num_columns();
 
@@ -2240,7 +2247,7 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
   CUDF_EXPECTS(list_type == type_id::INT8 || list_type == type_id::UINT8,
                "Only a list of bytes is supported as input");
   for (auto const& t : schema) {
-    CUDF_EXPECTS(is_supported_row_conversion_type(t),
+    CUDF_EXPECTS(is_supported_row_conversion_type(t, /*fixed_width_only=*/false),
                  "Unsupported schema type for row conversion. Only fixed-width and STRING "
                  "are accepted.");
   }
@@ -2541,9 +2548,9 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   CUDF_EXPECTS(list_type == type_id::INT8 || list_type == type_id::UINT8,
                "Only a list of bytes is supported as input");
   for (auto const& t : schema) {
-    CUDF_EXPECTS(is_supported_row_conversion_type(t),
-                 "Unsupported schema type for row conversion. Only fixed-width and STRING "
-                 "are accepted.");
+    CUDF_EXPECTS(is_supported_row_conversion_type(t, /*fixed_width_only=*/true),
+                 "Unsupported schema type for row conversion. The fixed-width-optimized "
+                 "path only accepts fixed-width columns.");
   }
   CUDF_EXPECTS(input.parent().offset() == 0,
                "Sliced row list (offset != 0) is not supported by row conversion.");

--- a/src/main/cpp/tests/row_conversion.cpp
+++ b/src/main/cpp/tests/row_conversion.cpp
@@ -591,6 +591,46 @@ TEST_F(ColumnToRowTests, RejectSlicedColumn)
   EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
 }
 
+TEST_F(ColumnToRowTests, RejectStringColumnInFixedWidthOptimized)
+{
+  cudf::test::strings_column_wrapper col({"a", "bb", "ccc"});
+  cudf::table_view in({col});
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows_fixed_width_optimized(in), cudf::logic_error);
+}
+
+TEST_F(RowToColumnTests, RejectUnsupportedSchema)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col({1, 2, 3});
+  cudf::table_view in({col});
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+
+  std::vector<cudf::data_type> list_schema{cudf::data_type{cudf::type_id::LIST}};
+  EXPECT_THROW(spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), list_schema),
+               cudf::logic_error);
+
+  std::vector<cudf::data_type> string_schema{cudf::data_type{cudf::type_id::STRING}};
+  EXPECT_THROW(spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+                 cudf::lists_column_view(*rows[0]), string_schema),
+               cudf::logic_error);
+}
+
+TEST_F(RowToColumnTests, RejectSlicedRowList)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> col({1, 2, 3});
+  cudf::table_view in({col});
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto sliced = cudf::slice(rows[0]->view(), {1, 3})[0];
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::INT32}};
+
+  EXPECT_THROW(spark_rapids_jni::convert_from_rows(cudf::lists_column_view(sliced), schema),
+               cudf::logic_error);
+  EXPECT_THROW(spark_rapids_jni::convert_from_rows_fixed_width_optimized(
+                 cudf::lists_column_view(sliced), schema),
+               cudf::logic_error);
+}
+
 // Regression repro for spark-rapids-jni#4587. Disabled by default because it requires ~2.5 GB
 // of free GPU memory to build the input; enable manually with --gtest_also_run_disabled_tests.
 //

--- a/src/main/cpp/tests/row_conversion.cpp
+++ b/src/main/cpp/tests/row_conversion.cpp
@@ -503,11 +503,17 @@ TEST_F(ColumnToRowTests, PivotLikeLayout)
 // fixed-width column wider than 8 bytes (DECIMAL128 in practice) was silently corrupted.
 TEST_F(ColumnToRowTests, Decimal128RoundTrip)
 {
+  // Include a value with non-zero bytes spread across all 16 positions so a regression that
+  // copies the same byte 16 times (the original bug) is detected anywhere in the word, not
+  // only in the low bytes. Also include a null to cover the validity-bitmap path.
+  auto const wide = (static_cast<__int128_t>(0x0102030405060708LL) << 64) |
+                    static_cast<__int128_t>(0x090A0B0C0D0E0F10LL);
   std::vector<__int128_t> vals{static_cast<__int128_t>(12345),
                                static_cast<__int128_t>(-67890),
-                               static_cast<__int128_t>(999999999999LL)};
+                               static_cast<__int128_t>(999999999999LL),
+                               wide};
   cudf::test::fixed_point_column_wrapper<__int128_t> col(
-    vals.begin(), vals.end(), numeric::scale_type{-2});
+    vals.begin(), vals.end(), {true, false, true, true}, numeric::scale_type{-2});
   cudf::table_view in({col});
   std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::DECIMAL128, -2}};
 
@@ -534,7 +540,7 @@ TEST_F(ColumnToRowTests, TileBoundaryWideInt32RoundTrip)
   constexpr int num_cols = 500;
   constexpr int num_rows = 64;
 
-  auto r = spark_rapids_jni::util::make_counting_transform_iterator(
+  auto data_iter = spark_rapids_jni::util::make_counting_transform_iterator(
     0, [](auto i) -> int32_t { return static_cast<int32_t>(i * 2654435761u); });
 
   std::vector<cudf::test::fixed_width_column_wrapper<int32_t>> cols;
@@ -544,7 +550,7 @@ TEST_F(ColumnToRowTests, TileBoundaryWideInt32RoundTrip)
   std::vector<cudf::data_type> schema;
   schema.reserve(num_cols);
   for (int c = 0; c < num_cols; ++c) {
-    cols.emplace_back(r + c * num_rows, r + c * num_rows + num_rows);
+    cols.emplace_back(data_iter + c * num_rows, data_iter + c * num_rows + num_rows);
     views.emplace_back(cols.back());
     schema.push_back(cudf::data_type{cudf::type_id::INT32});
   }
@@ -589,6 +595,14 @@ TEST_F(ColumnToRowTests, RejectSlicedColumn)
   auto sliced = cudf::slice(static_cast<cudf::column_view>(source), {2, 6})[0];
   cudf::table_view in({sliced});
   EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
+}
+
+TEST_F(ColumnToRowTests, RejectSlicedColumnFixedWidthOptimized)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> source({10, 11, 12, 13, 14, 15, 16, 17});
+  auto sliced = cudf::slice(static_cast<cudf::column_view>(source), {2, 6})[0];
+  cudf::table_view in({sliced});
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows_fixed_width_optimized(in), cudf::logic_error);
 }
 
 TEST_F(ColumnToRowTests, RejectStringColumnInFixedWidthOptimized)

--- a/src/main/cpp/tests/row_conversion.cpp
+++ b/src/main/cpp/tests/row_conversion.cpp
@@ -20,6 +20,7 @@
 #include <cudf_test/table_utilities.hpp>
 
 #include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/types.hpp>
 
@@ -494,6 +495,162 @@ TEST_F(ColumnToRowTests, PivotLikeLayout)
     int32_t actual = 0;
     std::memcpy(&actual, host_bytes.data() + r * row_stride + int_offset, sizeof(int32_t));
     EXPECT_EQ(actual, int_data[r]) << "row " << r;
+  }
+}
+
+// Regression test for spark-rapids-jni#4586: the default branch of the type-size switch in
+// copy_to_rows wrote to the same byte col_size times rather than advancing the offset, so any
+// fixed-width column wider than 8 bytes (DECIMAL128 in practice) was silently corrupted.
+TEST_F(ColumnToRowTests, Decimal128RoundTrip)
+{
+  std::vector<__int128_t> vals{static_cast<__int128_t>(12345),
+                               static_cast<__int128_t>(-67890),
+                               static_cast<__int128_t>(999999999999LL)};
+  cudf::test::fixed_point_column_wrapper<__int128_t> col(
+    vals.begin(), vals.end(), numeric::scale_type{-2});
+  cudf::table_view in({col});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::DECIMAL128, -2}};
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_EQ(rows.size(), 1u);
+  auto result = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), schema);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+}
+
+// Regression test for spark-rapids-jni#4590: when a tile boundary falls at a byte offset that
+// is not 8-aligned, the old code wrote `round_up_8(actual_size)` bytes from the shared tile to
+// global memory. The trailing padding bytes overlapped with the next tile's destination range,
+// causing a non-deterministic race between adjacent CUDA blocks. With the fix, the write length
+// is the actual data span, so adjacent tiles never touch the same bytes.
+//
+// The race itself is timing-dependent; this test simply round-trips a wide INT32 schema known
+// to produce a multi-tile layout and asserts data integrity over many iterations. With the bug,
+// at least some iterations would mismatch on certain GPUs.
+TEST_F(ColumnToRowTests, TileBoundaryWideInt32RoundTrip)
+{
+  // A row of 500 INT32 columns is ~2 KB, which overflows the per-tile shmem budget and
+  // forces multiple tiles. The exact tile boundary location depends on shmem_limit_per_tile
+  // at runtime, but for the supported budgets it lands somewhere inside the schema.
+  constexpr int num_cols = 500;
+  constexpr int num_rows = 64;
+
+  auto r = spark_rapids_jni::util::make_counting_transform_iterator(
+    0, [](auto i) -> int32_t { return static_cast<int32_t>(i * 2654435761u); });
+
+  std::vector<cudf::test::fixed_width_column_wrapper<int32_t>> cols;
+  cols.reserve(num_cols);
+  std::vector<cudf::column_view> views;
+  views.reserve(num_cols);
+  std::vector<cudf::data_type> schema;
+  schema.reserve(num_cols);
+  for (int c = 0; c < num_cols; ++c) {
+    cols.emplace_back(r + c * num_rows, r + c * num_rows + num_rows);
+    views.emplace_back(cols.back());
+    schema.push_back(cudf::data_type{cudf::type_id::INT32});
+  }
+  cudf::table_view in(views);
+
+  // Repeat to give a non-deterministic tile-write race more chances to surface.
+  for (int iter = 0; iter < 8; ++iter) {
+    auto rows = spark_rapids_jni::convert_to_rows(in);
+    ASSERT_EQ(rows.size(), 1u);
+    auto result = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*rows[0]), schema);
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in, *result);
+  }
+}
+
+// Regression test for spark-rapids-jni#4586: nested types (LIST, STRUCT, MAP) and other
+// unsupported data types must be rejected at the entry point with a clear exception, rather
+// than producing silently corrupted output (which happened when LIST/STRUCT columns reached
+// the variable-width path that assumes STRING).
+TEST_F(ColumnToRowTests, RejectListColumn)
+{
+  cudf::test::lists_column_wrapper<int32_t> list_col{{1, 2}, {3}, {4, 5, 6}};
+  cudf::table_view in({list_col});
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
+}
+
+TEST_F(ColumnToRowTests, RejectStructColumn)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> child_a({1, 2, 3});
+  cudf::test::fixed_width_column_wrapper<int64_t> child_b({10L, 20L, 30L});
+  cudf::test::structs_column_wrapper struct_col({child_a, child_b});
+  cudf::table_view in({struct_col});
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
+}
+
+// Regression test for spark-rapids-jni#4586: column_view::data<int8_t>() returns
+// `head + offset_in_elements` interpreted as bytes, so a sliced column produced a misaligned
+// input pointer and could either crash or silently corrupt data. With the entry-point guard
+// the caller now gets a clear exception.
+TEST_F(ColumnToRowTests, RejectSlicedColumn)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> source({10, 11, 12, 13, 14, 15, 16, 17});
+  auto sliced = cudf::slice(static_cast<cudf::column_view>(source), {2, 6})[0];
+  cudf::table_view in({sliced});
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
+}
+
+// Regression repro for spark-rapids-jni#4587. Disabled by default because it requires ~2.5 GB
+// of free GPU memory to build the input; enable manually with --gtest_also_run_disabled_tests.
+//
+// With fewer than 32 rows whose cumulative encoded size exceeds 2 GiB, the old
+// detail::build_batches would loop forever because round_down_safe(batch_size, 32) returned
+// zero and last_row_end never advanced. The fix surfaces the situation as an exception.
+TEST_F(ColumnToRowTests, DISABLED_HugeStringRowThrows)
+{
+  constexpr std::size_t per_col_bytes = 35ULL * 1024 * 1024;
+  constexpr int num_rows              = 33;
+
+  std::string const s(per_col_bytes, 'x');
+  std::vector<std::string> data(num_rows, s);
+
+  cudf::test::strings_column_wrapper col_a(data.begin(), data.end());
+  cudf::test::strings_column_wrapper col_b(data.begin(), data.end());
+  cudf::table_view in({col_a, col_b});
+
+  EXPECT_THROW(spark_rapids_jni::convert_to_rows(in), cudf::logic_error);
+}
+
+// Regression repro for spark-rapids-jni#4588. Disabled by default for the same memory reason as
+// HugeStringRowThrows.
+//
+// The old kernel launch passed batch_num_rows (a per-batch count) as the kernel's `num_rows`
+// while start_row was an absolute index, so all batches whose start lay past the per-batch
+// count silently produced uninitialized output. The fix passes batch_row_offset +
+// batch_num_rows as the absolute end bound; this test exercises the multi-batch path.
+TEST_F(ColumnToRowTests, DISABLED_MultiBatchStringDoesNotSkip)
+{
+  constexpr std::size_t per_col_bytes = 33ULL * 1024 * 1024;
+  constexpr int num_rows              = 35;
+
+  std::vector<std::string> data_a, data_b;
+  data_a.reserve(num_rows);
+  data_b.reserve(num_rows);
+  for (int i = 0; i < num_rows; ++i) {
+    data_a.push_back(std::string(per_col_bytes, static_cast<char>('a' + (i % 26))));
+    data_b.push_back(std::string(per_col_bytes, static_cast<char>('A' + (i % 26))));
+  }
+
+  cudf::test::strings_column_wrapper col_a(data_a.begin(), data_a.end());
+  cudf::test::strings_column_wrapper col_b(data_b.begin(), data_b.end());
+  cudf::table_view in({col_a, col_b});
+  std::vector<cudf::data_type> schema{cudf::data_type{cudf::type_id::STRING},
+                                      cudf::data_type{cudf::type_id::STRING}};
+
+  auto rows = spark_rapids_jni::convert_to_rows(in);
+  ASSERT_GE(rows.size(), 2u) << "Expected multiple batches; if a single batch fits the issue "
+                                "cannot be reproduced — increase per_col_bytes or num_rows.";
+
+  // Reconstruct each batch and compare against the matching row slice of the input.
+  std::size_t row_start = 0;
+  for (auto& batch : rows) {
+    auto result   = spark_rapids_jni::convert_from_rows(cudf::lists_column_view(*batch), schema);
+    auto in_slice = cudf::slice(in,
+                                {static_cast<cudf::size_type>(row_start),
+                                 static_cast<cudf::size_type>(row_start + result->num_rows())})[0];
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(in_slice, *result);
+    row_start += result->num_rows();
   }
 }
 


### PR DESCRIPTION
## Summary

Address several latent bugs in `row_conversion.cu` that block re-enabling the `AcceleratedColumnarToRowIterator` fast path in spark-rapids (see NVIDIA/spark-rapids#14651 for context).

- **#4586 — data corruption and missing input guards.**
  - The default branch of `copy_to_rows` (used for any fixed-width column wider than 8 bytes, i.e. DECIMAL128 in practice) dropped the per-byte index in both the shared-memory write and the input read, so it copied one byte 16 times instead of 16 bytes once. Index both pointers by `i`.
  - Add `CUDF_EXPECTS` at the public entry points to reject unsupported column types (LIST / STRUCT / MAP / ...) and sliced columns (`column_view::offset() \!= 0`). The latter is necessary because `column_view::data<int8_t>()` returns `head<int8_t>() + offset`, which is byte-misaligned for any non-1-byte element type. The optimized variants additionally reject STRING up front (fail-fast) so callers do not get a misleading double-message.

- **#4587 — string hang.** `build_batches` looped forever when fewer than 32 rows already exceeded `MAX_BATCH_SIZE`, because `round_down_safe(batch_size, 32)` returned zero and `last_row_end` never advanced. Surface as an exception.

- **#4588 — multi-batch string skip.** `copy_strings_to_rows` was launched with the per-batch row count as `num_rows`, but the kernel computes an absolute `start_row` from `batch_row_offset + ...`. For every batch past the first, `start_row >= num_rows` and the loop body never executed, returning an uninitialized output buffer. Pass `batch_row_offset + batch_num_rows` (the absolute end bound) instead.

- **#4589 — cuda::barrier in string kernels.** Both `copy_strings_to_rows` and `copy_strings_from_rows` declared the barrier as a stack-local, never-initialized variable and never waited on it before kernel exit. Made it `__shared__`, initialized from thread 0 with `my_block.size()`, and added `arrive_and_wait()` before the kernel returns.

- **#4590 — tile-boundary race in copy_to_rows.** `tile_row_size` (`= round_up_8(actual_data_size)`) was used as the `memcpy_async` write length. When the cumulative byte width at a tile boundary was not a multiple of 8, the padding bytes tile A wrote spilled into the output range tile B was writing concurrently, producing non-deterministic corruption that depended on block scheduling. Added `tile_info::get_actual_row_size()`; the padded size stays as the in-shared row pitch (kept 8-aligned for SIMD access), but `memcpy_async` now writes / fetches only the un-padded actual span, so adjacent tiles never touch the same output bytes. Applied symmetrically to the `from-rows` fetch.

## Test plan

- [x] `ColumnToRowTests.Decimal128RoundTrip` — DECIMAL128 round trip that exercises the 16-byte default branch in copy_to_rows.
- [x] `ColumnToRowTests.TileBoundaryWideInt32RoundTrip` — 500-INT32 schema round-tripped 8 times to give the tile-boundary race more chances to surface on the un-fixed code path.
- [x] `ColumnToRowTests.RejectListColumn`, `RejectStructColumn`, `RejectSlicedColumn` — verify the new entry-point guards throw cleanly rather than letting corrupt data propagate.
- [x] `ColumnToRowTests.DISABLED_HugeStringRowThrows`, `DISABLED_MultiBatchStringDoesNotSkip` — the natural reproducers for #4587 and #4588 require ~2.5 GiB of GPU memory to build, so they are disabled by default and runnable manually with `--gtest_also_run_disabled_tests`.
- [x] Existing `ROW_CONVERSION` gtest suite (including `ColumnToRowTests.PivotLikeLayout` for #10062) still passes.

End-to-end integration coverage for the C2R path through `AcceleratedColumnarToRowIterator` lives in the matching spark-rapids PR that lands alongside the spark-rapids-jni version bump.

Fixes #4586, fixes #4587, fixes #4588, fixes #4589, fixes #4590.