### PR TITLE
Add a fluent builder for protobuf schema test descriptors

### DIFF
--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorBuilder.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorBuilder.java
@@ -18,7 +18,9 @@ package com.nvidia.spark.rapids.jni;
 
 import ai.rapids.cudf.DType;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 
 /**
@@ -37,6 +39,25 @@ import java.util.List;
  *
  * <p>Each attribute setter applies to the most recently added field. Wire types are derived from
  * the output type and encoding unless overridden via {@link #wireType(int)}.
+ *
+ * <p>For nested messages, {@link #down()} descends into the most recently added field so that
+ * subsequent {@code addField} calls become its children (with parent index and depth derived
+ * automatically); {@link #up()} returns to the enclosing level. This avoids hand-counting flat
+ * parent indices as the nesting deepens:
+ *
+ * <pre>{@code
+ * ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+ *     .addField(1, DType.STRUCT).down()   // message Outer
+ *         .addField(1, DType.INT32)       //   int32 a = 1
+ *         .addField(2, DType.STRUCT).down()  // Inner b = 2
+ *             .addField(1, DType.INT32)   //     int32 x = 1
+ *         .up()
+ *     .up()
+ *     .build();
+ * }</pre>
+ *
+ * <p>{@link #parent(int)} remains available as an explicit escape hatch, e.g. to construct the
+ * malformed schemas that the validation tests deliberately feed to the descriptor.
  */
 public final class ProtobufSchemaDescriptorBuilder {
   private static final class Field {
@@ -58,19 +79,54 @@ public final class ProtobufSchemaDescriptorBuilder {
   }
 
   private final List<Field> fields = new ArrayList<>();
+  // Indices of the fields we have descended into via down(); the top is the current parent.
+  private final Deque<Integer> parentStack = new ArrayDeque<>();
 
-  /** Start a new top-level field with the given field number and output type. */
+  /**
+   * Add a field. By default it is top-level; inside a {@link #down()} scope it becomes a child of
+   * the enclosing field, with parent index and depth derived automatically.
+   */
   public ProtobufSchemaDescriptorBuilder addField(int fieldNumber, DType outputType) {
     Field f = new Field();
     f.fieldNumber = fieldNumber;
     f.outputTypeId = outputType.getTypeId().getNativeId();
+    if (!parentStack.isEmpty()) {
+      int parentIndex = parentStack.peek();
+      f.parentIndex = parentIndex;
+      f.depth = fields.get(parentIndex).depth + 1;
+    }
     fields.add(f);
     return this;
   }
 
   /**
-   * Mark the current field as a child of {@code parentIndex}, setting its depth to
-   * parent depth + 1.
+   * Descend into the most recently added field so that subsequent {@code addField} calls become
+   * its children (until the matching {@link #up()}). This is the idiom for expressing message
+   * nesting; prefer it over {@link #parent(int)}, which is a low-level primitive.
+   */
+  public ProtobufSchemaDescriptorBuilder down() {
+    if (fields.isEmpty()) {
+      throw new IllegalStateException("down() requires a field to descend into");
+    }
+    parentStack.push(fields.size() - 1);
+    return this;
+  }
+
+  /** Return to the enclosing nesting level opened by {@link #down()}. */
+  public ProtobufSchemaDescriptorBuilder up() {
+    if (parentStack.isEmpty()) {
+      throw new IllegalStateException("up() called without a matching down()");
+    }
+    parentStack.pop();
+    return this;
+  }
+
+  /**
+   * Low-level: assign a raw parent index to the current field (depth = parent depth + 1),
+   * overriding any parent set by {@link #down()}. Prefer {@link #down()}/{@link #up()} for ordinary
+   * nesting. Reserve this for (a) loop-built degenerate chains where {@code parent(i - 1)} reads
+   * cleaner, and (b) malformed parent links that {@code down()}/{@code up()} cannot express (e.g. a
+   * non-ancestor index) in validation tests.
    */
   public ProtobufSchemaDescriptorBuilder parent(int parentIndex) {
     Field f = current();
@@ -169,6 +225,9 @@ public final class ProtobufSchemaDescriptorBuilder {
   }
 
   public ProtobufSchemaDescriptor build() {
+    if (!parentStack.isEmpty()) {
+      throw new IllegalStateException("build() called inside a down() scope; missing up()");
+    }
     int n = fields.size();
     int[] fieldNumbers = new int[n];
     int[] parentIndices = new int[n];

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorBuilder.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorBuilder.java
@@ -94,6 +94,12 @@ public final class ProtobufSchemaDescriptorBuilder {
     return this;
   }
 
+  /** Conditional form so callers can pass a flag inline; {@code repeated(false)} is a no-op. */
+  public ProtobufSchemaDescriptorBuilder repeated(boolean value) {
+    current().isRepeated = value;
+    return this;
+  }
+
   public ProtobufSchemaDescriptorBuilder required() {
     current().isRequired = true;
     return this;
@@ -133,6 +139,12 @@ public final class ProtobufSchemaDescriptorBuilder {
    */
   public ProtobufSchemaDescriptorBuilder hasDefault() {
     current().hasDefaultValue = true;
+    return this;
+  }
+
+  /** Conditional form so callers can pass a flag inline; {@code hasDefault(false)} is a no-op. */
+  public ProtobufSchemaDescriptorBuilder hasDefault(boolean value) {
+    current().hasDefaultValue = value;
     return this;
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorBuilder.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorBuilder.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.DType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test-only fluent builder for {@link ProtobufSchemaDescriptor}.
+ *
+ * <p>The descriptor is a set of parallel arrays, which is error-prone to assemble by hand: the
+ * reader has to count positions across a dozen arrays to see what a single field looks like. This
+ * builder lets each field be described in one place, with only the non-default attributes named:
+ *
+ * <pre>{@code
+ * ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+ *     .addField(1, DType.INT32)
+ *     .addField(2, DType.STRING).required()
+ *     .build();
+ * }</pre>
+ *
+ * <p>Each attribute setter applies to the most recently added field. Wire types are derived from
+ * the output type and encoding unless overridden via {@link #wireType(int)}.
+ */
+public final class ProtobufSchemaDescriptorBuilder {
+  private static final class Field {
+    int fieldNumber;
+    int outputTypeId;
+    int parentIndex = -1;
+    int depth = 0;
+    int encoding = Protobuf.ENC_DEFAULT;
+    Integer wireType = null;  // null => derive from output type + encoding
+    boolean isRepeated = false;
+    boolean isRequired = false;
+    boolean hasDefaultValue = false;
+    long defaultInt = 0L;
+    double defaultFloat = 0.0;
+    boolean defaultBool = false;
+    byte[] defaultString = null;
+    int[] enumValidValues = null;
+    byte[][] enumNames = null;
+  }
+
+  private final List<Field> fields = new ArrayList<>();
+
+  /** Start a new top-level field with the given field number and output type. */
+  public ProtobufSchemaDescriptorBuilder addField(int fieldNumber, DType outputType) {
+    Field f = new Field();
+    f.fieldNumber = fieldNumber;
+    f.outputTypeId = outputType.getTypeId().getNativeId();
+    fields.add(f);
+    return this;
+  }
+
+  /**
+   * Mark the current field as a child of {@code parentIndex}, setting its depth to
+   * parent depth + 1.
+   */
+  public ProtobufSchemaDescriptorBuilder parent(int parentIndex) {
+    Field f = current();
+    f.parentIndex = parentIndex;
+    f.depth = fields.get(parentIndex).depth + 1;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder encoding(int encoding) {
+    current().encoding = encoding;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder wireType(int wireType) {
+    current().wireType = wireType;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder repeated() {
+    current().isRepeated = true;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder required() {
+    current().isRequired = true;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder defaultInt(long value) {
+    Field f = current();
+    f.hasDefaultValue = true;
+    f.defaultInt = value;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder defaultFloat(double value) {
+    Field f = current();
+    f.hasDefaultValue = true;
+    f.defaultFloat = value;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder defaultBool(boolean value) {
+    Field f = current();
+    f.hasDefaultValue = true;
+    f.defaultBool = value;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder defaultString(byte[] value) {
+    Field f = current();
+    f.hasDefaultValue = true;
+    f.defaultString = value;
+    return this;
+  }
+
+  /**
+   * Set the has-default flag without a value. Used by negative tests that pair a default with an
+   * incompatible field (e.g. a repeated or STRUCT field) to exercise validation.
+   */
+  public ProtobufSchemaDescriptorBuilder hasDefault() {
+    current().hasDefaultValue = true;
+    return this;
+  }
+
+  /** Provide enum-as-string metadata for the current field (also sets ENC_ENUM_STRING). */
+  public ProtobufSchemaDescriptorBuilder enumMetadata(int[] validValues, byte[][] names) {
+    Field f = current();
+    f.encoding = Protobuf.ENC_ENUM_STRING;
+    f.enumValidValues = validValues;
+    f.enumNames = names;
+    return this;
+  }
+
+  /** Attach raw enum metadata without forcing the encoding (for validation-only tests). */
+  public ProtobufSchemaDescriptorBuilder enumValidValues(int[] validValues) {
+    current().enumValidValues = validValues;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptorBuilder enumNames(byte[][] names) {
+    current().enumNames = names;
+    return this;
+  }
+
+  public ProtobufSchemaDescriptor build() {
+    int n = fields.size();
+    int[] fieldNumbers = new int[n];
+    int[] parentIndices = new int[n];
+    int[] depthLevels = new int[n];
+    int[] wireTypes = new int[n];
+    int[] outputTypeIds = new int[n];
+    int[] encodings = new int[n];
+    boolean[] isRepeated = new boolean[n];
+    boolean[] isRequired = new boolean[n];
+    boolean[] hasDefaultValue = new boolean[n];
+    long[] defaultInts = new long[n];
+    double[] defaultFloats = new double[n];
+    boolean[] defaultBools = new boolean[n];
+    byte[][] defaultStrings = new byte[n][];
+    int[][] enumValidValues = new int[n][];
+    byte[][][] enumNames = new byte[n][][];
+
+    for (int i = 0; i < n; i++) {
+      Field f = fields.get(i);
+      fieldNumbers[i] = f.fieldNumber;
+      parentIndices[i] = f.parentIndex;
+      depthLevels[i] = f.depth;
+      outputTypeIds[i] = f.outputTypeId;
+      encodings[i] = f.encoding;
+      wireTypes[i] = f.wireType != null ? f.wireType : deriveWireType(f.outputTypeId, f.encoding);
+      isRepeated[i] = f.isRepeated;
+      isRequired[i] = f.isRequired;
+      hasDefaultValue[i] = f.hasDefaultValue;
+      defaultInts[i] = f.defaultInt;
+      defaultFloats[i] = f.defaultFloat;
+      defaultBools[i] = f.defaultBool;
+      defaultStrings[i] = f.defaultString;
+      enumValidValues[i] = f.enumValidValues;
+      enumNames[i] = f.enumNames;
+    }
+
+    return new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels, wireTypes,
+        outputTypeIds, encodings, isRepeated, isRequired, hasDefaultValue,
+        defaultInts, defaultFloats, defaultBools, defaultStrings, enumValidValues, enumNames);
+  }
+
+  private Field current() {
+    if (fields.isEmpty()) {
+      throw new IllegalStateException("addField must be called before setting field attributes");
+    }
+    return fields.get(fields.size() - 1);
+  }
+
+  static int deriveWireType(int typeId, int encoding) {
+    if (encoding == Protobuf.ENC_ENUM_STRING) return Protobuf.WT_VARINT;
+    if (typeId == DType.FLOAT32.getTypeId().getNativeId()) return Protobuf.WT_32BIT;
+    if (typeId == DType.FLOAT64.getTypeId().getNativeId()) return Protobuf.WT_64BIT;
+    if (typeId == DType.STRING.getTypeId().getNativeId()) return Protobuf.WT_LEN;
+    if (typeId == DType.LIST.getTypeId().getNativeId()) return Protobuf.WT_LEN;
+    if (typeId == DType.STRUCT.getTypeId().getNativeId()) return Protobuf.WT_LEN;
+    if (encoding == Protobuf.ENC_FIXED) {
+      if (typeId == DType.INT64.getTypeId().getNativeId()
+          || typeId == DType.UINT64.getTypeId().getNativeId()) return Protobuf.WT_64BIT;
+      return Protobuf.WT_32BIT;
+    }
+    return Protobuf.WT_VARINT;
+  }
+}

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
@@ -38,13 +38,11 @@ public class ProtobufSchemaDescriptorTest {
       int[] enumValidValues,
       byte[][] enumNames) {
     DType outputType = (encoding == Protobuf.ENC_ENUM_STRING) ? DType.STRING : DType.INT32;
-    ProtobufSchemaDescriptorBuilder b =
-        new ProtobufSchemaDescriptorBuilder().addField(1, outputType).encoding(encoding);
-    if (isRepeated) b.repeated();
-    if (hasDefaultValue) b.hasDefault();
-    if (enumValidValues != null) b.enumValidValues(enumValidValues);
-    if (enumNames != null) b.enumNames(enumNames);
-    return b.build();
+    return new ProtobufSchemaDescriptorBuilder()
+        .addField(1, outputType).encoding(encoding)
+            .repeated(isRepeated).hasDefault(hasDefaultValue)
+            .enumValidValues(enumValidValues).enumNames(enumNames)
+        .build();
   }
 
   @Test
@@ -137,7 +135,7 @@ public class ProtobufSchemaDescriptorTest {
     assertThrows(IllegalArgumentException.class, () ->
         new ProtobufSchemaDescriptorBuilder()
             .addField(1, DType.STRING).wireType(Protobuf.WT_LEN)
-            .enumMetadata(new int[]{0, 1}, new byte[][]{"A".getBytes(), "B".getBytes()})
+                .enumMetadata(new int[]{0, 1}, new byte[][]{"A".getBytes(), "B".getBytes()})
             .build());
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
@@ -152,6 +152,57 @@ public class ProtobufSchemaDescriptorTest {
   }
 
   @Test
+  void testDownUpNestingMatchesExplicitParent() {
+    // A branching tree:
+    //   message Outer { int32 a = 1; Mid b = 2; int32 f = 3; }
+    //   message Mid   { int32 c = 1; Inner d = 2; }
+    //   message Inner { int32 e = 1; }
+    ProtobufSchemaDescriptor viaDownUp = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).down()        // Outer
+            .addField(1, DType.INT32)            //   a
+            .addField(2, DType.STRUCT).down()    //   b: Mid
+                .addField(1, DType.INT32)        //     c
+                .addField(2, DType.STRUCT).down()//     d: Inner
+                    .addField(1, DType.INT32)    //       e
+                .up()
+            .up()
+            .addField(3, DType.INT32)            //   f
+        .up()
+        .build();
+
+    ProtobufSchemaDescriptor viaExplicitParent = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT)
+        .addField(1, DType.INT32).parent(0)
+        .addField(2, DType.STRUCT).parent(0)
+        .addField(1, DType.INT32).parent(2)
+        .addField(2, DType.STRUCT).parent(2)
+        .addField(1, DType.INT32).parent(4)
+        .addField(3, DType.INT32).parent(0)
+        .build();
+
+    assertArrayEquals(viaExplicitParent.parentIndices, viaDownUp.parentIndices);
+    assertArrayEquals(viaExplicitParent.depthLevels, viaDownUp.depthLevels);
+    assertArrayEquals(viaExplicitParent.fieldNumbers, viaDownUp.fieldNumbers);
+    assertArrayEquals(viaExplicitParent.outputTypeIds, viaDownUp.outputTypeIds);
+    // Spot-check the derived flat indices directly.
+    assertArrayEquals(new int[]{-1, 0, 0, 2, 2, 4, 0}, viaDownUp.parentIndices);
+    assertArrayEquals(new int[]{0, 1, 1, 2, 2, 3, 1}, viaDownUp.depthLevels);
+  }
+
+  @Test
+  void testUnbalancedNestingRejected() {
+    // up() without a matching down()
+    assertThrows(IllegalStateException.class, () ->
+        new ProtobufSchemaDescriptorBuilder().addField(1, DType.STRUCT).up());
+    // down() before any field
+    assertThrows(IllegalStateException.class, () ->
+        new ProtobufSchemaDescriptorBuilder().down());
+    // build() left inside a down() scope (missing up())
+    assertThrows(IllegalStateException.class, () ->
+        new ProtobufSchemaDescriptorBuilder().addField(1, DType.STRUCT).down().build());
+  }
+
+  @Test
   void testSerializationRoundTripPreservesContentsAndIsolation() throws Exception {
     ProtobufSchemaDescriptor original = new ProtobufSchemaDescriptorBuilder()
         .addField(1, DType.STRING)

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.jni;
 
+import ai.rapids.cudf.DType;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -36,25 +37,14 @@ public class ProtobufSchemaDescriptorTest {
       int encoding,
       int[] enumValidValues,
       byte[][] enumNames) {
-    int outputType = (encoding == Protobuf.ENC_ENUM_STRING)
-        ? ai.rapids.cudf.DType.STRING.getTypeId().getNativeId()
-        : ai.rapids.cudf.DType.INT32.getTypeId().getNativeId();
-    return new ProtobufSchemaDescriptor(
-        new int[]{1},
-        new int[]{-1},
-        new int[]{0},
-        new int[]{Protobuf.WT_VARINT},
-        new int[]{outputType},
-        new int[]{encoding},
-        new boolean[]{isRepeated},
-        new boolean[]{false},
-        new boolean[]{hasDefaultValue},
-        new long[]{0},
-        new double[]{0.0},
-        new boolean[]{false},
-        new byte[][]{null},
-        new int[][]{enumValidValues},
-        new byte[][][]{enumNames});
+    DType outputType = (encoding == Protobuf.ENC_ENUM_STRING) ? DType.STRING : DType.INT32;
+    ProtobufSchemaDescriptorBuilder b =
+        new ProtobufSchemaDescriptorBuilder().addField(1, outputType).encoding(encoding);
+    if (isRepeated) b.repeated();
+    if (hasDefaultValue) b.hasDefault();
+    if (enumValidValues != null) b.enumValidValues(enumValidValues);
+    if (enumNames != null) b.enumNames(enumNames);
+    return b.build();
   }
 
   @Test
@@ -66,64 +56,25 @@ public class ProtobufSchemaDescriptorTest {
   @Test
   void testFieldCannotBeBothRepeatedAndRequired() {
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{Protobuf.WT_VARINT},
-            new int[]{ai.rapids.cudf.DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
-            new boolean[]{true},
-            new boolean[]{true},
-            new boolean[]{false},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{null},
-            new byte[][][]{null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.INT32).repeated().required()
+            .build());
   }
 
   @Test
   void testStructFieldCannotCarryDefaultValue() {
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{Protobuf.WT_LEN},
-            new int[]{ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
-            new boolean[]{false},
-            new boolean[]{false},
-            new boolean[]{true},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{null},
-            new byte[][][]{null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.STRUCT).hasDefault()
+            .build());
   }
 
   @Test
   void testListFieldCannotCarryDefaultValue() {
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{Protobuf.WT_LEN},
-            new int[]{ai.rapids.cudf.DType.LIST.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
-            new boolean[]{false},
-            new boolean[]{false},
-            new boolean[]{true},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{null},
-            new byte[][][]{null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.LIST).hasDefault()
+            .build());
   }
 
   @Test
@@ -146,173 +97,69 @@ public class ProtobufSchemaDescriptorTest {
   @Test
   void testDuplicateFieldNumbersUnderSameParentRejected() {
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1, 7, 7},
-            new int[]{-1, 0, 0},
-            new int[]{0, 1, 1},
-            new int[]{Protobuf.WT_LEN, Protobuf.WT_VARINT, Protobuf.WT_VARINT},
-            new int[]{
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-            new boolean[]{false, false, false},
-            new boolean[]{false, false, false},
-            new boolean[]{false, false, false},
-            new long[]{0, 0, 0},
-            new double[]{0.0, 0.0, 0.0},
-            new boolean[]{false, false, false},
-            new byte[][]{null, null, null},
-            new int[][]{null, null, null},
-            new byte[][][]{null, null, null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.STRUCT)
+            .addField(7, DType.INT32).parent(0)
+            .addField(7, DType.INT32).parent(0)  // duplicate field number under same parent
+            .build());
   }
 
   @Test
   void testDuplicateFieldNumbersUnderDifferentParentsAllowed() {
     assertDoesNotThrow(() ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1, 2, 7, 7},
-            new int[]{-1, -1, 0, 1},
-            new int[]{0, 0, 1, 1},
-            new int[]{Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_VARINT, Protobuf.WT_VARINT},
-            new int[]{
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId()},
-            new int[]{
-                Protobuf.ENC_DEFAULT,
-                Protobuf.ENC_DEFAULT,
-                Protobuf.ENC_DEFAULT,
-                Protobuf.ENC_DEFAULT},
-            new boolean[]{false, false, false, false},
-            new boolean[]{false, false, false, false},
-            new boolean[]{false, false, false, false},
-            new long[]{0, 0, 0, 0},
-            new double[]{0.0, 0.0, 0.0, 0.0},
-            new boolean[]{false, false, false, false},
-            new byte[][]{null, null, null, null},
-            new int[][]{null, null, null, null},
-            new byte[][][]{null, null, null, null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.STRUCT)
+            .addField(2, DType.STRUCT)
+            .addField(7, DType.INT32).parent(0)
+            .addField(7, DType.INT32).parent(1)  // same number, different parents -> allowed
+            .build());
   }
 
   @Test
   void testChildParentMustBeStruct() {
+    // Field 2 is parented under field 1, but field 1 is INT32 (not STRUCT) -> illegal.
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1, 2},
-            new int[]{-1, 0},
-            new int[]{0, 1},
-            new int[]{Protobuf.WT_VARINT, Protobuf.WT_VARINT},
-            new int[]{
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-            new boolean[]{false, false},
-            new boolean[]{false, false},
-            new boolean[]{false, false},
-            new long[]{0, 0},
-            new double[]{0.0, 0.0},
-            new boolean[]{false, false},
-            new byte[][]{null, null},
-            new int[][]{null, null},
-            new byte[][][]{null, null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.INT32)
+            .addField(2, DType.INT32).parent(0)
+            .build());
   }
 
   @Test
   void testEncodingCompatibilityValidation() {
+    // INT32 with a 32-bit wire type under default (non-fixed) encoding is incompatible.
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{Protobuf.WT_32BIT},
-            new int[]{ai.rapids.cudf.DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
-            new boolean[]{false},
-            new boolean[]{false},
-            new boolean[]{false},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{null},
-            new byte[][][]{null}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.INT32).wireType(Protobuf.WT_32BIT)
+            .build());
 
+    // Enum-as-string must use the varint wire type; WT_LEN is incompatible.
     assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{Protobuf.WT_LEN},
-            new int[]{ai.rapids.cudf.DType.STRING.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_ENUM_STRING},
-            new boolean[]{false},
-            new boolean[]{false},
-            new boolean[]{false},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{{0, 1}},
-            new byte[][][]{new byte[][]{"A".getBytes(), "B".getBytes()}}));
+        new ProtobufSchemaDescriptorBuilder()
+            .addField(1, DType.STRING).wireType(Protobuf.WT_LEN)
+            .enumMetadata(new int[]{0, 1}, new byte[][]{"A".getBytes(), "B".getBytes()})
+            .build());
   }
 
   @Test
   void testDepthAboveSupportedLimitRejected() {
-    assertThrows(IllegalArgumentException.class, () ->
-        new ProtobufSchemaDescriptor(
-            new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
-            new int[]{-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-            new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-            new int[]{Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_LEN,
-                Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_LEN,
-                Protobuf.WT_LEN, Protobuf.WT_LEN, Protobuf.WT_VARINT},
-            new int[]{
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.STRUCT.getTypeId().getNativeId(),
-                ai.rapids.cudf.DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT,
-                Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT,
-                Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT,
-                Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-            new boolean[]{false, false, false, false, false, false, false, false, false, false, false},
-            new boolean[]{false, false, false, false, false, false, false, false, false, false, false},
-            new boolean[]{false, false, false, false, false, false, false, false, false, false, false},
-            new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-            new boolean[]{false, false, false, false, false, false, false, false, false, false, false},
-            new byte[][]{null, null, null, null, null, null, null, null, null, null, null},
-            new int[][]{null, null, null, null, null, null, null, null, null, null, null},
-            new byte[][][]{null, null, null, null, null, null, null, null, null, null, null}));
+    // Build a STRUCT chain reaching depth 10 (one past the limit), capped with an INT32 leaf.
+    ProtobufSchemaDescriptorBuilder builder = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT);
+    for (int i = 1; i <= 9; i++) {
+      builder.addField(i + 1, DType.STRUCT).parent(i - 1);
+    }
+    builder.addField(11, DType.INT32).parent(9);  // depth 10 -> exceeds limit
+    assertThrows(IllegalArgumentException.class, builder::build);
   }
 
   @Test
   void testSerializationRoundTripPreservesContentsAndIsolation() throws Exception {
-    ProtobufSchemaDescriptor original = new ProtobufSchemaDescriptor(
-        new int[]{1},
-        new int[]{-1},
-        new int[]{0},
-        new int[]{Protobuf.WT_VARINT},
-        new int[]{ai.rapids.cudf.DType.STRING.getTypeId().getNativeId()},
-        new int[]{Protobuf.ENC_ENUM_STRING},
-        new boolean[]{false},
-        new boolean[]{false},
-        new boolean[]{false},
-        new long[]{7},
-        new double[]{0.0},
-        new boolean[]{false},
-        new byte[][]{"def".getBytes()},
-        new int[][]{{0, 1}},
-        new byte[][][]{new byte[][]{"A".getBytes(), "B".getBytes()}});
+    ProtobufSchemaDescriptor original = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRING)
+            .enumMetadata(new int[]{0, 1}, new byte[][]{"A".getBytes(), "B".getBytes()})
+            .defaultString("def".getBytes())
+        .build();
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufSchemaDescriptorTest.java
@@ -159,6 +159,7 @@ public class ProtobufSchemaDescriptorTest {
         .addField(1, DType.STRING)
             .enumMetadata(new int[]{0, 1}, new byte[][]{"A".getBytes(), "B".getBytes()})
             .defaultString("def".getBytes())
+            .defaultInt(7)  // non-zero numeric default to exercise scalar round-trip
         .build();
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -173,6 +174,7 @@ public class ProtobufSchemaDescriptorTest {
 
     assertEquals(original.numFields(), roundTrip.numFields());
     assertArrayEquals(original.fieldNumbers, roundTrip.fieldNumbers);
+    assertArrayEquals(original.defaultInts, roundTrip.defaultInts);
     assertArrayEquals(original.defaultStrings[0], roundTrip.defaultStrings[0]);
     assertArrayEquals(original.enumValidValues[0], roundTrip.enumValidValues[0]);
     assertArrayEquals(original.enumNames[0][0], roundTrip.enumNames[0][0]);

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -127,118 +127,11 @@ public class ProtobufTest {
     return out;
   }
 
-  // ============================================================================
-  // Helper methods for calling the unified API
-  // ============================================================================
-
-  private static ProtobufSchemaDescriptor makeScalarSchema(int[] fieldNumbers, int[] typeIds,
-                                                           int[] encodings) {
-    int n = fieldNumbers.length;
-    int[] parentIndices = new int[n];
-    int[] depthLevels = new int[n];
-    int[] wireTypes = new int[n];
-    boolean[] isRepeated = new boolean[n];
-    boolean[] isRequired = new boolean[n];
-    boolean[] hasDefault = new boolean[n];
-    long[] defaultInts = new long[n];
-    double[] defaultFloats = new double[n];
-    boolean[] defaultBools = new boolean[n];
-    byte[][] defaultStrings = new byte[n][];
-    int[][] enumValid = new int[n][];
-    byte[][][] enumNames = new byte[n][][];
-
-    java.util.Arrays.fill(parentIndices, -1);
-    for (int i = 0; i < n; i++) {
-      wireTypes[i] = ProtobufSchemaDescriptorBuilder.deriveWireType(typeIds[i], encodings[i]);
-    }
-    return new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
-        wireTypes, typeIds, encodings, isRepeated, isRequired, hasDefault,
-        defaultInts, defaultFloats, defaultBools, defaultStrings, enumValid, enumNames);
-  }
-
-  /**
-   * Helper to decode all scalar fields using the unified API.
-   * Builds a flat schema (parentIndices=-1, depth=0, isRepeated=false for all fields).
-   */
-  private static ColumnVector decodeScalarFields(ColumnView binaryInput,
-                                                 int[] fieldNumbers,
-                                                 int[] typeIds,
-                                                 int[] encodings,
-                                                 boolean[] isRequired,
-                                                 boolean[] hasDefaultValue,
-                                                 long[] defaultInts,
-                                                 double[] defaultFloats,
-                                                 boolean[] defaultBools,
-                                                 byte[][] defaultStrings,
-                                                 int[][] enumValidValues,
-                                                 boolean failOnErrors) {
-    int numFields = fieldNumbers.length;
-    int[] parentIndices = new int[numFields];
-    int[] depthLevels = new int[numFields];
-    int[] wireTypes = new int[numFields];
-    boolean[] isRepeated = new boolean[numFields];
-
-    java.util.Arrays.fill(parentIndices, -1);
-    // depthLevels already initialized to 0
-    // isRepeated already initialized to false
-    for (int i = 0; i < numFields; i++) {
-      wireTypes[i] = ProtobufSchemaDescriptorBuilder.deriveWireType(typeIds[i], encodings[i]);
-    }
-
-    return Protobuf.decodeToStruct(binaryInput,
-        new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
-            wireTypes, typeIds, encodings, isRepeated, isRequired, hasDefaultValue,
-            defaultInts, defaultFloats, defaultBools, defaultStrings, enumValidValues,
-            new byte[fieldNumbers.length][][]),
-        failOnErrors);
-  }
-
-  /**
-   * Helper method that wraps the unified API for tests that decode all scalar fields.
-   */
-  private static ColumnVector decodeAllFields(ColumnView binaryInput,
-                                              int[] fieldNumbers,
-                                              int[] typeIds,
-                                              int[] encodings) {
-    return decodeAllFields(binaryInput, fieldNumbers, typeIds, encodings, true);
-  }
-
-  /**
-   * Helper method that wraps the unified API for tests that decode all scalar fields.
-   */
-  private static ColumnVector decodeAllFields(ColumnView binaryInput,
-                                              int[] fieldNumbers,
-                                              int[] typeIds,
-                                              int[] encodings,
-                                              boolean failOnErrors) {
-    int numFields = fieldNumbers.length;
-    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
-        new boolean[numFields], new boolean[numFields], new long[numFields],
-        new double[numFields], new boolean[numFields], new byte[numFields][],
-        new int[numFields][], failOnErrors);
-  }
-
   private static void assertSingleNullStructRow(ColumnVector actual, String message) {
     try (HostColumnVector hostStruct = actual.copyToHost()) {
       assertEquals(1, actual.getNullCount(), message);
       assertTrue(hostStruct.isNull(0), "Row 0 should be null");
     }
-  }
-
-  /**
-   * Helper method for tests with required field support.
-   */
-  private static ColumnVector decodeAllFieldsWithRequired(ColumnView binaryInput,
-                                                          int[] fieldNumbers,
-                                                          int[] typeIds,
-                                                          int[] encodings,
-                                                          boolean[] isRequired,
-                                                          boolean failOnErrors) {
-    int numFields = fieldNumbers.length;
-    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
-        isRequired, new boolean[numFields], new long[numFields],
-        new double[numFields], new boolean[numFields], new byte[numFields][],
-        new int[numFields][], failOnErrors);
   }
 
   // ============================================================================
@@ -268,11 +161,13 @@ public class ProtobufTest {
          ColumnVector expectedId = ColumnVector.fromBoxedLongs(100L, 200L, null);
          ColumnVector expectedName = ColumnVector.fromStrings("alice", null, null);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedId, expectedName);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
-             new int[]{0, 0})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .addField(2, DType.STRING)
+                 .build(),
+             true)) {
       // Row 2 is a null input row — the output struct row should also be null.
       assertEquals(3, actualStruct.getRowCount());
       assertEquals(1, actualStruct.getNullCount());
@@ -315,19 +210,15 @@ public class ProtobufTest {
          ColumnVector expectedB = ColumnVector.fromLists(
             new ListType(true, new BasicType(true, DType.UINT8)),
              Arrays.asList((byte) 1, (byte) 2, (byte) 3));
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2, 3, 4},
-             new int[]{
-                 DType.UINT32.getTypeId().getNativeId(),
-                 DType.INT64.getTypeId().getNativeId(),
-                 DType.INT32.getTypeId().getNativeId(),
-                 DType.LIST.getTypeId().getNativeId()},
-             new int[]{
-                 Protobuf.ENC_DEFAULT,
-                 Protobuf.ENC_ZIGZAG,
-                 Protobuf.ENC_FIXED,
-                 Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.UINT32)
+                 .addField(2, DType.INT64).encoding(Protobuf.ENC_ZIGZAG)
+                 .addField(3, DType.INT32).encoding(Protobuf.ENC_FIXED)
+                 .addField(4, DType.LIST)
+                 .build(),
+             true)) {
       try (ColumnVector expectedU32Correct = expectedU32.castTo(DType.UINT32);
            ColumnVector expectedStructCorrect = ColumnVector.makeStruct(
                expectedU32Correct, expectedS64, expectedF32, expectedB)) {
@@ -354,14 +245,14 @@ public class ProtobufTest {
          ColumnVector expectedFloat = ColumnVector.fromBoxedFloats(3.14f, -1.5f);
          ColumnVector expectedDouble = ColumnVector.fromBoxedDoubles(2.71828, 0.0);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedBool, expectedFloat, expectedDouble);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2, 3},
-             new int[]{
-                 DType.BOOL8.getTypeId().getNativeId(),
-                 DType.FLOAT32.getTypeId().getNativeId(),
-                 DType.FLOAT64.getTypeId().getNativeId()},
-             new int[]{0, 0, 0})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.BOOL8)
+                 .addField(2, DType.FLOAT32)
+                 .addField(3, DType.FLOAT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -384,14 +275,13 @@ public class ProtobufTest {
          ColumnVector expectedF1 = ColumnVector.fromBoxedLongs(100L);
          ColumnVector expectedF3 = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedF1, expectedF3);
-         // Decode only f1 (field_number=1) and f3 (field_number=3), skip f2
-         // With the unified API, we only include the fields we want in the schema
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 3},  // field numbers for f1 and f3
-             new int[]{DType.INT64.getTypeId().getNativeId(),
-                       DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)   // f1
+                 .addField(3, DType.INT32)   // f3 (f2 skipped -> projection)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -405,11 +295,11 @@ public class ProtobufTest {
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0}).build();
          // With no fields in the schema, the GPU returns an empty struct
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{},  // no field numbers
-             new int[]{},  // no types
-             new int[]{})) {  // no encodings
+             new ProtobufSchemaDescriptorBuilder()
+                 .build(),
+             true)) {
       assertNotNull(actualStruct);
       assertEquals(DType.STRUCT, actualStruct.getType());
     }
