### PR TITLE
Drop `CUDF_EXPORT_NVCOMP` and add `CUDF_BUILD_STATIC_DEPS` cmake option

### DIFF
--- a/build/buildcpp.sh
+++ b/build/buildcpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ if [[ $LIBCUDF_BUILD_CONFIGURE == true || ! -f $LIBCUDF_BUILD_PATH/CMakeCache.tx
     -DCUDF_USE_PER_THREAD_DEFAULT_STREAM="$CUDF_USE_PER_THREAD_DEFAULT_STREAM" \
     -DCUDF_KVIKIO_REMOTE_IO=OFF \
     -DCUDF_LARGE_STRINGS_DISABLED=ON \
-    -DCUDF_EXPORT_NVCOMP=ON \
+    -DCUDF_BUILD_STATIC_DEPS=FORCE \
     -DLIBCUDF_LOGGING_LEVEL="$RMM_LOGGING_LEVEL" \
     -DRMM_LOGGING_LEVEL="$RMM_LOGGING_LEVEL" \
     -C="$CUDF_PIN_PATH/setup.cmake"


### PR DESCRIPTION
`CUDF_EXPORT_NVCOMP` cmake option has been completely removed in https://github.com/rapidsai/cudf/pull/20828 thus we should remove it here. In addition, `CUDF_BUILD_STATIC_DEPS` needs to be explicitly set to `FORCE` to static link all cudf's dependent libraries to avoid the issue of missing libraries similar to reported in https://github.com/NVIDIA/spark-rapids/issues/14996.

Closes https://github.com/NVIDIA/spark-rapids-jni/issues/4699.