### PR TITLE
Added comments to empty methods in helper test classes, for clarity. [skip ci]

### DIFF
--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -2321,6 +2321,8 @@ class test_deallocate_noop_resource {
                   std::size_t,
                   std::size_t = alignof(std::max_align_t)) noexcept
   {
+    // Empty by design: this test resource is used with a fake pointer, and the test needs the
+    // enclosing spark_resource_adaptor_impl::deallocate() path to continue past the upstream free.
   }
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
@@ -2342,6 +2344,8 @@ class test_deallocate_noop_resource {
   friend void get_property(test_deallocate_noop_resource const&,
                            cuda::mr::device_accessible) noexcept
   {
+    // Empty by design: CCCL/RMM finds this overload via ADL as a marker that allocations from this
+    // test resource satisfy the device_accessible property.
   }
 };
 static_assert(cuda::mr::resource_with<test_deallocate_noop_resource, cuda::mr::device_accessible>);


### PR DESCRIPTION
This commit adds comments to the `deallocate` and `get_property` methods of the `test_deallocate_noop_resource` test utility, indicating why those method bodies are empty.

The short of it is that these methods are empty by design.  These are test utilities exercised by `RmmSparkDeallocationFailureTest`.  The methods have to have implementations for them to be valid memory resources.

Note:  This change is to address nitpicks in the static analyzer runs.