@@ -429,11 +319,12 @@ public class ProtobufTest {
                    (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0x01});
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.UINT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.UINT64)
+                 .build(),
+             true)) {
       try (ColumnVector expectedU64 = ColumnVector.fromBoxedLongs(-1L);  // -1 as unsigned = max
            ColumnVector expectedU64Correct = expectedU64.castTo(DType.UINT64);
            ColumnVector expectedStruct = ColumnVector.makeStruct(expectedU64Correct)) {
@@ -451,7 +342,7 @@ public class ProtobufTest {
     Byte[] row = new Byte[]{0x08, 0x01};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(new int[]{}, new int[]{}, new int[]{}), true)) {
+             new ProtobufSchemaDescriptorBuilder().build(), true)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(1, result.getRowCount());
@@ -467,11 +358,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(0L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -481,10 +373,9 @@ public class ProtobufTest {
     Byte[] row = new Byte[]{0x08, 0x01};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(
-                 new int[]{1},
-                 new int[]{DType.INT64.getTypeId().getNativeId()},
-                 new int[]{Protobuf.ENC_DEFAULT}), true)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(), true)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(1, result.getRowCount());
@@ -505,11 +396,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(0L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -524,11 +416,11 @@ public class ProtobufTest {
                    (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0x02});  // 0x02 has 2nd bit set
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              false)) {
       try (ColumnVector expected = ColumnVector.fromBoxedLongs((Long)null);
            ColumnVector expectedStruct = ColumnVector.makeStruct(expected)) {
@@ -553,11 +445,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(minInt32);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ZIGZAG})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).encoding(Protobuf.ENC_ZIGZAG)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -574,11 +467,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(maxInt32);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ZIGZAG})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).encoding(Protobuf.ENC_ZIGZAG)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -594,11 +488,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedLong = ColumnVector.fromBoxedLongs(minInt64);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ZIGZAG})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).encoding(Protobuf.ENC_ZIGZAG)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -613,11 +508,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedLong = ColumnVector.fromBoxedLongs(maxInt64);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ZIGZAG})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).encoding(Protobuf.ENC_ZIGZAG)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -632,11 +528,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedLong = ColumnVector.fromBoxedLongs(-1L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ZIGZAG})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).encoding(Protobuf.ENC_ZIGZAG)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -652,11 +549,11 @@ public class ProtobufTest {
                                    (byte)0xFF, (byte)0xFF, (byte)0xFF,
                                    (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{malformed}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Malformed varint should null the struct row");
     }
@@ -667,11 +564,11 @@ public class ProtobufTest {
     // Single byte with continuation bit set but no following byte
     Byte[] truncated = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte)0x80});
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Truncated varint should null the struct row");
     }
