### PR TITLE
Match Spark whitespace and separator handling in parseTimestampWithFormat

### DIFF
--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -210,9 +210,10 @@ std::unique_ptr<cudf::column> parse_strings_to_date(
  *
  * Pattern letters follow JDK conventions: `y`/`M`/`d`/`H`/`m`/`s`. Lowercase `m` is minute,
  * not month. Non-year letter runs must have length 2; longer runs (e.g. `MMM` for month
- * name) are rejected because this kernel does not implement text forms. Space in the
- * pattern matches either ' ' or 'T' in the input — quoted literals (`'T'`) are not
- * supported, callers should use a space instead. Pattern literals must be ASCII. In LEGACY
+ * name) are rejected because this kernel does not implement text forms. A space in the
+ * pattern matches exactly one ' ' in the input; 'T' is rejected as the date/time separator
+ * under both policies (unlike the format-less cast). Quoted literals (`'T'`) are not
+ * supported. Pattern literals must be ASCII. In LEGACY
  * mode, non-year digit fields are 1 or 2 digits unless adjacent to another digit field (in
  * which case widths are exact to disambiguate). Parsed values are wall-clock UTC; timezone
  * rebasing remains the caller's responsibility — in LEGACY mode the trailing non-digit rule

--- a/src/main/cpp/src/parse_timestamp_with_format.cu
+++ b/src/main/cpp/src/parse_timestamp_with_format.cu
@@ -38,14 +38,20 @@
 #include <string>
 #include <vector>
 
