### PR TITLE
Floor-divide timestamp to seconds in convert_timestamp

### DIFF
--- a/src/main/cpp/src/datetime_utils.cuh
+++ b/src/main/cpp/src/datetime_utils.cuh
@@ -536,8 +536,14 @@ __device__ static timestamp_type convert_timestamp(
   auto const tz_instants  = fixed_transitions.child().child(1);
   auto const utc_offsets  = fixed_transitions.child().child(2);
 
-  auto const epoch_seconds = static_cast<int64_t>(
-    cuda::std::chrono::duration_cast<cudf::duration_s>(timestamp.time_since_epoch()).count());
+  // Floor-divide the raw count to seconds. `duration_cast` truncates toward zero, which for
+  // negative timestamps with a non-zero sub-second component rounds up by one second. If such a
+  // timestamp lies in the last sub-second window before a DST gap transition, the rounded value
+  // snaps onto the transition instant itself, and the binary search below returns the
+  // post-transition offset (off by one DST step, typically 1 hour).
+  constexpr int64_t sub_seconds_per_second = duration_type::period::den;
+  auto const epoch_seconds =
+    integer_utils::floor_div(timestamp.time_since_epoch().count(), sub_seconds_per_second);
   auto const tz_transitions = cudf::list_device_view{fixed_transitions, tz_index};
   auto const list_size      = tz_transitions.size();
 

--- a/src/main/cpp/src/datetime_utils.cuh
+++ b/src/main/cpp/src/datetime_utils.cuh
@@ -536,14 +536,22 @@ __device__ static timestamp_type convert_timestamp(
   auto const tz_instants  = fixed_transitions.child().child(1);
   auto const utc_offsets  = fixed_transitions.child().child(2);
 
-  // Floor-divide the raw count to seconds. `duration_cast` truncates toward zero, which for
-  // negative timestamps with a non-zero sub-second component rounds up by one second. If such a
-  // timestamp lies in the last sub-second window before a DST gap transition, the rounded value
-  // snaps onto the transition instant itself, and the binary search below returns the
-  // post-transition offset (off by one DST step, typically 1 hour).
+  // Direction-aware µs→s conversion:
+  //
+  //   - from_utc (to_utc == false): the input is a UTC instant. `duration_cast` truncates
+  //     toward zero, which for a negative count with non-zero sub-second part rounds up by
+  //     one second. At a UTC instant 1 µs before a DST gap transition this snaps onto the
+  //     transition itself and the binary search returns the post-transition offset (1-hour
+  //     off-by-one, see #14861). Floor-divide gives the correct pre-transition offset.
+  //
+  //   - to_utc (to_utc == true): the input is a local wall clock. Sub-second negative inputs
+  //     that fall inside a DST gap (a local time that does not exist) must resolve to the
+  //     post-gap `offset_after`, matching Spark/Java's `LocalDateTime.atZone()` convention.
+  //     Truncation toward zero happens to land on the post-gap row, so we keep it.
   constexpr int64_t sub_seconds_per_second = duration_type::period::den;
-  auto const epoch_seconds =
-    integer_utils::floor_div(timestamp.time_since_epoch().count(), sub_seconds_per_second);
+  auto const raw_count                     = timestamp.time_since_epoch().count();
+  auto const epoch_seconds  = to_utc ? static_cast<int64_t>(raw_count / sub_seconds_per_second)
+                                     : integer_utils::floor_div(raw_count, sub_seconds_per_second);
   auto const tz_transitions = cudf::list_device_view{fixed_transitions, tz_index};
   auto const list_size      = tz_transitions.size();
 

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -314,8 +314,14 @@ __device__ static cudf::timestamp_us convert_timestamp_between_timezones(
 {
   constexpr int64_t MICROS_PER_MILLI = 1000L;
 
-  int64_t const epoch_millis = static_cast<int64_t>(
-    cuda::std::chrono::duration_cast<cudf::duration_ms>(ts.time_since_epoch()).count());
+  // Floor-divide µs to ms. `duration_cast` truncates toward zero, so a negative timestamp with a
+  // non-zero sub-millisecond component would round up by one ms; at a DST gap whose recorded
+  // instant is exactly that ms, get_transition_index would then return the post-transition offset
+  // (1-hour off-by-one). Same shape of bug as the µs→s path in
+  // datetime_utils.cuh::convert_timestamp. GpuTimeZoneDBTest.convertOrcTimezonesOnCPU uses
+  // Math.floorDiv/floorMod to match.
+  int64_t const epoch_millis = spark_rapids_jni::integer_utils::floor_div(
+    static_cast<int64_t>(ts.time_since_epoch().count()), MICROS_PER_MILLI);
 
   int32_t writer_offset_millis = get_transition_index(writer_trans_begin,
                                                       writer_trans_end,

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -309,3 +309,38 @@ TEST_F(TimeZoneTest, ConvertFromUTCMicrosecondsSubSecondBeforeGap)
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
+
+// Sibling regression for the ORC path (convert_orc_writer_reader_timezones). The two-pass
+// `convertBetweenTimezones` algorithm self-corrects on natural DST tables (the second lookup at
+// adjusted_ms lands in the same row as the first, so floor and truncate give the same final
+// answer). To lock down the floor semantics end-to-end this test uses a contrived 3-transition
+// reader table that forces the adjusted_ms lookups in the floor vs truncate paths to land in
+// different rows.
+//
+// Reader transitions (ms): [-1800000, 0, 1000000000], offsets (ms): [0, 3600000, 0],
+// raw_offset = 7_200_000. Writer is nullptr (fixed UTC, offset 0). For input µs = -1:
+//   * floor: epoch_ms = -1, reader_offset = 0, adjusted_ms = -1, reader_adjusted = 0,
+//            final_diff = 0, result = -1.
+//   * truncate (pre-fix): epoch_ms = 0, reader_offset = 3_600_000, adjusted_ms = -3_600_000,
+//            reader_adjusted = raw_offset = 7_200_000, final_diff = -7_200_000,
+//            result = -1 - 7_200_000_000 = -7200000001.
+// The fix flips the result back to -1.
+TEST_F(TimeZoneTest, ConvertOrcTimezonesSubMillisBeforeGap)
+{
+  auto reader_trans   = int64_col({-1800000L, 0L, 1000000000L});
+  auto reader_offsets = int32_col({0, 3600000, 0});
+  auto reader_tv      = cudf::table_view({reader_trans, reader_offsets});
+
+  auto const ts_col   = micros_col{-1L};
+  auto const expected = micros_col{-1L};
+  auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
+    ts_col,
+    nullptr,
+    0,
+    &reader_tv,
+    7200000,
+    cudf::get_default_stream(),
+    rmm::mr::get_current_device_resource_ref());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -292,3 +292,20 @@ TEST_F(TimeZoneTest, ConvertFromUTCMicroseconds)
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 }
+
+// Regression for the negative-microsecond floor-division bug: when a negative timestamp lies in
+// the last sub-second window before a gap transition (here -908870400s, offset 28800 → 32400),
+// truncation toward zero would snap to the transition itself and pick the post-transition offset.
+TEST_F(TimeZoneTest, ConvertFromUTCMicrosecondsSubSecondBeforeGap)
+{
+  auto const ts_col   = micros_col{-908870400000001L, -908870400000000L};
+  auto const expected = micros_col{-908841600000001L, -908838000000000L};
+  auto const actual =
+    spark_rapids_jni::convert_utc_timestamp_to_timezone(ts_col,
+                                                        *transitions,
+                                                        1,
+                                                        cudf::get_default_stream(),
+                                                        rmm::mr::get_current_device_resource_ref());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,13 +49,18 @@ public class GpuTimeZoneDBTest {
     TimeZone writeTz = TimeZone.getTimeZone(writeTzId);
     TimeZone readerTz = TimeZone.getTimeZone(readerTzId);
     for (int i = 0; i < microseconds.length; ++i) {
-      long millis = microseconds[i] / microsPerMillis;
+      // Floor-divide µs to ms (and floor-mod for the sub-ms remainder) so reconstruction round-trips
+      // for negative timestamps with a non-zero sub-millisecond component. Truncation toward zero
+      // would round such an input up by one ms; at a DST gap transition that lands on the
+      // post-transition offset, producing a 1-hour off-by-one. Must match the GPU kernel's
+      // floor-divide in convert_timestamp_between_timezones.
+      long millis = Math.floorDiv(microseconds[i], microsPerMillis);
       long writerOffset = writeTz.getOffset(millis);
       long readerOffset = readerTz.getOffset(millis);
       long adjustedMillis = millis + writerOffset - readerOffset;
       long adjustedReader = readerTz.getOffset(adjustedMillis);
       long finalDiffs = writerOffset - adjustedReader;
-      results[i] = (millis + finalDiffs) * microsPerMillis + (microseconds[i] % microsPerMillis);
+      results[i] = (millis + finalDiffs) * microsPerMillis + Math.floorMod(microseconds[i], microsPerMillis);
     }
     return ColumnVector.timestampMicroSecondsFromLongs(results);
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/TimeZoneTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/TimeZoneTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c)  2023-2025, NVIDIA CORPORATION.
+* Copyright (c)  2023-2026, NVIDIA CORPORATION.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -403,7 +403,9 @@ public class TimeZoneTest {
           null);
         ColumnVector expected = ColumnVector.timestampMicroSecondsFromBoxedLongs(
           -1262260800000123L,
-          -908838000000456L,
+          // input -908870400000456 is 456 µs before the 1941 Shanghai spring-forward at
+          // UTC -908870400. Pre-transition offset is +8h (CST), so wall = utc + 28800.
+          -908841600000456L,
           -908837100000789L,
           -888800400000001L,
           -888799500000999L,
@@ -463,7 +465,8 @@ public class TimeZoneTest {
           null);
         ColumnVector expected = ColumnVector.timestampNanoSecondsFromBoxedLongs(
           -1262260800000000123L,
-          -908838000000000456L,
+          // Pre-transition offset (+8h CST) applies; see micros variant above.
+          -908841600000000456L,
           -908837100000000789L,
           -888800400000000001L,
           -888799500000000999L,

--- a/src/test/java/com/nvidia/spark/rapids/jni/TimeZoneTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/TimeZoneTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c)  2023-2026, NVIDIA CORPORATION.
+* Copyright (c) 2023-2026, NVIDIA CORPORATION.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/14861

## Summary

Fixes a 1-hour off-by-one in `from_utc_timestamp` and the ORC writer-reader rebase path that triggered when a negative microsecond input landed in the last sub-second window before a DST **gap** (spring-forward) transition.

Root cause is in `convert_timestamp` (`src/main/cpp/src/datetime_utils.cuh`):

```cpp
auto const epoch_seconds = static_cast<int64_t>(
  cuda::std::chrono::duration_cast<cudf::duration_s>(timestamp.time_since_epoch()).count());
```

`duration_cast<duration_s>` truncates toward zero. For a negative count with a non-zero sub-second part, this rounds *up* by one second:

- input `-1757264400968948` µs → seconds is mathematically `-1757264400.968948`
- truncation gives `-1757264400`
- correct floor gives `-1757264401`

If that exact second `-1757264400` is the UTC instant of a DST gap transition (e.g. `1914-04-26T07:00:00Z` for `SystemV/EST5EDT`'s last-Sunday-in-April spring-forward), the `upper_bound` call below treats the input as being *at* the transition rather than *before* it and returns the post-transition offset — a 1-hour overshoot.

## Direction matters in `convert_timestamp`

The fix in `datetime_utils.cuh::convert_timestamp` is **directional**:

- **`from_utc` (`to_utc == false`)**: input is a UTC instant. Floor-divide is correct — a UTC instant 1 µs before a gap belongs to the pre-transition offset.
- **`to_utc` (`to_utc == true`)**: input is a local wall clock. Sub-second negative inputs that fall *in* a DST gap (a local time that doesn't exist) must resolve to `offset_after` to match Spark/Java's `LocalDateTime.atZone()` convention. Truncation toward zero happens to land on the post-gap row, so we keep it for this direction.

The existing `TimeZoneTest.convertToUtc{Micro,Nano}SecondsTest` fixtures with local µs `-908838000000456` (in Asia/Shanghai's 1941 spring-forward gap) verify the to_utc semantics — they continue to pass after this PR.

## ORC path

`convert_timestamp_between_timezones` in `timezones.cu` had the same shape of bug: a `duration_cast<duration_ms>` truncation on the `timestamp_us` input. Unlike the bidirectional `convert_timestamp`, **every** lookup in the ORC algorithm is from_utc-style (`tz.getOffset(millis)` interprets its argument as a UTC instant), so floor-divide is the right semantic — no direction split needed.

The Java reference `GpuTimeZoneDBTest.convertOrcTimezonesOnCPU` was using `microseconds / microsPerMillis` (Java integer division, truncate toward zero) for the same µs→ms step, and reconstructed the result with `microseconds[i] % microsPerMillis`. Switched both to `Math.floorDiv` / `Math.floorMod` so:

1. The reference matches the GPU's new floor semantics.
2. The round-trip identity `(millis * 1000) + remainder == microseconds` still holds for negative inputs (which only works when div and mod share the same rounding convention).

## Reproduction

`integration_tests/src/main/python/date_time_test.py::test_comprehensive_from_utc_timestamp` with `DATAGEN_SEED=1779422092` on Databricks 14.3, timezone `SystemV/EST5EDT`. Row 324 hit a UTC instant 0.97 s before the 1914 spring-forward; CPU returned EST offset, GPU returned EDT (NVIDIA/spark-rapids#14861).

Equivalent C++ regression added in `src/main/cpp/tests/timezones.cpp::ConvertFromUTCMicrosecondsSubSecondBeforeGap` using the existing test transition table (gap at `-908870400` UTC seconds, offset 28800 → 32400). Before the fix, input `-908870400000001` µs returned offset 32400 (post-gap); after, it correctly returns 28800.

## Notes

- Positive timestamps are unaffected: truncation and floor agree for non-negative integers.
- Floor-divide goes through `integer_utils::floor_div`, which exists in `integer_utils.cuh` and is already used by other date-math helpers.

## Test plan

- [ ] `ConvertFromUTCMicrosecondsSubSecondBeforeGap` (new C++ regression) passes
- [ ] `convertTo/FromUtc{Micro,Nano}SecondsTest` (existing JUnit) still pass — verifies to_utc gap semantics preserved
- [ ] `testConvertOrcTimezones` (existing JUnit) still passes against the updated CPU reference
- [ ] Rerun `test_comprehensive_from_utc_timestamp` with `DATAGEN_SEED=1779422092` on Databricks 14.3
- [ ] Existing ORC integration tests in spark-rapids (`test_orc_non_utc_timezone`) still pass