@@ -682,11 +579,11 @@ public class ProtobufTest {
     // String field with length=5 but no actual data
     Byte[] truncated = concat(box(tag(2, WT_LEN)), box(encodeVarint(5)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{2},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(2, DType.STRING)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result,
           "Truncated length-delimited field should null the struct row");
@@ -698,11 +595,11 @@ public class ProtobufTest {
     // Fixed32 needs 4 bytes but only 3 provided
     Byte[] truncated = concat(box(tag(1, WT_32BIT)), new Byte[]{0x01, 0x02, 0x03});
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_FIXED},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).encoding(Protobuf.ENC_FIXED)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Truncated fixed32 should null the struct row");
     }
@@ -714,11 +611,11 @@ public class ProtobufTest {
     Byte[] truncated = concat(box(tag(1, WT_64BIT)), 
         new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_FIXED},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).encoding(Protobuf.ENC_FIXED)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Truncated fixed64 should null the struct row");
     }
@@ -732,11 +629,11 @@ public class ProtobufTest {
         box(encodeVarint(10)),
         box("hello".getBytes()));  // only 5 bytes
     try (Table input = new Table.TestBuilder().column(new Byte[][]{partial}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result,
           "Partial length-delimited payload should null the struct row");
@@ -754,11 +651,11 @@ public class ProtobufTest {
         box(tag(1, WT_32BIT)),  // wire type 5 instead of 0
         box(encodeFixed32(100)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{wrongType}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},  // expects varint
-             new int[]{Protobuf.ENC_DEFAULT},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Wrong wire type should null the struct row");
     }
@@ -771,11 +668,11 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)),
         box(encodeVarint(12345)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{wrongType}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},  // expects LEN