+// This kernel mirrors the formatters Spark uses for to_timestamp / unix_timestamp /
+// ParseToTimestamp: java.text.SimpleDateFormat for LEGACY, and java.time.DateTimeFormatter with a
+// STRICT resolver for CORRECTED. It is NOT a drop-in for the CSV/JSON read path, which uses
+// commons-lang3 FastDateFormat and has different whitespace rules — do not reuse it there.
 namespace spark_rapids_jni {
 
 namespace {
 
 // ---- Low-level string-parsing primitives. ------------------------------------------------------
 
-// Whitespace test consistent with Spark UTF8String.trimAll for char input.
-__device__ bool is_whitespace(unsigned char c) { return c <= 32 || c == 127; }
+// LEGACY parses via java.text.SimpleDateFormat, which skips only ' ' and '\t' before fields — it
+// does not trimAll. So the outer trim must match: a leading control byte like '\r'/'\f'/'\v'
+// rejects on CPU and must not be treated as whitespace here.
+__device__ bool is_whitespace(unsigned char c) { return c == ' ' || c == '\t'; }
 
 // Read between `min_d` and `max_d` digits greedily. Advances pos by the digits read.
 // Returns false (and the partial pos advance is irrelevant since walk_tokens aborts on failure).
@@ -146,7 +152,9 @@ struct format_token {
 //     e.g. yyyyMMdd) get exact width — otherwise the boundary is ambiguous.
 //   - Otherwise CORRECTED uses exact width and LEGACY uses [1, 2].
 //   - CORRECTED `yyyy/MM/dd` keeps the existing spark-rapids compatibility contract and accepts
-//     1-2 digit month/day fields.
+//     1-2 digit month/day fields. This intentionally DEVIATES from Spark CPU, whose STRICT
+//     DateTimeFormatter rejects single-digit fields ("2024/5/6" is null on CPU); the GPU
+//     over-accepts. Pinned by parseTimestampWithFormat_correctedSlashDateDeviation.
 // Literal handling:
 //   - A space matches exactly one ' '. Spark rejects 'T' as the separator for a space pattern
 //     under both policies (unlike the format-less cast, which accepts 'T').

--- a/src/main/cpp/src/parse_timestamp_with_format.cu
+++ b/src/main/cpp/src/parse_timestamp_with_format.cu
@@ -71,16 +71,7 @@ __device__ bool try_parse_char(unsigned char const* p, int& pos, int end, unsign
   return true;
 }
 
-__device__ bool try_parse_t_or_space(unsigned char const* p, int& pos, int end)
-{
-  if (pos >= end) { return false; }
-  unsigned char c = p[pos];
-  if (c != ' ' && c != 'T') { return false; }
-  ++pos;
-  return true;
-}
-
-// Skip [ \t]* — used to fold REMOVE_WHITESPACE_FROM_MONTH_DAY into the legacy state machine.
+// Skip [ \t]* — LEGACY whitespace-before-field fold (see compile_format).
 __device__ void skip_ht_whitespace(unsigned char const* p, int& pos, int end)
 {
   while (pos < end && (p[pos] == ' ' || p[pos] == '\t')) {
@@ -127,7 +118,6 @@ struct parsed_dt {
 enum tok_kind : uint8_t {
   TOK_DIGITS,           // a = field, b = min_digits, c = max_digits
   TOK_LITERAL,          // a = literal char
-  TOK_T_OR_SPACE,       // 'T' or ' ' between date and time
   TOK_SKIP_HT_WS,       // skip [ \t]* (legacy whitespace fold)
   TOK_TRAIL_EOF,        // pos must equal end
   TOK_TRAIL_NON_DIGIT,  // pos == end OR p[pos] is not a digit (legacy tail rule)
@@ -158,9 +148,10 @@ struct format_token {
 //   - CORRECTED `yyyy/MM/dd` keeps the existing spark-rapids compatibility contract and accepts
 //     1-2 digit month/day fields.
 // Literal handling:
-//   - Space ' ' compiles to TOK_T_OR_SPACE (Spark accepts both as the date/time separator).
-//   - In LEGACY, '-' and '/' literals are followed by TOK_SKIP_HT_WS, folding the legacy
-//     `REMOVE_WHITESPACE_FROM_MONTH_DAY` rewrite into the state machine.
+//   - A space matches exactly one ' '. Spark rejects 'T' as the separator for a space pattern
+//     under both policies (unlike the format-less cast, which accepts 'T').
+//   - LEGACY: SimpleDateFormat skips [ \t] before every numeric field, so a TOK_SKIP_HT_WS
+//     precedes each non-packed digit field (subsumes the old REMOVE_WHITESPACE_FROM_MONTH_DAY).
 // The trailing token is TOK_TRAIL_EOF for CORRECTED and TOK_TRAIL_NON_DIGIT for LEGACY.
 
 uint8_t letter_to_field(char c)
@@ -205,21 +196,19 @@ std::vector<format_token> compile_format(std::string const& fmt, bool legacy)
       bool const variable_width = (legacy && !packed) || corrected_variable_width_slash_date;
       uint8_t const min_d       = (c == 'y') ? run : (variable_width ? 1 : run);
       uint8_t const max_d       = run;
+      // Skip [ \t] before each field, except inside a packed run which stays exact-width.
+      bool const abuts_prev_field = (i > 0 && std::isalpha(static_cast<unsigned char>(fmt[i - 1])));
+      if (legacy && !abuts_prev_field) { out.push_back({TOK_SKIP_HT_WS, 0, 0, 0}); }
       out.push_back({TOK_DIGITS, letter_to_field(c), min_d, max_d});
       saw_digit_field = true;
       i               = j;
     } else {
-      if (c == ' ') {
-        out.push_back({TOK_T_OR_SPACE, 0, 0, 0});
-      } else {
-        // Literal char must be ASCII; non-ASCII bytes would alias UTF-8 continuation bytes
-        // when matched against the input.
-        if (static_cast<unsigned char>(c) >= 0x80) {
-          throw std::invalid_argument("non-ASCII literal in pattern is not supported");
-        }
-        out.push_back({TOK_LITERAL, static_cast<uint8_t>(c), 0, 0});
-        if (legacy && (c == '-' || c == '/')) { out.push_back({TOK_SKIP_HT_WS, 0, 0, 0}); }
+      // A space is an ordinary literal (matches one ' '). Reject non-ASCII: it would alias
+      // UTF-8 continuation bytes against the input.
+      if (static_cast<unsigned char>(c) >= 0x80) {
+        throw std::invalid_argument("non-ASCII literal in pattern is not supported");
       }
+      out.push_back({TOK_LITERAL, static_cast<uint8_t>(c), 0, 0});
       ++i;
     }
   }
@@ -261,7 +250,6 @@ __device__ bool walk_tokens(unsigned char const* p,
         break;
       }
       case TOK_LITERAL: ok = try_parse_char(p, pos, end, t.a); break;
-      case TOK_T_OR_SPACE: ok = try_parse_t_or_space(p, pos, end); break;
       case TOK_SKIP_HT_WS: skip_ht_whitespace(p, pos, end); break;
       case TOK_TRAIL_EOF: ok = (pos == end); break;
       case TOK_TRAIL_NON_DIGIT:

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -1421,6 +1421,24 @@ public class CastStringsTest {
         new String[]{"06/05", "6/05", "06/5", "06-05"},
         "dd/MM", false,
         new Long[]{y1970_05_06, null, null, null});
+
+    // yyyy/MM, MM/dd, MM/yyyy, MM-yyyy corrected: strict 2-digit fields, missing fields default.
+    assertParsedTimestamp(
+        new String[]{"2024/05", "2024/5"},
+        "yyyy/MM", false,
+        new Long[]{y2024_05_01, null});
+    assertParsedTimestamp(
+        new String[]{"05/06", "5/06"},
+        "MM/dd", false,
+        new Long[]{y1970_05_06, null});
+    assertParsedTimestamp(
+        new String[]{"05/2024", "5/2024"},
+        "MM/yyyy", false,
+        new Long[]{y2024_05_01, null});
+    assertParsedTimestamp(
+        new String[]{"05-2024", "5-2024"},
+        "MM-yyyy", false,
+        new Long[]{y2024_05_01, null});
   }
 
   @Test
@@ -1483,11 +1501,17 @@ public class CastStringsTest {
             "2024-05-06xxx",    // legacy trailing non-digit accepted
             "2024-05-061",      // trailing digit rejected
             "\n2024-05-06",     // leading newline rejected
+            // SimpleDateFormat skips only ' '/'\t', so other leading control bytes reject on CPU.
+            "\r2024-05-06",
+            "\f2024-05-06",
+            "\u000B2024-05-06",
+            "\b2024-05-06",
             null,
         },
         "yyyy-MM-dd", true,
         new Long[]{y2024_05_06, y2024_05_06, y2024_05_06, y2024_05_06,
-                    null, y2024_05_06, y2024_05_06, null, null, null});
+                    null, y2024_05_06, y2024_05_06, null, null,
+                    null, null, null, null, null});
   }
 
   @Test
@@ -1612,12 +1636,27 @@ public class CastStringsTest {
 
   @Test
   void parseTimestampWithFormat_correctedSingleSeparatorOnly() {
-    // CORRECTED keeps DateTimeFormatter semantics: exactly one separator, no whitespace fold.
+    // CORRECTED keeps DateTimeFormatter semantics: exactly one separator, no whitespace fold,
+    // and no leading whitespace (CORRECTED does not trim).
     long ts = expectedUs(1999, 12, 31, 11, 59, 59);
     assertParsedTimestamp(
-        new String[]{"1999-12-31 11:59:59", "1999-12-31  11:59:59", "1999-12-31 11: 59:59"},
+        new String[]{"1999-12-31 11:59:59", "1999-12-31  11:59:59", "1999-12-31 11: 59:59",
+                     "\n1999-12-31 11:59:59", " 1999-12-31 11:59:59"},
         "yyyy-MM-dd HH:mm:ss", false,
-        new Long[]{ts, null, null});
+        new Long[]{ts, null, null, null, null});
+  }
+
+  @Test
+  void parseTimestampWithFormat_correctedSlashDateDeviation() {
+    // CORRECTED yyyy/MM/dd accepts 1-2 digit month/day to preserve the pre-existing spark-rapids
+    // compatibility contract. This DEVIATES from Spark CPU, whose STRICT DateTimeFormatter rejects
+    // single-digit fields ("2024/5/6" is null on CPU). This test pins the deviation so a future
+    // refactor of compile_format's corrected_variable_width_slash_date cannot silently change it.
+    long y2024_05_06 = expectedUs(2024, 5, 6, 0, 0, 0);
+    assertParsedTimestamp(
+        new String[]{"2024/05/06", "2024/5/6", "2024/5/06", "2024/05/6"},
+        "yyyy/MM/dd", false,
+        new Long[]{y2024_05_06, y2024_05_06, y2024_05_06, y2024_05_06});
   }
 
   @Test

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -1426,11 +1426,12 @@ public class CastStringsTest {
   @Test
   void parseTimestampWithFormat_correctedDateTime() {
     long ts = expectedUs(2024, 12, 31, 23, 59, 58);
+    // CORRECTED: one ' ' separator only, so 'T' and double-space are rejected.
     assertParsedTimestamp(
         new String[]{"2024-12-31 23:59:58", "2024-12-31T23:59:58",
                      "2024-12-31 23:59:5", "2024-12-31  23:59:58", "2024-12-31 23:59:60"},
         "yyyy-MM-dd HH:mm:ss", false,
-        new Long[]{ts, ts, null, null, null});
+        new Long[]{ts, null, null, null, null});
   }
 
   @Test
@@ -1463,15 +1464,15 @@ public class CastStringsTest {
   void parseTimestampWithFormat_legacyWhitespaceFold() {
     long y2024_05_06 = expectedUs(2024, 5, 6, 0, 0, 0);
 
-    // LEGACY yyyy-MM-dd: 1-2 digit month/day, whitespace fold AFTER each '-' separator,
+    // LEGACY yyyy-MM-dd: 1-2 digit month/day, [ \t] skipped before each numeric field,
     // outer trim, trailing non-digit/EOF accepted.
     assertParsedTimestamp(
         new String[]{
             "2024-05-06",
             "2024-5-6",
-            "2024- 05- 06",     // [ \t]* fold after each '-'
-            "2024-\t05-\t06",   // tabs accepted by fold
-            "2024  -05-06",     // whitespace before '-' is NOT folded
+            "2024- 05- 06",     // [ \t] skipped before month/day
+            "2024-\t05-\t06",   // tabs skipped too
+            "2024  -05-06",     // whitespace before the '-' literal is NOT skipped
             " 2024-05-06 ",     // outer trim
             "2024-05-06xxx",    // legacy trailing non-digit accepted
             "2024-05-061",      // trailing digit rejected
@@ -1494,17 +1495,17 @@ public class CastStringsTest {
         new Long[]{expectedUs(2024, 5, 6, 0, 0, 0), null, null,
                     expectedUs(2024, 5, 6, 0, 0, 0)});
 
-    // yyyyMMdd HH:mm:ss
+    // yyyyMMdd HH:mm:ss: 'T' separator rejected (literal space matches only ' ').
     assertParsedTimestamp(
         new String[]{"20241231 23:59:58", "20241231T23:59:58", "20241231 23:59:58Z"},
         "yyyyMMdd HH:mm:ss", true,
-        new Long[]{ts, ts, ts});
+        new Long[]{ts, null, ts});
 
     // Slash-separated legacy timestamp path.
     assertParsedTimestamp(
         new String[]{"2024/12/31 23:59:58", "2024/12/31T23:59:58", "2024/12/31 23:59:58Z"},
         "yyyy/MM/dd HH:mm:ss", true,
-        new Long[]{ts, ts, ts});
+        new Long[]{ts, null, ts});
   }
 
   @Test
@@ -1569,7 +1570,7 @@ public class CastStringsTest {
 
   @Test
   void parseTimestampWithFormat_legacyMultiTabFold() {
-    // skip_ht_whitespace loops, so multiple tabs/spaces after a '-' or '/' are all consumed.
+    // skip_ht_whitespace loops, so a whole run of tabs/spaces before a numeric field is consumed.
     long y2024_05_06 = expectedUs(2024, 5, 6, 0, 0, 0);
     assertParsedTimestamp(
         new String[]{"2024-\t\t05-\t \t06", "2024/  05/\t\t06"},
@@ -1579,6 +1580,37 @@ public class CastStringsTest {
         new String[]{"2024/  05/\t\t06"},
         "yyyy/MM/dd", true,
         new Long[]{y2024_05_06});
+  }
+
+  @Test
+  void parseTimestampWithFormat_legacyWhitespaceBeforeEveryField() {
+    // LEGACY skips [ \t] before each numeric field, so whitespace runs after the separator and
+    // after ':' parse; whitespace before a literal, and a tab/'T' separator, still fail.
+    long ts = expectedUs(1999, 12, 31, 11, 59, 59);
+    assertParsedTimestamp(
+        new String[]{
+            "1999-12-31 11:59:59",     // single space
+            "1999-12-31  11:59:59",    // double space after separator
+            "1999-12-31   11:59:59",   // triple space
+            "1999-12-31 \t 11:59:59",  // mixed space/tab run after separator
+            "1999-12-31 11: 59: 59",   // whitespace after ':' before minute/second
+            " 1999-12-31 11:59:59 ",   // outer trim
+            "1999-12-31\t11:59:59",    // tab separator rejected (literal space != '\t')
+            "1999-12-31T11:59:59",     // 'T' separator rejected (literal space != 'T')
+            "1999-12-31 11 :59:59",    // whitespace before ':' literal rejected
+        },
+        "yyyy-MM-dd HH:mm:ss", true,
+        new Long[]{ts, ts, ts, ts, ts, ts, null, null, null});
+  }
+
+  @Test
+  void parseTimestampWithFormat_correctedSingleSeparatorOnly() {
+    // CORRECTED keeps DateTimeFormatter semantics: exactly one separator, no whitespace fold.
+    long ts = expectedUs(1999, 12, 31, 11, 59, 59);
+    assertParsedTimestamp(
+        new String[]{"1999-12-31 11:59:59", "1999-12-31  11:59:59", "1999-12-31 11: 59:59"},
+        "yyyy-MM-dd HH:mm:ss", false,
+        new Long[]{ts, null, null});
   }
 
   @Test

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -1432,6 +1432,12 @@ public class CastStringsTest {
                      "2024-12-31 23:59:5", "2024-12-31  23:59:58", "2024-12-31 23:59:60"},
         "yyyy-MM-dd HH:mm:ss", false,
         new Long[]{ts, null, null, null, null});
+
+    // Packed date + time under CORRECTED: 'T' separator rejected, same as LEGACY.
+    assertParsedTimestamp(
+        new String[]{"20241231 23:59:58", "20241231T23:59:58"},
+        "yyyyMMdd HH:mm:ss", false,
+        new Long[]{ts, null});
   }
 
   @Test
@@ -1512,9 +1518,10 @@ public class CastStringsTest {
   void parseTimestampWithFormat_legacyDayFirstFormats() {
     long y2024_05_06 = expectedUs(2024, 5, 6, 0, 0, 0);
     assertParsedTimestamp(
-        new String[]{"06-05-2024", "6-5-2024", "6- 5-2024", "06-05-2024x"},
+        new String[]{"06-05-2024", "6-5-2024", "6- 5-2024", "06-05-2024x",
+                     "06-05-  2024"},  // [ \t] skipped before a mid-format year field too
         "dd-MM-yyyy", true,
-        new Long[]{y2024_05_06, y2024_05_06, y2024_05_06, y2024_05_06});
+        new Long[]{y2024_05_06, y2024_05_06, y2024_05_06, y2024_05_06, y2024_05_06});
     assertParsedTimestamp(
         new String[]{"06/05/2024", "6/5/2024", "6/ 5/2024", "06/05/2024x"},
         "dd/MM/yyyy", true,


### PR DESCRIPTION
## Summary

Fixes two ways the fused `parseTimestampWithFormat` parser diverged from Spark on space-separated timestamp formats such as `yyyy-MM-dd HH:mm:ss`. Both were silent (GPU result differs from CPU, no error):

1. **Whitespace (LEGACY).** Under `timeParserPolicy=LEGACY` Spark parses with `SimpleDateFormat`, which skips leading `[ \t]` before every numeric field. The kernel only folded whitespace after `-` and `/`, so a multi-space date/time separator (`1999-12-31  11:59:59`), a space/tab run after the separator, or whitespace after `:` (`11: 59: 59`) returned NULL while CPU parses them. A `TOK_SKIP_HT_WS` is now emitted ahead of each non-packed digit field (subsumes the old `REMOVE_WHITESPACE_FROM_MONTH_DAY` rewrite).

2. **`'T'` separator (both policies).** A literal space was compiled to a `'T'`-or-space token, so `1999-12-31T11:59:59` was accepted. Spark matches a literal space with exactly one `' '` and returns NULL for `'T'` under both LEGACY and CORRECTED — consistent with the existing `.{10}T` rejection in the spark-rapids cuDF fallback path. The space now compiles to a plain literal.

The format-less string→timestamp cast uses a different kernel and is unaffected (it still accepts `'T'` per ISO).

## Testing

- `CastStringsTest`: added whitespace cases; `'T'`-separator cases now expect NULL.
- Cross-checked against `java.text.SimpleDateFormat` (lenient) and Spark 3.5.x `to_timestamp` on CPU for both policies.
- End-to-end GPU vs CPU coverage will be added on the spark-rapids side (`date_time_test.py`) in a separate PR.
