### PR TITLE
Update submodule sync for cudf-spark-jni rename [skip ci]

### DIFF
--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -24,7 +24,7 @@
 set -ex
 
 OWNER=${OWNER:-"NVIDIA"}
-REPO=${REPO:-"spark-rapids-jni"}
+REPO=${REPO:-"cudf-spark-jni"}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 REPO_LOC="github.com/${OWNER}/${REPO}.git"
 


### PR DESCRIPTION
## Summary
- update the Jenkins submodule-sync default repo slug to `cudf-spark-jni`

## Validation
- `bash -n ci/submodule-sync.sh`
- `git diff --check`
- `codex review --uncommitted`

## Notes
- This assumes the GitHub repo rename is applied with the CI repo URL update.