-             new int[]{Protobuf.ENC_DEFAULT},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Wrong wire type for string should null the struct row");
     }
@@ -797,11 +694,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -818,11 +716,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -840,11 +739,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -861,11 +761,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(42L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -885,11 +786,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs(300L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -905,11 +807,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedStr = ColumnVector.fromStrings("last");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -925,11 +828,11 @@ public class ProtobufTest {
                                    (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{malformed}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              true)) {
         }
       });
@@ -941,11 +844,11 @@ public class ProtobufTest {
     // Field number 0 is reserved and invalid
     Byte[] invalid = concat(box(tag(0, WT_VARINT)), box(encodeVarint(123)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{invalid}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              false)) {
       assertSingleNullStructRow(result, "Field number zero should null the struct row");
     }
@@ -959,11 +862,13 @@ public class ProtobufTest {
          ColumnVector expectedInt = ColumnVector.fromBoxedLongs((Long)null);
          ColumnVector expectedStr = ColumnVector.fromStrings((String)null);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt, expectedStr);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
-             new int[]{0, 0})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .addField(2, DType.STRING)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -985,11 +890,12 @@ public class ProtobufTest {
              Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN, 
              Float.MIN_VALUE, Float.MAX_VALUE);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedFloat);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.FLOAT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.FLOAT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1007,11 +913,12 @@ public class ProtobufTest {
              Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN,
              Double.MIN_VALUE, Double.MAX_VALUE);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedDouble);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.FLOAT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.FLOAT64)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1029,11 +936,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(1);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1047,11 +955,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(0);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1065,11 +974,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(999);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1083,11 +993,12 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(-1);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1106,13 +1017,14 @@ public class ProtobufTest {
          ColumnVector expectedCount = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedS2 = ColumnVector.fromBoxedInts(0);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedS1, expectedCount, expectedS2);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2, 3},
-             new int[]{DType.INT32.getTypeId().getNativeId(),
-                       DType.INT32.getTypeId().getNativeId(),
-                       DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .addField(2, DType.INT32)
+                 .addField(3, DType.INT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1126,12 +1038,13 @@ public class ProtobufTest {
          ColumnVector expectedEnum = ColumnVector.fromBoxedInts((Integer) null);
          ColumnVector expectedCount = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedEnum, expectedCount);
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(),
-                       DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .addField(2, DType.INT32)
+                 .build(),
+             true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
   }
@@ -1152,12 +1065,12 @@ public class ProtobufTest {
          ColumnVector expectedId = ColumnVector.fromBoxedLongs(42L);
          ColumnVector expectedName = ColumnVector.fromStrings("hello");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedId, expectedName);
-         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{true, false},  // id is required, name is optional
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).required()
+                 .addField(2, DType.STRING)
+                 .build(),
              true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1172,12 +1085,12 @@ public class ProtobufTest {
         box(tag(2, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{true, false},  // id is required, name is optional
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).required()
+                 .addField(2, DType.STRING)
+                 .build(),
              false)) {  // permissive mode - don't fail on errors
       assertSingleNullStructRow(actualStruct,
           "Missing top-level required field should null the row in PERMISSIVE mode");
@@ -1194,12 +1107,12 @@ public class ProtobufTest {
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFieldsWithRequired(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1, 2},
-            new int[]{DType.INT64.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-            new boolean[]{true, false},  // id is required, name is optional
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64).required()
+                .addField(2, DType.STRING)
+                .build(),
             true)) {  // failfast mode - should throw
         }
       });
@@ -1219,14 +1132,13 @@ public class ProtobufTest {
          ColumnVector expectedB = ColumnVector.fromBoxedLongs(20L);
          ColumnVector expectedC = ColumnVector.fromStrings("abc");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB, expectedC);
-         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2, 3},
-             new int[]{DType.INT32.getTypeId().getNativeId(),
-                       DType.INT64.getTypeId().getNativeId(),
-                       DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{true, true, true},  // all required
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).required()
+                 .addField(2, DType.INT64).required()
+                 .addField(3, DType.STRING).required()
+                 .build(),
              true)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1241,14 +1153,13 @@ public class ProtobufTest {
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFieldsWithRequired(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1, 2, 3},
-            new int[]{DType.INT32.getTypeId().getNativeId(),
-                      DType.INT64.getTypeId().getNativeId(),
-                      DType.STRING.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-            new boolean[]{true, true, true},  // all required
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT32).required()
+                .addField(2, DType.INT64).required()
+                .addField(3, DType.STRING).required()
+                .build(),
             true)) {
         }
       });
@@ -1265,12 +1176,12 @@ public class ProtobufTest {
          ColumnVector expectedA = ColumnVector.fromBoxedInts((Integer) null);
          ColumnVector expectedB = ColumnVector.fromBoxedLongs((Long) null);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
-         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false},  // all optional
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .addField(2, DType.INT64)
+                 .build(),
              true)) {  // even with failOnErrors=true, should succeed since all fields are optional
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1286,12 +1197,11 @@ public class ProtobufTest {
 
     try (Table input = new Table.TestBuilder().column(row0, row1).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFieldsWithRequired(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
-            new boolean[]{true},  // required
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64).required()
+                .build(),
             true)) {
         }
       });
@@ -1304,12 +1214,11 @@ public class ProtobufTest {
     Byte[] row1 = null;
 
     try (Table input = new Table.TestBuilder().column(row0, row1).build();
-         ColumnVector actualStruct = decodeAllFieldsWithRequired(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).required()
+                 .build(),
              true);
          ColumnVector idCol = actualStruct.getChildColumnView(0).copyToColumnVector();
          HostColumnVector hostStruct = actualStruct.copyToHost();
@@ -1326,26 +1235,6 @@ public class ProtobufTest {
   // Default Value Tests (API accepts parameters, CUDA fill not yet implemented)
   // ============================================================================
 
-  /**
-   * Helper method for tests with default value support.
-   */
-  private static ColumnVector decodeAllFieldsWithDefaults(ColumnView binaryInput,
-                                                          int[] fieldNumbers,
-                                                          int[] typeIds,
-                                                          int[] encodings,
-                                                          boolean[] isRequired,
-                                                          boolean[] hasDefaultValue,
-                                                          long[] defaultInts,
-                                                          double[] defaultFloats,
-                                                          boolean[] defaultBools,
-                                                          byte[][] defaultStrings,
-                                                          boolean failOnErrors) {
-    int numFields = fieldNumbers.length;
-    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
-        isRequired, hasDefaultValue, defaultInts, defaultFloats, defaultBools,
-        defaultStrings, new int[numFields][], failOnErrors);
-  }
-
   @Test
   void testDefaultValueForMissingFields() {
     // Test that missing fields with default values return the defaults
@@ -1356,17 +1245,12 @@ public class ProtobufTest {
          ColumnVector expectedA = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedB = ColumnVector.fromBoxedLongs(100L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false},  // not required
-             new boolean[]{true, true},    // has default value
-             new long[]{42, 100},          // default int values (42, 100)
-             new double[]{0.0, 0.0},       // default float values (unused for int fields)
-             new boolean[]{false, false},  // default bool values (unused)
-             new byte[][]{null, null},     // default string values (unused)
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).defaultInt(42)
+                 .addField(2, DType.INT64).defaultInt(100)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1383,17 +1267,12 @@ public class ProtobufTest {
          ColumnVector expectedA = ColumnVector.fromBoxedInts(99);
          ColumnVector expectedB = ColumnVector.fromBoxedLongs(200L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false},  // not required
-             new boolean[]{true, true},    // has default value
-             new long[]{42, 100},          // default values - NOT used since field is present
-             new double[]{0.0, 0.0},
-             new boolean[]{false, false},
-             new byte[][]{null, null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).defaultInt(42)
+                 .addField(2, DType.INT64).defaultInt(100)
+                 .build(),
              false)) {
       // Actual values should be used, not defaults
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
@@ -1409,17 +1288,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},   // not required
-             new boolean[]{true},    // has default
-             new long[]{42},         // default = 42
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).defaultInt(42)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1433,17 +1306,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedBool = ColumnVector.fromBoxedBooleans(true);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedBool);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.BOOL8.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{true},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{true},  // default = true
-             new byte[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.BOOL8).defaultBool(true)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1457,17 +1324,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedDouble = ColumnVector.fromBoxedDoubles(3.14);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedDouble);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.FLOAT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{true},
-             new long[]{0},
-             new double[]{3.14},  // default = 3.14
-             new boolean[]{false},
-             new byte[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.FLOAT64).defaultFloat(3.14)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1481,17 +1342,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedLong = ColumnVector.fromBoxedLongs(9876543210L);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedLong);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{true},
-             new long[]{9876543210L},  // default = 9876543210
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).defaultInt(9876543210L)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1510,19 +1365,13 @@ public class ProtobufTest {
          ColumnVector expectedB = ColumnVector.fromBoxedLongs((Long) null);  // no default
          ColumnVector expectedC = ColumnVector.fromBoxedBooleans(true);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB, expectedC);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2, 3},
-             new int[]{DType.INT32.getTypeId().getNativeId(),
-                       DType.INT64.getTypeId().getNativeId(),
-                       DType.BOOL8.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false, false},  // not required
-             new boolean[]{true, false, true},    // a and c have defaults, b doesn't
-             new long[]{42, 0, 0},                // default for a
-             new double[]{0.0, 0.0, 0.0},
-             new boolean[]{false, false, true},   // default for c
-             new byte[][]{null, null, null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).defaultInt(42)
+                 .addField(2, DType.INT64)
+                 .addField(3, DType.BOOL8).defaultBool(true)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1540,17 +1389,12 @@ public class ProtobufTest {
          ColumnVector expectedA = ColumnVector.fromBoxedInts(42);  // default
          ColumnVector expectedB = ColumnVector.fromBoxedLongs(999L);  // actual value
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedA, expectedB);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false},  // not required
-             new boolean[]{true, true},    // both have defaults
-             new long[]{42, 100},
-             new double[]{0.0, 0.0},
-             new boolean[]{false, false},
-             new byte[][]{null, null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).defaultInt(42)
+                 .addField(2, DType.INT64).defaultInt(100)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1565,17 +1409,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedStr = ColumnVector.fromStrings("hello");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},   // not required
-             new boolean[]{true},    // has default
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{"hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).defaultString("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1590,17 +1428,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedStr = ColumnVector.fromStrings("");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{true},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{new byte[0]},  // empty default string
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).defaultString(new byte[0])
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1619,17 +1451,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedStr = ColumnVector.fromStrings("actual");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{true},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{"default".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).defaultString("default".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1646,17 +1472,12 @@ public class ProtobufTest {
          ColumnVector expectedInt = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedStr = ColumnVector.fromStrings("test");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedInt, expectedStr);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false},
