### PR TITLE
Honor configured POM file during deploy [skip ci]

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -94,7 +94,7 @@ echo "Deploy CMD: $DEPLOY_CMD"
 
 ###### Deploy spark-rapids-jni jar with all its additions ######
 $DEPLOY_CMD -Dfile=$FPATH.jar \
-            -DpomFile=pom.xml \
+            -DpomFile=$POM_FILE \
             -Dsources=$FPATH-sources.jar \
             -Djavadoc=$FPATH-javadoc.jar \
             -Dfiles=$CLASS_FILES \

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Use the POM_FILE environment variable for the final deploy-file invocation instead of hardcoding pom.xml.

This matches the configurable deployment flow from NVIDIA/spark-rapids#15002, where we can stage rewritten

Maven POMs for CUDF artifacts and pass their paths through POM_FILE. Without this change, ci/deploy.sh

evaluates the rewritten POM to derive the CUDF artifactId but then deploys with the original pom.xml,

causing coordinate mismatches for cudf-spark-jni artifacts.