-             new boolean[]{true, true},
-             new long[]{42, 0},
-             new double[]{0.0, 0.0},
-             new boolean[]{false, false},
-             new byte[][]{null, "test".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).defaultInt(42)
+                 .addField(2, DType.STRING).defaultString("test".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1677,17 +1498,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row1, row2, row3}).build();
          ColumnVector expectedStr = ColumnVector.fromStrings("default", "row2val", "default");
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedStr);
-         ColumnVector actualStruct = decodeAllFieldsWithDefaults(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{true},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{"default".getBytes(java.nio.charset.StandardCharsets.UTF_8)},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).defaultString("default".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1707,11 +1522,10 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(3)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
-      // Field: ids (field_number=1, repeated int32)
       try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
           new ProtobufSchemaDescriptorBuilder()
-              .addField(1, DType.INT32).repeated()
+              .addField(1, DType.INT32).repeated()  // ids
               .build(),
           false)) {
         // Result should be STRUCT<ids: LIST<INT32>> containing [1, 2, 3]
@@ -1783,7 +1597,7 @@ public class ProtobufTest {
       try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
           new ProtobufSchemaDescriptorBuilder()
-              .addField(1, DType.INT32)            // id
+              .addField(1, DType.INT32)               // id
               .addField(2, DType.INT32).repeated()    // int_values (packed)
               .addField(3, DType.FLOAT64).repeated()  // double_values (packed)
               .addField(4, DType.BOOL8).repeated()    // bool_values (packed)
@@ -1843,15 +1657,11 @@ public class ProtobufTest {
         innerMessage);
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
-      // Flattened schema:
-      // [0] inner: STRUCT, field_number=1, parent=-1, depth=0
-      // [1] inner.x: INT32, field_number=1, parent=0, depth=1
-      // Flattened schema: [0] inner STRUCT, [1] inner.x INT32 (child of 0)
       try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
           new ProtobufSchemaDescriptorBuilder()
-              .addField(1, DType.STRUCT)
-              .addField(1, DType.INT32).parent(0)
+              .addField(1, DType.STRUCT)           // inner
+              .addField(1, DType.INT32).parent(0)  // inner.x
               .build(),
           false)) {
         assertNotNull(result);
@@ -1953,11 +1763,11 @@ public class ProtobufTest {
                                    (byte)0xFF, (byte)0xFF, (byte)0xFF, (byte)0xFF};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{malformed}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{0},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64)
+                .build(),
             true)) {  // failOnErrors = true
         }
       });
@@ -1970,11 +1780,11 @@ public class ProtobufTest {
     Byte[] truncated = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte)0x80});
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{0},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64)
+                .build(),
             true)) {
         }
       });
@@ -1987,11 +1797,11 @@ public class ProtobufTest {
     Byte[] truncated = concat(box(tag(2, WT_LEN)), box(encodeVarint(5)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{2},
-            new int[]{DType.STRING.getTypeId().getNativeId()},
-            new int[]{0},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(2, DType.STRING)
+                .build(),
             true)) {
         }
       });
@@ -2004,11 +1814,11 @@ public class ProtobufTest {
     Byte[] truncated = concat(box(tag(1, WT_32BIT)), new Byte[]{0x01, 0x02, 0x03});
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_FIXED},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT32).encoding(Protobuf.ENC_FIXED)
+                .build(),
             true)) {
         }
       });
@@ -2021,11 +1831,11 @@ public class ProtobufTest {
     Byte[] truncated = concat(box(tag(1, WT_64BIT)), new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
     try (Table input = new Table.TestBuilder().column(new Byte[][]{truncated}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_FIXED},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64).encoding(Protobuf.ENC_FIXED)
+                .build(),
             true)) {
         }
       });
@@ -2038,11 +1848,11 @@ public class ProtobufTest {
     Byte[] row = concat(box(tag(1, WT_LEN)), box(encodeVarint(3)), box("abc".getBytes()));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64)
+                .build(),
             true)) {
         }
       });
@@ -2055,11 +1865,11 @@ public class ProtobufTest {
     Byte[] row = concat(box(tag(0, WT_VARINT)), box(encodeVarint(42)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{0},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64)
+                .build(),
             true)) {
         }
       });
@@ -2072,11 +1882,11 @@ public class ProtobufTest {
     Byte[] row = concat(box(tag(1 << 29, WT_VARINT)), box(encodeVarint(42)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(ai.rapids.cudf.CudfException.class, () -> {
-        try (ColumnVector result = decodeAllFields(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_DEFAULT},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64)
+                .build(),
             true)) {
         }
       });
@@ -2089,11 +1899,11 @@ public class ProtobufTest {
         box(tag(5, 4)),
         box(tag(1, WT_VARINT)), box(encodeVarint(42)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actual = decodeAllFields(
+         ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              false)) {
       assertSingleNullStructRow(actual, "Unknown end-group wire type should null the struct row");
     }
@@ -2104,11 +1914,11 @@ public class ProtobufTest {
     // Valid protobuf should not throw even with failOnErrors = true
     Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(42)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeAllFields(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{0},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(),
              true)) {
       try (ColumnVector expected = ColumnVector.fromBoxedLongs(42L);
            ColumnVector expectedStruct = ColumnVector.makeStruct(expected)) {
@@ -2134,17 +1944,17 @@ public class ProtobufTest {
         box(tag(6, WT_LEN)), box(encodeVarint(5)), box("hello".getBytes()));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actualStruct = decodeAllFields(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2, 3, 4, 5, 6},
-             new int[]{
-                 DType.BOOL8.getTypeId().getNativeId(),
-                 DType.INT32.getTypeId().getNativeId(),
-                 DType.INT64.getTypeId().getNativeId(),
-                 DType.FLOAT32.getTypeId().getNativeId(),
-                 DType.FLOAT64.getTypeId().getNativeId(),
-                 DType.STRING.getTypeId().getNativeId()},
-             new int[]{0, 0, 0, 0, 0, 0})) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.BOOL8)
+                 .addField(2, DType.INT32)
+                 .addField(3, DType.INT64)
+                 .addField(4, DType.FLOAT32)
+                 .addField(5, DType.FLOAT64)
+                 .addField(6, DType.STRING)
+                 .build(),
+             true)) {
       try (ColumnVector expectedBool = ColumnVector.fromBoxedBooleans(true);
            ColumnVector expectedInt = ColumnVector.fromBoxedInts(12345);
            ColumnVector expectedLong = ColumnVector.fromBoxedLongs(9876543210L);
@@ -2162,52 +1972,6 @@ public class ProtobufTest {
   // Enum Validation Tests
   // ============================================================================
 
-  /**
-   * Helper method that wraps decodeToStruct with enum validation support.
-   */
-  private static ColumnVector decodeAllFieldsWithEnums(ColumnView binaryInput,
-                                                        int[] fieldNumbers,
-                                                        int[] typeIds,
-                                                        int[] encodings,
-                                                        int[][] enumValidValues,
-                                                        boolean failOnErrors) {
-    int numFields = fieldNumbers.length;
-    return decodeScalarFields(binaryInput, fieldNumbers, typeIds, encodings,
-        new boolean[numFields], new boolean[numFields], new long[numFields],
-        new double[numFields], new boolean[numFields], new byte[numFields][],
-        enumValidValues, failOnErrors);
-  }
-
-  /**
-   * Helper that enables enum-as-string decoding by passing enum name mappings.
-   */
-  private static ColumnVector decodeAllFieldsWithEnumStrings(ColumnView binaryInput,
-                                                             int[] fieldNumbers,
-                                                             int[][] enumValidValues,
-                                                             byte[][][] enumNames,
-                                                             boolean failOnErrors) {
-    int numFields = fieldNumbers.length;
-    int[] typeIds = new int[numFields];
-    int[] encodings = new int[numFields];
-    for (int i = 0; i < numFields; i++) {
-      typeIds[i] = DType.STRING.getTypeId().getNativeId();
-      encodings[i] = Protobuf.ENC_ENUM_STRING;
-    }
-    int[] parentIndices = new int[numFields];
-    int[] depthLevels = new int[numFields];
-    int[] wireTypes = new int[numFields];
-    boolean[] isRepeated = new boolean[numFields];
-    java.util.Arrays.fill(parentIndices, -1);
-    java.util.Arrays.fill(wireTypes, Protobuf.WT_VARINT);
-    return Protobuf.decodeToStruct(binaryInput,
-        new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
-            wireTypes, typeIds, encodings, isRepeated,
-            new boolean[numFields], new boolean[numFields], new long[numFields],
-            new double[numFields], new boolean[numFields], new byte[numFields][],
-            enumValidValues, enumNames),
-        failOnErrors);
-  }
-
   @Test
   void testEnumAsStringValidValue() {
     // enum Color { RED=0; GREEN=1; BLUE=2; }
@@ -2223,11 +1987,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedField = ColumnVector.fromStrings("GREEN");
          ColumnVector expected = ColumnVector.makeStruct(expectedField);
-         ColumnVector actual = decodeAllFieldsWithEnumStrings(
+         ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[][]{{0, 1, 2}},
-             enumNames,
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).enumMetadata(new int[]{0, 1, 2}, enumNames[0])
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expected, actual);
     }
@@ -2246,11 +2010,11 @@ public class ProtobufTest {
         }
     };
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actual = decodeAllFieldsWithEnumStrings(
+         ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[][]{{0, 1, 2}},
-             enumNames,
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).enumMetadata(new int[]{0, 1, 2}, enumNames[0])
+                 .build(),
              false);
          HostColumnVector hostStruct = actual.copyToHost()) {
       assertEquals(1, actual.getNullCount(), "Struct row should be null for unknown enum value");
@@ -2272,11 +2036,11 @@ public class ProtobufTest {
         }
     };
     try (Table input = new Table.TestBuilder().column(row0, row1, row2).build();
-         ColumnVector actual = decodeAllFieldsWithEnumStrings(
+         ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[][]{{0, 1, 2}},
-             enumNames,
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).enumMetadata(new int[]{0, 1, 2}, enumNames[0])
+                 .build(),
              false);
          HostColumnVector hostStruct = actual.copyToHost()) {
       assertEquals(1, actual.getNullCount(), "Only the unknown enum row should be null");
@@ -2296,12 +2060,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedColor = ColumnVector.fromBoxedInts(1);  // GREEN
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedColor);
-         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new int[][]{{0, 1, 2}},  // valid enum values: RED=0, GREEN=1, BLUE=2
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).enumValidValues(new int[]{0, 1, 2})
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -2316,12 +2079,11 @@ public class ProtobufTest {
     Byte[] row = concat(box(tag(1, WT_VARINT)), box(encodeVarint(999)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new int[][]{{0, 1, 2}},  // valid enum values: RED=0, GREEN=1, BLUE=2
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).enumValidValues(new int[]{0, 1, 2})
+                 .build(),
              false);
          HostColumnVector hostStruct = actualStruct.copyToHost()) {
       // The struct itself should be null (not just the field)
@@ -2340,12 +2102,11 @@ public class ProtobufTest {
     Byte[] row3 = concat(box(tag(1, WT_VARINT)), box(encodeVarint(-1)));   // negative (unknown) -> struct null
 
     try (Table input = new Table.TestBuilder().column(row0, row1, row2, row3).build();
-         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new int[][]{{0, 1, 2}},  // valid enum values
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).enumValidValues(new int[]{0, 1, 2})
+                 .build(),
              false);
          HostColumnVector hostStruct = actualStruct.copyToHost()) {
       // Check struct-level nulls
@@ -2367,12 +2128,12 @@ public class ProtobufTest {
         box(tag(2, WT_VARINT)), box(encodeVarint(42)));  // count = 42
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new int[][]{{0, 1, 2}, null},  // first field is enum, second is regular int (no validation)
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).enumValidValues(new int[]{0, 1, 2})
+                 .addField(2, DType.INT32)
+                 .build(),
              false);
          HostColumnVector hostStruct = actualStruct.copyToHost()) {
       // The entire struct row should be null
@@ -2390,12 +2151,11 @@ public class ProtobufTest {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector expectedColor = ColumnVector.fromBoxedInts((Integer) null);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedColor);
-         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new int[][]{{0, 1, 2}},  // valid enum values
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).enumValidValues(new int[]{0, 1, 2})
+                 .build(),
              false)) {
       // Struct row should be valid (not null), only the field is null
       assertEquals(0, actualStruct.getNullCount(), "Struct row should NOT be null for missing field");
@@ -2415,12 +2175,12 @@ public class ProtobufTest {
          ColumnVector expectedColor = ColumnVector.fromBoxedInts(1);
          ColumnVector expectedCount = ColumnVector.fromBoxedInts(42);
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedColor, expectedCount);
-         ColumnVector actualStruct = decodeAllFieldsWithEnums(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 2},
-             new int[]{DType.INT32.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new int[][]{{0, 1, 2}, null},  // first field is enum, second is regular int
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).enumValidValues(new int[]{0, 1, 2})
+                 .addField(2, DType.INT32)
+                 .build(),
              false)) {
       // Struct row should be valid with correct values
       assertEquals(0, actualStruct.getNullCount(), "Struct row should be valid");
@@ -2611,12 +2371,11 @@ public class ProtobufTest {
     Byte[] row = new Byte[]{0x08, 0x01};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(
-                 new int[]{1, 2, 3},
-                 new int[]{DType.INT64.getTypeId().getNativeId(),
-                           DType.STRING.getTypeId().getNativeId(),
-                           DType.FLOAT32.getTypeId().getNativeId()},
-                 new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT}),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .addField(2, DType.STRING)
+                 .addField(3, DType.FLOAT32)
+                 .build(),
              true)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
@@ -2635,10 +2394,9 @@ public class ProtobufTest {
     Byte[] row2 = new Byte[]{0x08, 0x03};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, row1, row2}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(
-                 new int[]{1},
-                 new int[]{DType.INT64.getTypeId().getNativeId()},
-                 new int[]{Protobuf.ENC_DEFAULT}), true)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(), true)) {
       assertEquals(3, result.getRowCount());
       assertEquals(1, result.getNumChildren());
     }
@@ -2653,10 +2411,9 @@ public class ProtobufTest {
     Byte[] row0 = new Byte[]{0x08, 0x01};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, null}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(
-                 new int[]{1},
-                 new int[]{DType.INT64.getTypeId().getNativeId()},
-                 new int[]{Protobuf.ENC_DEFAULT}), true)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .build(), true)) {
       assertEquals(2, result.getRowCount());
       try (HostColumnVector hcv = result.copyToHost()) {
         assertFalse(hcv.isNull(0), "Row 0 should not be null");
@@ -2698,11 +2455,10 @@ public class ProtobufTest {
   void testAllNullInputRows() {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{null, null, null}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(
-                 new int[]{1, 2},
-                 new int[]{DType.INT64.getTypeId().getNativeId(),
-                           DType.STRING.getTypeId().getNativeId()},
-                 new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT}), true)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .addField(2, DType.STRING)
+                 .build(), true)) {
       assertEquals(3, result.getRowCount());
       assertEquals(2, result.getNumChildren());
       try (HostColumnVector hcv = result.copyToHost()) {
@@ -2736,41 +2492,6 @@ public class ProtobufTest {
     }
   }
 
-  private void verifyDeepNesting(int numLevels) {
-    byte[] current = concatBytes(tag(1, WT_VARINT), encodeVarint(1));
-    for (int level = numLevels - 2; level >= 0; level--) {
-      current = concatBytes(
-          tag(1, WT_VARINT), encodeVarint(1),
-          tag(2, WT_LEN), encodeVarint(current.length), current);
-    }
-    Byte[] row = box(current);
-
-    // Each level contributes an INT32 leaf (field 1) and, except the last, a STRUCT (field 2)
-    // that parents the next level. Flat indices: int at 2*level, struct at 2*level+1.
-    ProtobufSchemaDescriptorBuilder builder = new ProtobufSchemaDescriptorBuilder();
-    for (int level = 0; level < numLevels; level++) {
-      int parentIdx = level == 0 ? -1 : 2 * (level - 1) + 1;
-      builder.addField(1, DType.INT32);
-      if (parentIdx >= 0) builder.parent(parentIdx);
-      if (level < numLevels - 1) {
-        builder.addField(2, DType.STRUCT);
-        if (parentIdx >= 0) builder.parent(parentIdx);
-      }
-    }
-
-    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0), builder.build(), false)) {
-      assertNotNull(result);
-      assertEquals(DType.STRUCT, result.getType());
-      // Verify the deepest leaf (encoded as 1 in this synthetic schema) actually decodes to 1.
-      try (ColumnVector firstChild = result.getChildColumnView(0).copyToColumnVector();
-           HostColumnVector hostChild = firstChild.copyToHost()) {
-        assertEquals(DType.INT32, firstChild.getType());
-        assertEquals(1, hostChild.getInt(0));
-      }
-    }
-  }
-
   // ============================================================================
   // Empty-row (0 rows) handling
   // ============================================================================
@@ -2779,11 +2500,10 @@ public class ProtobufTest {
   void testZeroRowInput() {
     try (Table input = new Table.TestBuilder().column(new Byte[][]{}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0),
-             makeScalarSchema(
-                 new int[]{1, 2},
-                 new int[]{DType.INT64.getTypeId().getNativeId(),
-                           DType.STRING.getTypeId().getNativeId()},
-                 new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT}), true)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64)
+                 .addField(2, DType.STRING)
+                 .build(), true)) {
       assertEquals(0, result.getRowCount());
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(2, result.getNumChildren());
@@ -2931,9 +2651,9 @@ public class ProtobufTest {
   void testNullBinaryInputThrows() {
     assertThrows(IllegalArgumentException.class, () ->
         Protobuf.decodeToStruct(null,
-            makeScalarSchema(new int[]{1},
-                new int[]{DType.INT64.getTypeId().getNativeId()},
-                new int[]{0}), true));
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64)
+                .build(), true));
   }
 
   @Test

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -1660,8 +1660,9 @@ public class ProtobufTest {
       try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
           new ProtobufSchemaDescriptorBuilder()
-              .addField(1, DType.STRUCT)           // inner
-              .addField(1, DType.INT32).parent(0)  // inner.x
+              .addField(1, DType.STRUCT).down()    // inner
+                  .addField(1, DType.INT32)        // inner.x
+              .up()
               .build(),
           false)) {
         assertNotNull(result);
@@ -2520,9 +2521,10 @@ public class ProtobufTest {
   void testNestedMessageOutputShape() {
     // Schema: message Outer { int32 a = 1; Inner b = 2; } message Inner { int32 x = 1; }
     ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
-        .addField(1, DType.INT32)
-        .addField(2, DType.STRUCT)
-        .addField(1, DType.INT32).parent(1)
+        .addField(1, DType.INT32)            // a
+        .addField(2, DType.STRUCT).down()    // b
+            .addField(1, DType.INT32)        // x
+        .up()
         .build();
 
     Byte[] row = new Byte[]{0x08, 0x01};
@@ -2548,8 +2550,9 @@ public class ProtobufTest {
          ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
              new ProtobufSchemaDescriptorBuilder()
-                 .addField(1, DType.STRUCT)
-                 .addField(1, DType.INT32).parent(0)
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.INT32)
+                 .up()
                  .build(),
              false)) {
       assertNotNull(result);
@@ -2597,9 +2600,10 @@ public class ProtobufTest {
     // 0 rows with nested schema — verify correct type hierarchy.
     // message Outer { int32 a = 1; Inner b = 2; }  message Inner { int32 x = 1; }
     ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
-        .addField(1, DType.INT32)
-        .addField(2, DType.STRUCT)
-        .addField(1, DType.INT32).parent(1)
+        .addField(1, DType.INT32)            // a
+        .addField(2, DType.STRUCT).down()    // b
+            .addField(1, DType.INT32)        // x
+        .up()
         .build();
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{}).build();
@@ -2617,8 +2621,9 @@ public class ProtobufTest {
   void testZeroRowRepeatedMessageShape() {
     // 0 rows with repeated message schema: repeated Inner inner = 1; message Inner { int32 x = 1; }
     ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
-        .addField(1, DType.STRUCT).repeated()
-        .addField(1, DType.INT32).parent(0)
+        .addField(1, DType.STRUCT).repeated().down()
+            .addField(1, DType.INT32)
+        .up()
         .build();
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{}).build();

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -1757,25 +1757,13 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(3)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
-      // Use the new nested API for repeated fields
-      // Field: ids (field_number=1, parent=-1, depth=0, wire_type=VARINT, type=INT32, repeated=true)
-      try (ColumnVector result = decodeRaw(
+      // Field: ids (field_number=1, repeated int32)
+      try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
-          new int[]{1},                    // fieldNumbers
-          new int[]{-1},                   // parentIndices (-1 = top level)
-          new int[]{0},                    // depthLevels
-          new int[]{Protobuf.WT_VARINT},   // wireTypes
-          new int[]{DType.INT32.getTypeId().getNativeId()},  // outputTypeIds (element type)
-          new int[]{Protobuf.ENC_DEFAULT}, // encodings
-          new boolean[]{true},             // isRepeated
-          new boolean[]{false},            // isRequired
-          new boolean[]{false},            // hasDefaultValue
-          new long[]{0},                   // defaultInts
-          new double[]{0.0},               // defaultFloats
-          new boolean[]{false},            // defaultBools
-          new byte[][]{null},              // defaultStrings
-          new int[][]{null},               // enumValidValues
-          false)) {                        // failOnErrors
+          new ProtobufSchemaDescriptorBuilder()
+              .addField(1, DType.INT32).repeated()
+              .build(),
+          false)) {
         // Result should be STRUCT<ids: LIST<INT32>> containing [1, 2, 3]
         assertNotNull(result);
         assertEquals(DType.STRUCT, result.getType());
@@ -1842,27 +1830,14 @@ public class ProtobufTest {
         box(tag(3, WT_LEN)), box(encodeVarint(r2Doubles.length)), box(r2Doubles));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, row1, row2}).build()) {
-      try (ColumnVector result = decodeRaw(
+      try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
-          new int[]{1, 2, 3, 4},
-          new int[]{-1, -1, -1, -1},
-          new int[]{0, 0, 0, 0},
-          new int[]{WT_VARINT, WT_VARINT, WT_64BIT, WT_VARINT},
-          new int[]{
-            DType.INT32.getTypeId().getNativeId(),
-            DType.INT32.getTypeId().getNativeId(),
-            DType.FLOAT64.getTypeId().getNativeId(),
-            DType.BOOL8.getTypeId().getNativeId()
-          },
-          new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-          new boolean[]{false, true, true, true},
-          new boolean[]{false, false, false, false},
-          new boolean[]{false, false, false, false},
-          new long[]{0, 0, 0, 0},
-          new double[]{0.0, 0.0, 0.0, 0.0},
-          new boolean[]{false, false, false, false},
-          new byte[][]{null, null, null, null},
-          new int[][]{null, null, null, null},
+          new ProtobufSchemaDescriptorBuilder()
+              .addField(1, DType.INT32)            // id
+              .addField(2, DType.INT32).repeated()    // int_values (packed)
+              .addField(3, DType.FLOAT64).repeated()  // double_values (packed)
+              .addField(4, DType.BOOL8).repeated()    // bool_values (packed)
+              .build(),
           false)) {
         assertNotNull(result);
         assertEquals(DType.STRUCT, result.getType());
@@ -1921,22 +1896,13 @@ public class ProtobufTest {
       // Flattened schema:
       // [0] inner: STRUCT, field_number=1, parent=-1, depth=0
       // [1] inner.x: INT32, field_number=1, parent=0, depth=1
-      try (ColumnVector result = decodeRaw(
+      // Flattened schema: [0] inner STRUCT, [1] inner.x INT32 (child of 0)
+      try (ColumnVector result = Protobuf.decodeToStruct(
           input.getColumn(0),
-          new int[]{1, 1},                 // fieldNumbers
-          new int[]{-1, 0},                // parentIndices
-          new int[]{0, 1},                 // depthLevels
-          new int[]{Protobuf.WT_LEN, Protobuf.WT_VARINT},  // wireTypes
-          new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
-          new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-          new boolean[]{false, false},     // isRepeated
-          new boolean[]{false, false},     // isRequired
-          new boolean[]{false, false},     // hasDefaultValue
-          new long[]{0, 0},
-          new double[]{0.0, 0.0},
-          new boolean[]{false, false},
-          new byte[][]{null, null},
-          new int[][]{null, null},
+          new ProtobufSchemaDescriptorBuilder()
+              .addField(1, DType.STRUCT)
+              .addField(1, DType.INT32).parent(0)
+              .build(),
           false)) {
         assertNotNull(result);
         assertEquals(DType.STRUCT, result.getType());
@@ -1963,22 +1929,11 @@ public class ProtobufTest {
              Arrays.asList(1),
              Arrays.asList(100));
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedIds);
-         ColumnVector actualStruct = decodeRaw(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated()
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -1992,22 +1947,11 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(3)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.UINT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.UINT32).repeated()
+                 .build(),
              false)) {
       try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
            ColumnVector vals = list.getChildColumnView(0).copyToColumnVector();
@@ -2029,22 +1973,11 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(33)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.UINT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.UINT64).repeated()
+                 .build(),
              false)) {
       try (ColumnVector list = result.getChildColumnView(0).copyToColumnVector();
            ColumnVector vals = list.getChildColumnView(0).copyToColumnVector();

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -149,61 +149,11 @@ public class ProtobufTest {
 
     java.util.Arrays.fill(parentIndices, -1);
     for (int i = 0; i < n; i++) {
-      wireTypes[i] = deriveWireType(typeIds[i], encodings[i]);
+      wireTypes[i] = ProtobufSchemaDescriptorBuilder.deriveWireType(typeIds[i], encodings[i]);
     }
     return new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
         wireTypes, typeIds, encodings, isRepeated, isRequired, hasDefault,
         defaultInts, defaultFloats, defaultBools, defaultStrings, enumValid, enumNames);
-  }
-
-  private static int deriveWireType(int typeId, int encoding) {
-    if (encoding == Protobuf.ENC_ENUM_STRING) return Protobuf.WT_VARINT;
-    if (typeId == DType.FLOAT32.getTypeId().getNativeId()) return Protobuf.WT_32BIT;
-    if (typeId == DType.FLOAT64.getTypeId().getNativeId()) return Protobuf.WT_64BIT;
-    if (typeId == DType.STRING.getTypeId().getNativeId()) return Protobuf.WT_LEN;
-    if (typeId == DType.LIST.getTypeId().getNativeId()) return Protobuf.WT_LEN;
-    if (typeId == DType.STRUCT.getTypeId().getNativeId()) return Protobuf.WT_LEN;
-    if (encoding == Protobuf.ENC_FIXED) {
-      if (typeId == DType.INT64.getTypeId().getNativeId()
-          || typeId == DType.UINT64.getTypeId().getNativeId()) return Protobuf.WT_64BIT;
-      return Protobuf.WT_32BIT;
-    }
-    return Protobuf.WT_VARINT;
-  }
-
-  /**
-   * Test-only convenience: wrap raw parallel arrays into a ProtobufSchemaDescriptor
-   * and decode. Avoids verbose ProtobufSchemaDescriptor construction at every call site.
-   */
-  private static ColumnVector decodeRaw(ColumnView binaryInput,
-                                        int[] fieldNumbers, int[] parentIndices, int[] depthLevels,
-                                        int[] wireTypes, int[] outputTypeIds, int[] encodings,
-                                        boolean[] isRepeated, boolean[] isRequired,
-                                        boolean[] hasDefaultValue, long[] defaultInts,
-                                        double[] defaultFloats, boolean[] defaultBools,
-                                        byte[][] defaultStrings, int[][] enumValidValues,
-                                        boolean failOnErrors) {
-    return decodeRaw(binaryInput, fieldNumbers, parentIndices, depthLevels,
-        wireTypes, outputTypeIds, encodings, isRepeated, isRequired,
-        hasDefaultValue, defaultInts, defaultFloats, defaultBools,
-        defaultStrings, enumValidValues, new byte[fieldNumbers.length][][], failOnErrors);
-  }
-
-  private static ColumnVector decodeRaw(ColumnView binaryInput,
-                                        int[] fieldNumbers, int[] parentIndices, int[] depthLevels,
-                                        int[] wireTypes, int[] outputTypeIds, int[] encodings,
-                                        boolean[] isRepeated, boolean[] isRequired,
-                                        boolean[] hasDefaultValue, long[] defaultInts,
-                                        double[] defaultFloats, boolean[] defaultBools,
-                                        byte[][] defaultStrings, int[][] enumValidValues,
-                                        byte[][][] enumNames,
-                                        boolean failOnErrors) {
-    return Protobuf.decodeToStruct(binaryInput,
-        new ProtobufSchemaDescriptor(fieldNumbers, parentIndices, depthLevels,
-            wireTypes, outputTypeIds, encodings, isRepeated, isRequired,
-            hasDefaultValue, defaultInts, defaultFloats, defaultBools,
-            defaultStrings, enumValidValues, enumNames),
-        failOnErrors);
   }
 
   /**
@@ -232,7 +182,7 @@ public class ProtobufTest {
     // depthLevels already initialized to 0
     // isRepeated already initialized to false
     for (int i = 0; i < numFields; i++) {
-      wireTypes[i] = deriveWireType(typeIds[i], encodings[i]);
+      wireTypes[i] = ProtobufSchemaDescriptorBuilder.deriveWireType(typeIds[i], encodings[i]);
     }
 
     return Protobuf.decodeToStruct(binaryInput,
@@ -2499,23 +2449,11 @@ public class ProtobufTest {
         }
     };
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector actual = decodeRaw(
+         ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{Protobuf.WT_VARINT},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ENUM_STRING},
-             new boolean[]{true},   // isRepeated
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{{0, 1, 2}},
-             enumNames,
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).repeated().enumMetadata(new int[]{0, 1, 2}, enumNames[0])
+                 .build(),
              false)) {
       assertNotNull(actual);
       assertEquals(DType.STRUCT, actual.getType());
@@ -2547,22 +2485,11 @@ public class ProtobufTest {
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(RuntimeException.class, () -> {
-        try (ColumnVector result = decodeRaw(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{WT_32BIT},
-            new int[]{DType.INT32.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_FIXED},
-            new boolean[]{true},
-            new boolean[]{false},
-            new boolean[]{false},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{null},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT32).repeated().encoding(Protobuf.ENC_FIXED)
+                .build(),
             true)) {
         }
       });
@@ -2579,22 +2506,11 @@ public class ProtobufTest {
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(RuntimeException.class, () -> {
-        try (ColumnVector result = decodeRaw(
+        try (ColumnVector result = Protobuf.decodeToStruct(
             input.getColumn(0),
-            new int[]{1},
-            new int[]{-1},
-            new int[]{0},
-            new int[]{WT_64BIT},
-            new int[]{DType.INT64.getTypeId().getNativeId()},
-            new int[]{Protobuf.ENC_FIXED},
-            new boolean[]{true},
-            new boolean[]{false},
-            new boolean[]{false},
-            new long[]{0},
-            new double[]{0.0},
-            new boolean[]{false},
-            new byte[][]{null},
-            new int[][]{null},
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.INT64).repeated().encoding(Protobuf.ENC_FIXED)
+                .build(),
             true)) {
         }
       });
@@ -2622,22 +2538,11 @@ public class ProtobufTest {
              Arrays.asList(),
              Arrays.asList(42, 99));
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedIds);
-         ColumnVector actualStruct = decodeRaw(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_32BIT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_FIXED},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated().encoding(Protobuf.ENC_FIXED)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -2661,22 +2566,11 @@ public class ProtobufTest {
              Arrays.asList(),
              Arrays.asList(7L, 11L));
          ColumnVector expectedStruct = ColumnVector.makeStruct(expectedIds);
-         ColumnVector actualStruct = decodeRaw(
+         ColumnVector actualStruct = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_64BIT},
-             new int[]{DType.INT64.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_FIXED},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT64).repeated().encoding(Protobuf.ENC_FIXED)
+                 .build(),
              false)) {
       AssertUtils.assertStructColumnsAreEqual(expectedStruct, actualStruct);
     }
@@ -2692,22 +2586,11 @@ public class ProtobufTest {
     Byte[] row = box(baos.toByteArray());
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated()
+                 .build(),
              false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
@@ -2791,22 +2674,11 @@ public class ProtobufTest {
         box(tag(1, WT_LEN)), box(encodeVarint(packedContent.length)), box(packedContent));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated()
+                 .build(),
              false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
@@ -2849,22 +2721,11 @@ public class ProtobufTest {
         box(encodeVarint(42)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{maxFieldNumber},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{false},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(maxFieldNumber, DType.INT32)
+                 .build(),
              false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
@@ -2876,8 +2737,6 @@ public class ProtobufTest {
   }
 
   private void verifyDeepNesting(int numLevels) {
-    int numFields = 2 * numLevels - 1;
-
     byte[] current = concatBytes(tag(1, WT_VARINT), encodeVarint(1));
     for (int level = numLevels - 2; level >= 0; level--) {
       current = concatBytes(
@@ -2886,50 +2745,21 @@ public class ProtobufTest {
     }
     Byte[] row = box(current);
 
-    int[] fieldNumbers = new int[numFields];
-    int[] parentIndices = new int[numFields];
-    int[] depthLevels = new int[numFields];
-    int[] wireTypes = new int[numFields];
-    int[] outputTypeIds = new int[numFields];
-    int[] encodings = new int[numFields];
-    boolean[] isRepeated = new boolean[numFields];
-    boolean[] isRequired = new boolean[numFields];
-    boolean[] hasDefaultValue = new boolean[numFields];
-    long[] defaultInts = new long[numFields];
-    double[] defaultFloats = new double[numFields];
-    boolean[] defaultBools = new boolean[numFields];
-    byte[][] defaultStrings = new byte[numFields][];
-    int[][] enumValidValues = new int[numFields][];
-
+    // Each level contributes an INT32 leaf (field 1) and, except the last, a STRUCT (field 2)
+    // that parents the next level. Flat indices: int at 2*level, struct at 2*level+1.
+    ProtobufSchemaDescriptorBuilder builder = new ProtobufSchemaDescriptorBuilder();
     for (int level = 0; level < numLevels; level++) {
-      int intIdx = 2 * level;
       int parentIdx = level == 0 ? -1 : 2 * (level - 1) + 1;
-
-      fieldNumbers[intIdx] = 1;
-      parentIndices[intIdx] = parentIdx;
-      depthLevels[intIdx] = level;
-      wireTypes[intIdx] = WT_VARINT;
-      outputTypeIds[intIdx] = DType.INT32.getTypeId().getNativeId();
-      encodings[intIdx] = Protobuf.ENC_DEFAULT;
-
+      builder.addField(1, DType.INT32);
+      if (parentIdx >= 0) builder.parent(parentIdx);
       if (level < numLevels - 1) {
-        int structIdx = 2 * level + 1;
-        fieldNumbers[structIdx] = 2;
-        parentIndices[structIdx] = parentIdx;
-        depthLevels[structIdx] = level;
-        wireTypes[structIdx] = WT_LEN;
-        outputTypeIds[structIdx] = DType.STRUCT.getTypeId().getNativeId();
-        encodings[structIdx] = Protobuf.ENC_DEFAULT;
+        builder.addField(2, DType.STRUCT);
+        if (parentIdx >= 0) builder.parent(parentIdx);
       }
     }
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
-             input.getColumn(0),
-             fieldNumbers, parentIndices, depthLevels, wireTypes,
-             outputTypeIds, encodings, isRepeated, isRequired,
-             hasDefaultValue, defaultInts, defaultFloats, defaultBools,
-             defaultStrings, enumValidValues, false)) {
+         ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0), builder.build(), false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
       // Verify the deepest leaf (encoded as 1 in this synthetic schema) actually decodes to 1.
@@ -2969,25 +2799,11 @@ public class ProtobufTest {
   @Test
   void testNestedMessageOutputShape() {
     // Schema: message Outer { int32 a = 1; Inner b = 2; } message Inner { int32 x = 1; }
-    int intType = DType.INT32.getTypeId().getNativeId();
-    int structType = DType.STRUCT.getTypeId().getNativeId();
-    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptor(
-        new int[]{1, 2, 1},           // field numbers
-        new int[]{-1, -1, 1},         // parent indices
-        new int[]{0, 0, 1},           // depth levels
-        new int[]{Protobuf.WT_VARINT, Protobuf.WT_LEN, Protobuf.WT_VARINT},
-        new int[]{intType, structType, intType},
-        new int[]{0, 0, 0},           // encodings
-        new boolean[]{false, false, false},
-        new boolean[]{false, false, false},
-        new boolean[]{false, false, false},
-        new long[]{0, 0, 0},
-        new double[]{0, 0, 0},
-        new boolean[]{false, false, false},
-        new byte[][]{null, null, null},
-        new int[][]{null, null, null},
-        new byte[][][]{null, null, null}
-    );
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.INT32)
+        .addField(2, DType.STRUCT)
+        .addField(1, DType.INT32).parent(1)
+        .build();
 
     Byte[] row = new Byte[]{0x08, 0x01};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
@@ -3009,22 +2825,12 @@ public class ProtobufTest {
         box(encodeVarint(0)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1, 1},
-             new int[]{-1, 0},
-             new int[]{0, 1},
-             new int[]{WT_LEN, WT_VARINT},
-             new int[]{DType.STRUCT.getTypeId().getNativeId(), DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT, Protobuf.ENC_DEFAULT},
-             new boolean[]{false, false},
-             new boolean[]{false, false},
-             new boolean[]{false, false},
-             new long[]{0, 0},
-             new double[]{0.0, 0.0},
-             new boolean[]{false, false},
-             new byte[][]{null, null},
-             new int[][]{null, null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT)
+                 .addField(1, DType.INT32).parent(0)
+                 .build(),
              false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
@@ -3034,24 +2840,9 @@ public class ProtobufTest {
   @Test
   void testRepeatedFieldOutputShape() {
     // Schema: message Msg { repeated int32 values = 1; }
-    int intType = DType.INT32.getTypeId().getNativeId();
-    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptor(
-        new int[]{1},
-        new int[]{-1},
-        new int[]{0},
-        new int[]{Protobuf.WT_VARINT},
-        new int[]{intType},
-        new int[]{0},
-        new boolean[]{true},          // is_repeated = true
-        new boolean[]{false},
-        new boolean[]{false},
-        new long[]{0},
-        new double[]{0},
-        new boolean[]{false},
-        new byte[][]{null},
-        new int[][]{null},
-        new byte[][][]{null}
-    );
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.INT32).repeated()
+        .build();
 
     Byte[] row = new Byte[]{0x08, 0x01};
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
@@ -3070,22 +2861,11 @@ public class ProtobufTest {
         box(encodeVarint(0)));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1},
-             new int[]{-1},
-             new int[]{0},
-             new int[]{WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true},
-             new boolean[]{false},
-             new boolean[]{false},
-             new long[]{0},
-             new double[]{0.0},
-             new boolean[]{false},
-             new byte[][]{null},
-             new int[][]{null},
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated()
+                 .build(),
              false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
@@ -3094,26 +2874,13 @@ public class ProtobufTest {
 
   @Test
   void testZeroRowNestedSchemaShape() {
-    // 0 rows with nested schema — verify correct type hierarchy
-    int intType = DType.INT32.getTypeId().getNativeId();
-    int structType = DType.STRUCT.getTypeId().getNativeId();
-    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptor(
-        new int[]{1, 2, 1},
-        new int[]{-1, -1, 1},
-        new int[]{0, 0, 1},
-        new int[]{Protobuf.WT_VARINT, Protobuf.WT_LEN, Protobuf.WT_VARINT},
-        new int[]{intType, structType, intType},
-        new int[]{0, 0, 0},
-        new boolean[]{false, false, false},
-        new boolean[]{false, false, false},
-        new boolean[]{false, false, false},
-        new long[]{0, 0, 0},
-        new double[]{0, 0, 0},
-        new boolean[]{false, false, false},
-        new byte[][]{null, null, null},
-        new int[][]{null, null, null},
-        new byte[][][]{null, null, null}
-    );
+    // 0 rows with nested schema — verify correct type hierarchy.
+    // message Outer { int32 a = 1; Inner b = 2; }  message Inner { int32 x = 1; }
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.INT32)
+        .addField(2, DType.STRUCT)
+        .addField(1, DType.INT32).parent(1)
+        .build();
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0), schema, true)) {
@@ -3128,26 +2895,11 @@ public class ProtobufTest {
 
   @Test
   void testZeroRowRepeatedMessageShape() {
-    // 0 rows with repeated message schema: repeated Inner inner = 1;
-    int structType = DType.STRUCT.getTypeId().getNativeId();
-    int intType = DType.INT32.getTypeId().getNativeId();
-    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptor(
-        new int[]{1, 1},              // field numbers
-        new int[]{-1, 0},             // parent indices: inner's child has parent=0
-        new int[]{0, 1},              // depth levels
-        new int[]{Protobuf.WT_LEN, Protobuf.WT_VARINT},
-        new int[]{structType, intType},
-        new int[]{0, 0},
-        new boolean[]{true, false},   // inner is repeated
-        new boolean[]{false, false},
-        new boolean[]{false, false},
-        new long[]{0, 0},
-        new double[]{0, 0},
-        new boolean[]{false, false},
-        new byte[][]{null, null},
-        new int[][]{null, null},
-        new byte[][][]{null, null}
-    );
+    // 0 rows with repeated message schema: repeated Inner inner = 1; message Inner { int32 x = 1; }
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.STRUCT).repeated()
+        .addField(1, DType.INT32).parent(0)
+        .build();
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0), schema, true)) {
@@ -3159,24 +2911,9 @@ public class ProtobufTest {
 
   @Test
   void testZeroRowRepeatedScalarShape() {
-    int intType = DType.INT32.getTypeId().getNativeId();
-    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptor(
-        new int[]{1},
-        new int[]{-1},
-        new int[]{0},
-        new int[]{Protobuf.WT_VARINT},
-        new int[]{intType},
-        new int[]{0},
-        new boolean[]{true},
-        new boolean[]{false},
-        new boolean[]{false},
-        new long[]{0},
-        new double[]{0},
-        new boolean[]{false},
-        new byte[][]{null},
-        new int[][]{null},
-        new byte[][][]{null}
-    );
+    ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
+        .addField(1, DType.INT32).repeated()
+        .build();
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{}).build();
          ColumnVector result = Protobuf.decodeToStruct(input.getColumn(0), schema, true)) {
@@ -3221,15 +2958,12 @@ public class ProtobufTest {
     Byte[] row1 = concat(
         box(tag(1, WT_LEN)), box(encodeVarint(s3.length)), box(s3));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, row1}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1}, new int[]{-1}, new int[]{0},
-             new int[]{Protobuf.WT_LEN},
-             new int[]{DType.STRING.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true}, new boolean[]{false}, new boolean[]{false},
-             new long[]{0}, new double[]{0.0}, new boolean[]{false},
-             new byte[][]{null}, new int[][]{null}, false)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRING).repeated()
+                 .build(),
+             false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(2, result.getRowCount());
@@ -3259,15 +2993,12 @@ public class ProtobufTest {
     Byte[] row1 = concat(
         box(tag(1, WT_LEN)), box(encodeVarint(b3.length)), box(b3));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, row1}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1}, new int[]{-1}, new int[]{0},
-             new int[]{Protobuf.WT_LEN},
-             new int[]{DType.LIST.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true}, new boolean[]{false}, new boolean[]{false},
-             new long[]{0}, new double[]{0.0}, new boolean[]{false},
-             new byte[][]{null}, new int[][]{null}, false)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.LIST).repeated()  // repeated bytes -> LIST<UINT8> element
+                 .build(),
+             false)) {
       assertNotNull(result);
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(2, result.getRowCount());
@@ -3313,15 +3044,12 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(3L)),
         box(tag(1, WT_VARINT)), box(encodeVarint(6L)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1}, new int[]{-1}, new int[]{0},
-             new int[]{Protobuf.WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_ZIGZAG},
-             new boolean[]{true}, new boolean[]{false}, new boolean[]{false},
-             new long[]{0}, new double[]{0.0}, new boolean[]{false},
-             new byte[][]{null}, new int[][]{null}, false);
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated().encoding(Protobuf.ENC_ZIGZAG)
+                 .build(),
+             false);
          ColumnView listCol = result.getChildColumnView(0);
          ColumnView vals = listCol.getChildColumnView(0);
          HostColumnVector hcv = vals.copyToHost()) {
@@ -3340,15 +3068,12 @@ public class ProtobufTest {
         box(tag(1, WT_VARINT)), box(encodeVarint(7)),
         box(tag(1, WT_VARINT)), box(encodeVarint(8)));
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row0, null}).build();
-         ColumnVector result = decodeRaw(
+         ColumnVector result = Protobuf.decodeToStruct(
              input.getColumn(0),
-             new int[]{1}, new int[]{-1}, new int[]{0},
-             new int[]{Protobuf.WT_VARINT},
-             new int[]{DType.INT32.getTypeId().getNativeId()},
-             new int[]{Protobuf.ENC_DEFAULT},
-             new boolean[]{true}, new boolean[]{false}, new boolean[]{false},
-             new long[]{0}, new double[]{0.0}, new boolean[]{false},
-             new byte[][]{null}, new int[][]{null}, false)) {
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32).repeated()
+                 .build(),
+             false)) {
       assertEquals(DType.STRUCT, result.getType());
       assertEquals(2, result.getRowCount());
       try (ColumnView listCol = result.getChildColumnView(0);
@@ -3365,29 +3090,12 @@ public class ProtobufTest {
     // Hits ERR_SCHEMA_TOO_LARGE: the scan_all_repeated_occurrences_kernel stack-array
     // guard rejects schemas with more than 32 top-level repeated fields.
     int n = 33;
-    int[] fns = new int[n];
-    int[] parents = new int[n];
-    int[] depths = new int[n];
-    int[] wts = new int[n];
-    int[] types = new int[n];
-    int[] encs = new int[n];
-    boolean[] rep = new boolean[n];
-    boolean[] req = new boolean[n];
-    boolean[] hasDef = new boolean[n];
-    long[] dInts = new long[n];
-    double[] dFlts = new double[n];
-    boolean[] dBools = new boolean[n];
-    byte[][] dStrs = new byte[n][];
-    int[][] enumVV = new int[n][];
+    ProtobufSchemaDescriptorBuilder builder = new ProtobufSchemaDescriptorBuilder();
     for (int i = 0; i < n; i++) {
-      fns[i] = i + 1;
-      parents[i] = -1;
-      depths[i] = 0;
-      wts[i] = WT_VARINT;
-      types[i] = DType.INT32.getTypeId().getNativeId();
-      encs[i] = Protobuf.ENC_DEFAULT;
-      rep[i] = true;
+      builder.addField(i + 1, DType.INT32).repeated();
     }
+    ProtobufSchemaDescriptor schema = builder.build();
+
     // The MAX_STACK_FIELDS guard in scan_all_repeated_occurrences_kernel only fires when
     // every field actually has occurrences (zero-count fields are filtered out before the
     // kernel launch). Encode one occurrence per field so num_scan_fields == n.
@@ -3403,9 +3111,7 @@ public class ProtobufTest {
     Byte[] row = box(baos.toByteArray());
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
       assertThrows(RuntimeException.class, () -> {
-        try (ColumnVector ignored = decodeRaw(input.getColumn(0),
-            fns, parents, depths, wts, types, encs, rep, req,
-            hasDef, dInts, dFlts, dBools, dStrs, enumVV, true)) {
+        try (ColumnVector ignored = Protobuf.decodeToStruct(input.getColumn(0), schema, true)) {
           // unreachable: should throw
         }
       });


### PR DESCRIPTION
## Summary

Pure test-readability refactor: introduce a fluent `ProtobufSchemaDescriptorBuilder` (test-only) and migrate **all** protobuf tests to it. No production behavior change.

`ProtobufSchemaDescriptor` is a bundle of ~15 parallel arrays. Building one by hand — or via the various `decode*Fields(...)`/`makeScalarSchema(...)`/`decodeRaw(...)` helpers that each wrapped a different slice of those arrays — forced the reader to count positions across a dozen arrays to understand a single field. This was raised in review on #4646 (the unreadability is pervasive across the test file). This PR addresses it across the whole test suite.

Before:
```java
decodeRaw(col,
    new int[]{1, 2, 3, 4}, new int[]{-1, -1, -1, -1}, new int[]{0, 0, 0, 0},
    new int[]{WT_VARINT, WT_VARINT, WT_64BIT, WT_VARINT},
    new int[]{INT32_id, INT32_id, FLOAT64_id, BOOL8_id},
    new int[]{ENC_DEFAULT, ENC_DEFAULT, ENC_DEFAULT, ENC_DEFAULT},
    new boolean[]{false, true, true, true}, /* …8 more arrays… */, false);
```
After:
```java
Protobuf.decodeToStruct(col,
    new ProtobufSchemaDescriptorBuilder()
        .addField(1, DType.INT32)               // id
        .addField(2, DType.INT32).repeated()    // int_values (packed)
        .addField(3, DType.FLOAT64).repeated()  // double_values (packed)
        .addField(4, DType.BOOL8).repeated()    // bool_values (packed)
        .build(),
    false);
```

Nested messages are described with `down()`/`up()` instead of hand-counted parent indices:
```java
new ProtobufSchemaDescriptorBuilder()
    .addField(1, DType.STRUCT).down()        // Outer
        .addField(1, DType.INT32)            //   a
        .addField(2, DType.STRUCT).down()    //   b: Mid
            .addField(1, DType.INT32)        //     c
        .up()
    .up()
    .build();
```

## What changed

- **New** `ProtobufSchemaDescriptorBuilder.java`: each attribute setter applies to the most recently added field; only non-default attributes are named. Wire types are derived from output type + encoding, with a `wireType()` override for the negative wire-type-compatibility cases.
  - `down()`/`up()` express message nesting as a structure (parent index and depth derived automatically) — the idiom for nesting.
  - `parent(int)` is retained as a low-level primitive, reserved for loop-built degenerate chains and the malformed parent links that the validation tests deliberately feed to the descriptor (links `down()/up()` can't express). A `build()`-time check rejects an unbalanced `down()/up()`.
- **ProtobufSchemaDescriptorTest** fully migrated (341 → 239 lines).
- **ProtobufTest** fully migrated (3481 → 2845 lines): every `decodeRaw(...)` and the entire helper family — `makeScalarSchema`, both `decodeAllFields` overloads, `decodeAllFieldsWithRequired`, `decodeAllFieldsWithDefaults`, `decodeAllFieldsWithEnums`, `decodeAllFieldsWithEnumStrings`, and the internal `decodeScalarFields` — are removed. Call sites now build a descriptor inline and call `Protobuf.decodeToStruct(...)` directly; the duplicate `deriveWireType` is consolidated into the builder. `parent(int)` no longer appears in `ProtobufTest` at all — all real nesting uses `down()/up()`.
- Removed dead code: the unused `verifyDeepNesting` helper.

## Notes

- The builder targets the current 15-arg `ProtobufSchemaDescriptor` API. The `isOutput` field from #4646 is intentionally not included here; once #4646 lands, the builder gains `isOutput()`.

## Sequencing

Standalone refactor split out from the in-flight protobuf kernel PRs (#4644, #4646) so it can migrate the test file uniformly without a half-migrated state. Conflicts with those PRs are resolved after they merge.
