### PR TITLE
Support non-repeated nested protobuf messages

### DIFF
--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -488,31 +488,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   int const num_nested   = static_cast<int>(nested_field_indices.size());
   int const num_scalar   = static_cast<int>(scalar_field_indices.size());
 
-  // Error flag
-  rmm::device_uvector<int> d_error(1, stream, cudf::get_current_device_resource_ref());
-  CUDF_CUDA_TRY(cudaMemsetAsync(d_error.data(), 0, sizeof(int), stream.value()));
-  auto error_message = [](protobuf_error error) -> std::string {
-    switch (error) {
-      case protobuf_error::BOUNDS: return "Protobuf decode error: message data out of bounds";
-      case protobuf_error::VARINT: return "Protobuf decode error: invalid or truncated varint";
-      case protobuf_error::FIELD_NUMBER: return "Protobuf decode error: invalid field number";
-      case protobuf_error::WIRE_TYPE: return "Protobuf decode error: unexpected wire type";
-      case protobuf_error::OVERFLOW:
-        return "Protobuf decode error: length-delimited field overflows message";
-      case protobuf_error::FIELD_SIZE: return "Protobuf decode error: invalid field size";
-      case protobuf_error::SKIP: return "Protobuf decode error: unable to skip unknown field";
-      case protobuf_error::FIXED_LEN:
-        return "Protobuf decode error: invalid fixed-width or packed field length";
-      case protobuf_error::REQUIRED: return "Protobuf decode error: missing required field";
-      case protobuf_error::SCHEMA_TOO_LARGE:
-        return "Protobuf decode error: schema exceeds maximum supported repeated fields per "
-               "kernel (" +
-               std::to_string(MAX_REPEATED_FIELDS_PER_KERNEL) + ")";
-      case protobuf_error::REPEATED_COUNT_MISMATCH:
-        return "Protobuf decode error: repeated-field count/scan mismatch";
-      default: return "Protobuf decode error: unknown error";
-    }
-  };
+  auto d_error = cudf::detail::make_zeroed_device_uvector_async<protobuf_error>(
+    1, stream, cudf::get_current_device_resource_ref());
   // PERMISSIVE-mode row nulling support. Unknown enum values and malformed rows should both
   // surface as null structs instead of partially decoded data.
   bool const track_permissive_null_rows = !fail_on_errors;
@@ -604,10 +581,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
-                                             h_field_descs.data(),
-                                             h_field_descs.size() * sizeof(field_descriptor),
-                                             stream));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+      d_field_descs.data(), h_field_descs.data(), num_scalar * sizeof(field_descriptor), stream));
 
     rmm::device_uvector<field_location> d_locations(
       static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
@@ -981,6 +956,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     // Phase B: allocate occurrence buffers and launch the combined scan kernel.
     auto h_scan_descs = cudf::detail::make_pinned_vector_async<repeated_field_scan_desc>(0, stream);
+    h_scan_descs.reserve(num_repeated);
 
     for (auto& w : rep_work) {
       if (w.total_count > 0) {
@@ -1273,17 +1249,17 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                     : make_null_column_with_schema(schema, i, num_fields, num_rows, stream, mr));
   }
 
-  CUDF_CUDA_TRY(cudaPeekAtLastError());
-  int h_error = 0;
-  CUDF_CUDA_TRY(cudf::detail::memcpy_async(&h_error, d_error.data(), sizeof(int), stream));
-  stream.synchronize();
-  auto const error = static_cast<protobuf_error>(h_error);
-  if (error == protobuf_error::SCHEMA_TOO_LARGE ||
-      error == protobuf_error::REPEATED_COUNT_MISMATCH) {
-    throw cudf::logic_error(error_message(error));
-  }
-  if (fail_on_errors && error != protobuf_error::NONE) {
-    throw cudf::logic_error(error_message(error));
+  {
+    using enum protobuf_error;
+    CUDF_CUDA_TRY(cudaPeekAtLastError());
+    protobuf_error h_error = NONE;
+    CUDF_CUDA_TRY(
+      cudf::detail::memcpy_async(&h_error, d_error.data(), sizeof(protobuf_error), stream));
+    stream.synchronize();
+    if (h_error == SCHEMA_TOO_LARGE || h_error == REPEATED_COUNT_MISMATCH) {
+      throw cudf::logic_error(error_message(h_error));
+    }
+    if (fail_on_errors && h_error != NONE) { throw cudf::logic_error(error_message(h_error)); }
   }
 
   // Build final struct null mask by combining input nulls with PERMISSIVE-mode row invalidation.

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -162,6 +162,16 @@ struct repeated_field_work {
   }
 };
 
+template <typename T>
+cudf::detail::host_vector<T> make_pinned_staging_copy(std::vector<T> const& source,
+                                                      rmm::cuda_stream_view stream)
+{
+  // Stream-ordered pinned deallocation keeps this staging safe without a local sync.
+  auto staging = cudf::detail::make_pinned_vector_async<T>(source.size(), stream);
+  std::copy(source.begin(), source.end(), staging.begin());
+  return staging;
+}
+
 }  // namespace
 
 std::unique_ptr<cudf::column> make_null_column_with_schema(
@@ -453,7 +463,6 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   // Scratch allocations consumed inside this function go through the current device resource;
   // only buffers that flow into the returned column should use the caller-supplied `mr`.
   auto const scratch_mr = cudf::get_current_device_resource_ref();
-  pinned_staging_buffer_store pinned_staging_buffers;
 
   // Copy schema to device
   std::vector<device_nested_field_descriptor> h_device_schema(num_fields);
@@ -562,17 +571,15 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested);
 
     if (!h_fn_to_rep.empty()) {
-      auto& h_pinned_fn_to_rep =
-        make_pinned_staging_copy(h_fn_to_rep, stream, pinned_staging_buffers);
-      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
+      auto h_pinned_fn_to_rep = make_pinned_staging_copy(h_fn_to_rep, stream);
+      d_fn_to_rep             = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_rep.data(),
                                                h_pinned_fn_to_rep.data(),
                                                h_pinned_fn_to_rep.size() * sizeof(int),
                                                stream));
     }
     if (!h_fn_to_nested.empty()) {
-      auto& h_pinned_fn_to_nested =
-        make_pinned_staging_copy(h_fn_to_nested, stream, pinned_staging_buffers);
+      auto h_pinned_fn_to_nested = make_pinned_staging_copy(h_fn_to_nested, stream);
       d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_nested.data(),
                                                h_pinned_fn_to_nested.data(),
@@ -614,8 +621,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    auto& h_pinned_field_descs =
-      make_pinned_staging_copy(h_field_descs, stream, pinned_staging_buffers);
+    auto h_pinned_field_descs = make_pinned_staging_copy(h_field_descs, stream);
     CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
                                              h_pinned_field_descs.data(),
                                              h_pinned_field_descs.size() * sizeof(field_descriptor),
@@ -628,8 +634,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
-      auto& h_pinned_field_lookup =
-        make_pinned_staging_copy(h_field_lookup, stream, pinned_staging_buffers);
+      auto h_pinned_field_lookup = make_pinned_staging_copy(h_field_lookup, stream);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_lookup.data(),
                                                h_pinned_field_lookup.data(),
                                                h_pinned_field_lookup.size() * sizeof(int),
@@ -658,7 +663,6 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                 track_permissive_null_rows ? d_row_force_null.data() : nullptr,
                                 nullptr,
                                 d_error.data(),
-                                pinned_staging_buffers,
                                 stream);
 
     // Batched scalar extraction: group non-special fixed-width fields by extraction
@@ -736,9 +740,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
         std::vector<std::unique_ptr<scalar_buf_pair>> bufs;
         bufs.reserve(nf);
-        auto& h_descs = keep_pinned_staging(
-          cudf::detail::make_pinned_vector_async<batched_scalar_desc>(nf, stream),
-          pinned_staging_buffers);
+        auto h_descs = cudf::detail::make_pinned_vector_async<batched_scalar_desc>(nf, stream);
 
         for (int j = 0; j < nf; j++) {
           int li   = idxs[j];
@@ -897,15 +899,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
             CUDF_EXPECTS(!valid_enums.empty() && valid_enums.size() == enum_name_bytes.size(),
                          "Protobuf decode error: missing or mismatched enum metadata for "
                          "enum-as-string field");
-            column_map[schema_idx] = build_enum_string_column(out,
-                                                              valid,
-                                                              valid_enums,
-                                                              enum_name_bytes,
-                                                              pinned_staging_buffers,
-                                                              d_row_force_null,
-                                                              num_rows,
-                                                              stream,
-                                                              mr);
+            column_map[schema_idx] = build_enum_string_column(
+              out, valid, valid_enums, enum_name_bytes, d_row_force_null, num_rows, stream, mr);
           } else {
             // Regular protobuf STRING (length-delimited)
             bool has_def_str    = has_def;
@@ -1023,8 +1018,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     if (!h_scan_descs.empty()) {
       rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
         h_scan_descs.size(), stream, scratch_mr);
-      auto& h_pinned_scan_descs =
-        make_pinned_staging_copy(h_scan_descs, stream, pinned_staging_buffers);
+      auto h_pinned_scan_descs = make_pinned_staging_copy(h_scan_descs, stream);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_scan_descs.data(),
                                                h_pinned_scan_descs.data(),
                                                h_pinned_scan_descs.size() * sizeof(h_scan_descs[0]),
@@ -1038,8 +1032,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       rmm::device_uvector<int> d_fn_to_scan(0, stream, scratch_mr);
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
-        auto& h_pinned_fn_to_scan =
-          make_pinned_staging_copy(h_fn_to_scan, stream, pinned_staging_buffers);
+        auto h_pinned_fn_to_scan = make_pinned_staging_copy(h_fn_to_scan, stream);
         d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
         CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_scan.data(),
                                                  h_pinned_fn_to_scan.data(),
@@ -1215,7 +1208,6 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                                                        num_rows,
                                                                        field_meta.enum_valid_values,
                                                                        field_meta.enum_names,
-                                                                       pinned_staging_buffers,
                                                                        d_row_force_null,
                                                                        d_error,
                                                                        stream,
@@ -1285,7 +1277,6 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       schema,
       num_fields,
       {default_ints, default_floats, default_bools, default_strings, enum_valid_values, enum_names},
-      pinned_staging_buffers,
       d_row_force_null,
       d_error,
       num_rows,

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -544,10 +544,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                              stream));
   }
   if (num_nested > 0) {
-    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_nested_indices.data(),
-                                             nested_field_indices.data(),
-                                             num_nested * sizeof(int),
-                                             stream));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+      d_nested_indices.data(), nested_field_indices.data(), num_nested * sizeof(int), stream));
   }
 
   // Count repeated fields at depth 0 (with O(1) field_number lookup tables)
@@ -562,17 +560,13 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     if (!h_fn_to_rep.empty()) {
       d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_rep.data(),
-                                               h_fn_to_rep.data(),
-                                               h_fn_to_rep.size() * sizeof(int),
-                                               stream));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+        d_fn_to_rep.data(), h_fn_to_rep.data(), h_fn_to_rep.size() * sizeof(int), stream));
     }
     if (!h_fn_to_nested.empty()) {
       d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_nested.data(),
-                                               h_fn_to_nested.data(),
-                                               h_fn_to_nested.size() * sizeof(int),
-                                               stream));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+        d_fn_to_nested.data(), h_fn_to_nested.data(), h_fn_to_nested.size() * sizeof(int), stream));
     }
 
     launch_count_repeated_fields(*d_in,
@@ -609,10 +603,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
-                                             h_field_descs.data(),
-                                             num_scalar * sizeof(field_descriptor),
-                                             stream));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+      d_field_descs.data(), h_field_descs.data(), num_scalar * sizeof(field_descriptor), stream));
 
     rmm::device_uvector<field_location> d_locations(
       static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
@@ -621,10 +613,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_lookup.data(),
-                                               h_field_lookup.data(),
-                                               h_field_lookup.size() * sizeof(int),
-                                               stream));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+        d_field_lookup.data(), h_field_lookup.data(), h_field_lookup.size() * sizeof(int), stream));
     }
 
     launch_scan_all_fields(*d_in,
@@ -968,11 +958,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       // overflow before truncating into the int32 LIST offsets buffer (cudf list offsets are
       // int32). The same total is reused as the `offsets[num_rows]` sentinel below, so this
       // single reduce serves both the overflow guard and the offsets construction.
-      int64_t total_64 =
-        thrust::reduce(rmm::exec_policy_nosync(stream, scratch_mr),
-                       counts_begin,
-                       counts_end,
-                       int64_t{0});
+      int64_t total_64 = thrust::reduce(
+        rmm::exec_policy_nosync(stream, scratch_mr), counts_begin, counts_end, int64_t{0});
       CUDF_EXPECTS(total_64 <= std::numeric_limits<int32_t>::max(),
                    "Top-level repeated field total element count exceeds 2^31-1");
       w.total_count = static_cast<int32_t>(total_64);
@@ -985,10 +972,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                w.offsets.begin(),
                                int32_t{0});
       }
-      thrust::fill_n(rmm::exec_policy_nosync(stream, scratch_mr),
-                     w.offsets.data() + num_rows,
-                     1,
-                     w.total_count);
+      thrust::fill_n(
+        rmm::exec_policy_nosync(stream, scratch_mr), w.offsets.data() + num_rows, 1, w.total_count);
     }
 
     // Phase B: allocate occurrence buffers and launch the combined scan kernel.
@@ -1023,10 +1008,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
         d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
-        CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_scan.data(),
-                                                 h_fn_to_scan.data(),
-                                                 h_fn_to_scan.size() * sizeof(int),
-                                                 stream));
+        CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+          d_fn_to_scan.data(), h_fn_to_scan.data(), h_fn_to_scan.size() * sizeof(int), stream));
         fn_to_scan_size = static_cast<int>(h_fn_to_scan.size());
       }
 
@@ -1053,9 +1036,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
       // Fail fast rather than silently returning a null LIST<STRUCT>, which would be
       // indistinguishable from a real all-null result downstream.
-      CUDF_EXPECTS(
-        element_type.id() != cudf::type_id::STRUCT,
-        "Protobuf decode: repeated MessageType is not yet supported");
+      CUDF_EXPECTS(element_type.id() != cudf::type_id::STRUCT,
+                   "Protobuf decode: repeated MessageType is not yet supported");
 
       if (total_count <= 0) {
         // All rows empty: w.offsets is already a zero-filled buffer from Phase A.

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -17,6 +17,7 @@
 #include "nvtx_ranges.hpp"
 #include "protobuf/protobuf_kernels.cuh"
 
+#include <cudf/detail/utilities/cuda_memcpy.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 
 #include <thrust/binary_search.h>
@@ -440,14 +441,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   auto const message_data_size = in_list_view.child().size();
   auto const* list_offsets     = in_list_view.offsets().data<cudf::size_type>();
 
-  // Stage list_offsets[0] through pinned host memory so the D2H stays truly async (pageable
-  // destinations turn small cudaMemcpyAsync calls into synchronous bounce-buffer copies).
+  // Stage list_offsets[0] through pinned host memory so the D2H stays truly async.
   auto h_base_offset = cudf::detail::make_pinned_vector_async<cudf::size_type>(1, stream);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(h_base_offset.data(),
-                                list_offsets,
-                                sizeof(cudf::size_type),
-                                cudaMemcpyDeviceToHost,
-                                stream.value()));
+  CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+    h_base_offset.data(), list_offsets, sizeof(cudf::size_type), stream));
   stream.synchronize();
   cudf::size_type base_offset = h_base_offset[0];
 
@@ -462,11 +459,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   }
 
   rmm::device_uvector<device_nested_field_descriptor> d_schema(num_fields, stream, scratch_mr);
-  CUDF_CUDA_TRY(cudaMemcpyAsync(d_schema.data(),
-                                h_device_schema.data(),
-                                num_fields * sizeof(device_nested_field_descriptor),
-                                cudaMemcpyHostToDevice,
-                                stream.value()));
+  CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_schema.data(),
+                                           h_device_schema.data(),
+                                           num_fields * sizeof(device_nested_field_descriptor),
+                                           stream));
 
   auto d_in = cudf::column_device_view::create(binary_input, stream);
   // Identify repeated and nested fields at depth 0
@@ -542,18 +538,16 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   rmm::device_uvector<int> d_nested_indices(std::max<size_t>(num_nested, 1), stream, scratch_mr);
 
   if (num_repeated > 0) {
-    CUDF_CUDA_TRY(cudaMemcpyAsync(d_repeated_indices.data(),
-                                  repeated_field_indices.data(),
-                                  num_repeated * sizeof(int),
-                                  cudaMemcpyHostToDevice,
-                                  stream.value()));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_repeated_indices.data(),
+                                             repeated_field_indices.data(),
+                                             num_repeated * sizeof(int),
+                                             stream));
   }
   if (num_nested > 0) {
-    CUDF_CUDA_TRY(cudaMemcpyAsync(d_nested_indices.data(),
-                                  nested_field_indices.data(),
-                                  num_nested * sizeof(int),
-                                  cudaMemcpyHostToDevice,
-                                  stream.value()));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_nested_indices.data(),
+                                             nested_field_indices.data(),
+                                             num_nested * sizeof(int),
+                                             stream));
   }
 
   // Count repeated fields at depth 0 (with O(1) field_number lookup tables)
@@ -568,19 +562,17 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     if (!h_fn_to_rep.empty()) {
       d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_rep.data(),
-                                    h_fn_to_rep.data(),
-                                    h_fn_to_rep.size() * sizeof(int),
-                                    cudaMemcpyHostToDevice,
-                                    stream.value()));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_rep.data(),
+                                               h_fn_to_rep.data(),
+                                               h_fn_to_rep.size() * sizeof(int),
+                                               stream));
     }
     if (!h_fn_to_nested.empty()) {
       d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_nested.data(),
-                                    h_fn_to_nested.data(),
-                                    h_fn_to_nested.size() * sizeof(int),
-                                    cudaMemcpyHostToDevice,
-                                    stream.value()));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_nested.data(),
+                                               h_fn_to_nested.data(),
+                                               h_fn_to_nested.size() * sizeof(int),
+                                               stream));
     }
 
     launch_count_repeated_fields(*d_in,
@@ -617,11 +609,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    CUDF_CUDA_TRY(cudaMemcpyAsync(d_field_descs.data(),
-                                  h_field_descs.data(),
-                                  num_scalar * sizeof(field_descriptor),
-                                  cudaMemcpyHostToDevice,
-                                  stream.value()));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
+                                             h_field_descs.data(),
+                                             num_scalar * sizeof(field_descriptor),
+                                             stream));
 
     rmm::device_uvector<field_location> d_locations(
       static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
@@ -630,11 +621,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
-      CUDF_CUDA_TRY(cudaMemcpyAsync(d_field_lookup.data(),
-                                    h_field_lookup.data(),
-                                    h_field_lookup.size() * sizeof(int),
-                                    cudaMemcpyHostToDevice,
-                                    stream.value()));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_lookup.data(),
+                                               h_field_lookup.data(),
+                                               h_field_lookup.size() * sizeof(int),
+                                               stream));
     }
 
     launch_scan_all_fields(*d_in,
@@ -777,11 +767,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
         }
         rmm::device_uvector<batched_scalar_desc> d_descs(
           nf, stream, cudf::get_current_device_resource_ref());
-        CUDF_CUDA_TRY(cudaMemcpyAsync(d_descs.data(),
-                                      h_descs.data(),
-                                      nf * sizeof(h_descs[0]),
-                                      cudaMemcpyHostToDevice,
-                                      stream.value()));
+        CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+          d_descs.data(), h_descs.data(), nf * sizeof(h_descs[0]), stream));
         dim3 grid((num_rows + threads - 1u) / threads, nf);
         kernel_fn(grid,
                   threads,
@@ -982,18 +969,26 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       // int32). The same total is reused as the `offsets[num_rows]` sentinel below, so this
       // single reduce serves both the overflow guard and the offsets construction.
       int64_t total_64 =
-        thrust::reduce(rmm::exec_policy_nosync(stream), counts_begin, counts_end, int64_t{0});
+        thrust::reduce(rmm::exec_policy_nosync(stream, scratch_mr),
+                       counts_begin,
+                       counts_end,
+                       int64_t{0});
       CUDF_EXPECTS(total_64 <= std::numeric_limits<int32_t>::max(),
                    "Top-level repeated field total element count exceeds 2^31-1");
       w.total_count = static_cast<int32_t>(total_64);
 
       // num_rows == 0: w.offsets has size 1; skip the scan and let fill_n write the sentinel.
       if (num_rows > 0) {
-        thrust::exclusive_scan(
-          rmm::exec_policy_nosync(stream), counts_begin, counts_end, w.offsets.begin(), int32_t{0});
+        thrust::exclusive_scan(rmm::exec_policy_nosync(stream, scratch_mr),
+                               counts_begin,
+                               counts_end,
+                               w.offsets.begin(),
+                               int32_t{0});
       }
-      thrust::fill_n(
-        rmm::exec_policy_nosync(stream), w.offsets.data() + num_rows, 1, w.total_count);
+      thrust::fill_n(rmm::exec_policy_nosync(stream, scratch_mr),
+                     w.offsets.data() + num_rows,
+                     1,
+                     w.total_count);
     }
 
     // Phase B: allocate occurrence buffers and launch the combined scan kernel.
@@ -1014,11 +1009,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     if (!h_scan_descs.empty()) {
       rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
         h_scan_descs.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudaMemcpyAsync(d_scan_descs.data(),
-                                    h_scan_descs.data(),
-                                    h_scan_descs.size() * sizeof(h_scan_descs[0]),
-                                    cudaMemcpyHostToDevice,
-                                    stream.value()));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_scan_descs.data(),
+                                               h_scan_descs.data(),
+                                               h_scan_descs.size() * sizeof(h_scan_descs[0]),
+                                               stream));
 
       // Build field_number -> scan_desc_index lookup. `build_lookup_table` returns {} when
       // max field_number exceeds FIELD_LOOKUP_TABLE_MAX (would over-allocate); the kernel
@@ -1029,11 +1023,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
         d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
-        CUDF_CUDA_TRY(cudaMemcpyAsync(d_fn_to_scan.data(),
-                                      h_fn_to_scan.data(),
-                                      h_fn_to_scan.size() * sizeof(int),
-                                      cudaMemcpyHostToDevice,
-                                      stream.value()));
+        CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_scan.data(),
+                                                 h_fn_to_scan.data(),
+                                                 h_fn_to_scan.size() * sizeof(int),
+                                                 stream));
         fn_to_scan_size = static_cast<int>(h_fn_to_scan.size());
       }
 
@@ -1058,12 +1051,11 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
         continue;
       }
 
-      // Repeated MessageType is not supported in this part; full implementation lands in
-      // parts 3b/3c. Fail fast rather than silently returning a null LIST<STRUCT>, which
-      // would be indistinguishable from a real all-null result downstream.
+      // Fail fast rather than silently returning a null LIST<STRUCT>, which would be
+      // indistinguishable from a real all-null result downstream.
       CUDF_EXPECTS(
         element_type.id() != cudf::type_id::STRUCT,
-        "Protobuf decode: repeated MessageType is not yet supported (covered by parts 3b/3c)");
+        "Protobuf decode: repeated MessageType is not yet supported");
 
       if (total_count <= 0) {
         // All rows empty: w.offsets is already a zero-filled buffer from Phase A.
@@ -1242,16 +1234,16 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           break;
         default:
           // Unreachable: schema validation admits the types enumerated above; STRUCT is
-          // rejected at the loop entry above (parts 3b/3c). Reaching this branch means a
-          // schema slipped past validation.
+          // rejected at the loop entry above. Reaching this branch means a schema slipped past
+          // validation.
           CUDF_FAIL("Protobuf decode internal error: unsupported repeated element type id=" +
                     std::to_string(static_cast<int>(element_type.id())));
       }
     }  // for (ri)
   }
 
-  // Process nested struct fields (3b.2). Only scalar numeric/bool children decode for real;
-  // other child shapes are filled with typed null columns by build_nested_struct_column.
+  // Process nested struct fields after top-level repeated fields so malformed repeated
+  // occurrences can still mark their rows before nested columns are assembled.
   for (int ni = 0; ni < num_nested; ni++) {
     int parent_schema_idx = nested_field_indices[ni];
     // find_child_field_indices is a full linear pass over the schema per nested struct, so this
@@ -1263,6 +1255,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     launch_extract_strided_locations(
       d_nested_locations.data(), ni, num_nested, d_parent_locs.data(), num_rows, stream);
 
+    // Invalid enum values inside a nested struct should null only the enum field, not the
+    // top-level row. Malformed data still propagates via the scan kernel directly.
     auto nested_col = build_nested_struct_column(
       message_data,
       message_data_size,
@@ -1280,7 +1274,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       mr,
       nullptr,
       0,
-      track_permissive_null_rows);
+      false);
     propagate_nulls_to_descendants(*nested_col, stream, mr);
     column_map[parent_schema_idx] = std::move(nested_col);
   }
@@ -1297,8 +1291,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   CUDF_CUDA_TRY(cudaPeekAtLastError());
   int h_error = 0;
-  CUDF_CUDA_TRY(
-    cudaMemcpyAsync(&h_error, d_error.data(), sizeof(int), cudaMemcpyDeviceToHost, stream.value()));
+  CUDF_CUDA_TRY(cudf::detail::memcpy_async(&h_error, d_error.data(), sizeof(int), stream));
   stream.synchronize();
   if (h_error == ERR_SCHEMA_TOO_LARGE || h_error == ERR_REPEATED_COUNT_MISMATCH) {
     throw cudf::logic_error(error_message(h_error));

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -162,15 +162,6 @@ struct repeated_field_work {
   }
 };
 
-template <typename T>
-cudf::detail::host_vector<T> make_pinned_staging_copy(std::vector<T> const& source,
-                                                      rmm::cuda_stream_view stream)
-{
-  auto staging = cudf::detail::make_pinned_vector_async<T>(source.size(), stream);
-  std::copy(source.begin(), source.end(), staging.begin());
-  return staging;
-}
-
 }  // namespace
 
 std::unique_ptr<cudf::column> make_null_column_with_schema(
@@ -462,6 +453,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   // Scratch allocations consumed inside this function go through the current device resource;
   // only buffers that flow into the returned column should use the caller-supplied `mr`.
   auto const scratch_mr = cudf::get_current_device_resource_ref();
+  pinned_staging_buffer_store pinned_staging_buffers;
 
   // Copy schema to device
   std::vector<device_nested_field_descriptor> h_device_schema(num_fields);
@@ -570,15 +562,17 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested);
 
     if (!h_fn_to_rep.empty()) {
-      auto h_pinned_fn_to_rep = make_pinned_staging_copy(h_fn_to_rep, stream);
-      d_fn_to_rep             = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
+      auto& h_pinned_fn_to_rep =
+        make_pinned_staging_copy(h_fn_to_rep, stream, pinned_staging_buffers);
+      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_rep.data(),
                                                h_pinned_fn_to_rep.data(),
                                                h_pinned_fn_to_rep.size() * sizeof(int),
                                                stream));
     }
     if (!h_fn_to_nested.empty()) {
-      auto h_pinned_fn_to_nested = make_pinned_staging_copy(h_fn_to_nested, stream);
+      auto& h_pinned_fn_to_nested =
+        make_pinned_staging_copy(h_fn_to_nested, stream, pinned_staging_buffers);
       d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_nested.data(),
                                                h_pinned_fn_to_nested.data(),
@@ -620,7 +614,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    auto h_pinned_field_descs = make_pinned_staging_copy(h_field_descs, stream);
+    auto& h_pinned_field_descs =
+      make_pinned_staging_copy(h_field_descs, stream, pinned_staging_buffers);
     CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
                                              h_pinned_field_descs.data(),
                                              h_pinned_field_descs.size() * sizeof(field_descriptor),
@@ -633,7 +628,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
-      auto h_pinned_field_lookup = make_pinned_staging_copy(h_field_lookup, stream);
+      auto& h_pinned_field_lookup =
+        make_pinned_staging_copy(h_field_lookup, stream, pinned_staging_buffers);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_lookup.data(),
                                                h_pinned_field_lookup.data(),
                                                h_pinned_field_lookup.size() * sizeof(int),
@@ -662,6 +658,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                 track_permissive_null_rows ? d_row_force_null.data() : nullptr,
                                 nullptr,
                                 d_error.data(),
+                                pinned_staging_buffers,
                                 stream);
 
     // Batched scalar extraction: group non-special fixed-width fields by extraction
@@ -739,7 +736,9 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
         std::vector<std::unique_ptr<scalar_buf_pair>> bufs;
         bufs.reserve(nf);
-        auto h_descs = cudf::detail::make_pinned_vector_async<batched_scalar_desc>(nf, stream);
+        auto& h_descs = keep_pinned_staging(
+          cudf::detail::make_pinned_vector_async<batched_scalar_desc>(nf, stream),
+          pinned_staging_buffers);
 
         for (int j = 0; j < nf; j++) {
           int li   = idxs[j];
@@ -899,7 +898,15 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                          "Protobuf decode error: missing or mismatched enum metadata for "
                          "enum-as-string field");
             column_map[schema_idx] = build_enum_string_column(
-              out, valid, valid_enums, enum_name_bytes, d_row_force_null, num_rows, stream, mr);
+              out,
+              valid,
+              valid_enums,
+              enum_name_bytes,
+              pinned_staging_buffers,
+              d_row_force_null,
+              num_rows,
+              stream,
+              mr);
           } else {
             // Regular protobuf STRING (length-delimited)
             bool has_def_str    = has_def;
@@ -1017,7 +1024,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     if (!h_scan_descs.empty()) {
       rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
         h_scan_descs.size(), stream, scratch_mr);
-      auto h_pinned_scan_descs = make_pinned_staging_copy(h_scan_descs, stream);
+      auto& h_pinned_scan_descs =
+        make_pinned_staging_copy(h_scan_descs, stream, pinned_staging_buffers);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_scan_descs.data(),
                                                h_pinned_scan_descs.data(),
                                                h_pinned_scan_descs.size() * sizeof(h_scan_descs[0]),
@@ -1031,7 +1039,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       rmm::device_uvector<int> d_fn_to_scan(0, stream, scratch_mr);
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
-        auto h_pinned_fn_to_scan = make_pinned_staging_copy(h_fn_to_scan, stream);
+        auto& h_pinned_fn_to_scan =
+          make_pinned_staging_copy(h_fn_to_scan, stream, pinned_staging_buffers);
         d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
         CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_scan.data(),
                                                  h_pinned_fn_to_scan.data(),
@@ -1207,6 +1216,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                                                        num_rows,
                                                                        field_meta.enum_valid_values,
                                                                        field_meta.enum_names,
+                                                                       pinned_staging_buffers,
                                                                        d_row_force_null,
                                                                        d_error,
                                                                        stream,
@@ -1276,6 +1286,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       schema,
       num_fields,
       {default_ints, default_floats, default_bools, default_strings, enum_valid_values, enum_names},
+      pinned_staging_buffers,
       d_row_force_null,
       d_error,
       num_rows,

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -491,23 +491,24 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   // Error flag
   rmm::device_uvector<int> d_error(1, stream, cudf::get_current_device_resource_ref());
   CUDF_CUDA_TRY(cudaMemsetAsync(d_error.data(), 0, sizeof(int), stream.value()));
-  auto error_message = [](int code) -> std::string {
-    switch (code) {
-      case ERR_BOUNDS: return "Protobuf decode error: message data out of bounds";
-      case ERR_VARINT: return "Protobuf decode error: invalid or truncated varint";
-      case ERR_FIELD_NUMBER: return "Protobuf decode error: invalid field number";
-      case ERR_WIRE_TYPE: return "Protobuf decode error: unexpected wire type";
-      case ERR_OVERFLOW: return "Protobuf decode error: length-delimited field overflows message";
-      case ERR_FIELD_SIZE: return "Protobuf decode error: invalid field size";
-      case ERR_SKIP: return "Protobuf decode error: unable to skip unknown field";
-      case ERR_FIXED_LEN:
+  auto error_message = [](protobuf_error error) -> std::string {
+    switch (error) {
+      case protobuf_error::BOUNDS: return "Protobuf decode error: message data out of bounds";
+      case protobuf_error::VARINT: return "Protobuf decode error: invalid or truncated varint";
+      case protobuf_error::FIELD_NUMBER: return "Protobuf decode error: invalid field number";
+      case protobuf_error::WIRE_TYPE: return "Protobuf decode error: unexpected wire type";
+      case protobuf_error::OVERFLOW:
+        return "Protobuf decode error: length-delimited field overflows message";
+      case protobuf_error::FIELD_SIZE: return "Protobuf decode error: invalid field size";
+      case protobuf_error::SKIP: return "Protobuf decode error: unable to skip unknown field";
+      case protobuf_error::FIXED_LEN:
         return "Protobuf decode error: invalid fixed-width or packed field length";
-      case ERR_REQUIRED: return "Protobuf decode error: missing required field";
-      case ERR_SCHEMA_TOO_LARGE:
+      case protobuf_error::REQUIRED: return "Protobuf decode error: missing required field";
+      case protobuf_error::SCHEMA_TOO_LARGE:
         return "Protobuf decode error: schema exceeds maximum supported repeated fields per "
                "kernel (" +
                std::to_string(MAX_REPEATED_FIELDS_PER_KERNEL) + ")";
-      case ERR_REPEATED_COUNT_MISMATCH:
+      case protobuf_error::REPEATED_COUNT_MISMATCH:
         return "Protobuf decode error: repeated-field count/scan mismatch";
       default: return "Protobuf decode error: unknown error";
     }
@@ -552,10 +553,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   rmm::device_uvector<int> d_fn_to_nested(0, stream, scratch_mr);
 
   if (num_repeated > 0 || num_nested > 0) {
-    auto h_fn_to_rep = build_pinned_index_lookup_table(
-      schema.data(), repeated_field_indices.data(), num_repeated, stream);
-    auto h_fn_to_nested = build_pinned_index_lookup_table(
-      schema.data(), nested_field_indices.data(), num_nested, stream);
+    auto h_fn_to_rep =
+      build_index_lookup_table(schema.data(), repeated_field_indices.data(), num_repeated, stream);
+    auto h_fn_to_nested =
+      build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested, stream);
 
     if (!h_fn_to_rep.empty()) {
       d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
@@ -611,7 +612,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     rmm::device_uvector<field_location> d_locations(
       static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
 
-    auto h_field_lookup = build_pinned_field_lookup_table(h_field_descs.data(), num_scalar, stream);
+    auto h_field_lookup = build_field_lookup_table(h_field_descs.data(), num_scalar, stream);
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
@@ -979,34 +980,32 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     }
 
     // Phase B: allocate occurrence buffers and launch the combined scan kernel.
-    auto h_scan_descs =
-      cudf::detail::make_pinned_vector_async<repeated_field_scan_desc>(num_repeated, stream);
-    int num_scan_descs = 0;
+    auto h_scan_descs = cudf::detail::make_pinned_vector_async<repeated_field_scan_desc>(0, stream);
 
     for (auto& w : rep_work) {
       if (w.total_count > 0) {
         w.occurrences = std::make_unique<rmm::device_uvector<repeated_occurrence>>(
           w.total_count, stream, scratch_mr);
-        h_scan_descs[num_scan_descs++] = {schema[w.schema_idx].field_number,
-                                          static_cast<int>(schema[w.schema_idx].wire_type),
-                                          w.offsets.data(),
-                                          w.occurrences->data()};
+        h_scan_descs.push_back({schema[w.schema_idx].field_number,
+                                static_cast<int>(schema[w.schema_idx].wire_type),
+                                w.offsets.data(),
+                                w.occurrences->data()});
       }
     }
 
-    if (num_scan_descs > 0) {
+    if (!h_scan_descs.empty()) {
       rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
-        num_scan_descs, stream, scratch_mr);
+        h_scan_descs.size(), stream, scratch_mr);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_scan_descs.data(),
                                                h_scan_descs.data(),
-                                               num_scan_descs * sizeof(h_scan_descs[0]),
+                                               h_scan_descs.size() * sizeof(h_scan_descs[0]),
                                                stream));
 
       // Build field_number -> scan_desc_index lookup. The helper returns an empty table when
       // max field_number exceeds FIELD_LOOKUP_TABLE_MAX (would over-allocate); the kernel
       // detects this via fn_to_scan_size == 0 and falls back to a linear scan.
-      auto h_fn_to_scan = build_pinned_lookup_table(
-        [&](int i) { return h_scan_descs[i].field_number; }, num_scan_descs, stream);
+      auto h_fn_to_scan = build_field_lookup_table(
+        h_scan_descs.data(), static_cast<int>(h_scan_descs.size()), stream);
       rmm::device_uvector<int> d_fn_to_scan(0, stream, scratch_mr);
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
@@ -1018,7 +1017,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
       launch_scan_all_repeated_occurrences(*d_in,
                                            d_scan_descs.data(),
-                                           num_scan_descs,
+                                           static_cast<int>(h_scan_descs.size()),
                                            d_error.data(),
                                            fn_to_scan_size > 0 ? d_fn_to_scan.data() : nullptr,
                                            fn_to_scan_size,
@@ -1278,10 +1277,14 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   int h_error = 0;
   CUDF_CUDA_TRY(cudf::detail::memcpy_async(&h_error, d_error.data(), sizeof(int), stream));
   stream.synchronize();
-  if (h_error == ERR_SCHEMA_TOO_LARGE || h_error == ERR_REPEATED_COUNT_MISMATCH) {
-    throw cudf::logic_error(error_message(h_error));
+  auto const error = static_cast<protobuf_error>(h_error);
+  if (error == protobuf_error::SCHEMA_TOO_LARGE ||
+      error == protobuf_error::REPEATED_COUNT_MISMATCH) {
+    throw cudf::logic_error(error_message(error));
   }
-  if (fail_on_errors && h_error != 0) throw cudf::logic_error(error_message(h_error));
+  if (fail_on_errors && error != protobuf_error::NONE) {
+    throw cudf::logic_error(error_message(error));
+  }
 
   // Build final struct null mask by combining input nulls with PERMISSIVE-mode row invalidation.
   cudf::size_type struct_null_count = 0;

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -18,10 +18,12 @@
 #include "protobuf/protobuf_kernels.cuh"
 
 #include <cudf/detail/utilities/cuda_memcpy.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 
 #include <thrust/binary_search.h>
 
+#include <algorithm>
 #include <limits>
 #include <set>
 #include <string>
@@ -159,6 +161,15 @@ struct repeated_field_work {
   {
   }
 };
+
+template <typename T>
+cudf::detail::host_vector<T> make_pinned_staging_copy(std::vector<T> const& source,
+                                                      rmm::cuda_stream_view stream)
+{
+  auto staging = cudf::detail::make_pinned_vector_async<T>(source.size(), stream);
+  std::copy(source.begin(), source.end(), staging.begin());
+  return staging;
+}
 
 }  // namespace
 
@@ -559,14 +570,20 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested);
 
     if (!h_fn_to_rep.empty()) {
-      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
-        d_fn_to_rep.data(), h_fn_to_rep.data(), h_fn_to_rep.size() * sizeof(int), stream));
+      auto h_pinned_fn_to_rep = make_pinned_staging_copy(h_fn_to_rep, stream);
+      d_fn_to_rep             = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_rep.data(),
+                                               h_pinned_fn_to_rep.data(),
+                                               h_pinned_fn_to_rep.size() * sizeof(int),
+                                               stream));
     }
     if (!h_fn_to_nested.empty()) {
+      auto h_pinned_fn_to_nested = make_pinned_staging_copy(h_fn_to_nested, stream);
       d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
-        d_fn_to_nested.data(), h_fn_to_nested.data(), h_fn_to_nested.size() * sizeof(int), stream));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_nested.data(),
+                                               h_pinned_fn_to_nested.data(),
+                                               h_pinned_fn_to_nested.size() * sizeof(int),
+                                               stream));
     }
 
     launch_count_repeated_fields(*d_in,
@@ -603,8 +620,11 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    CUDF_CUDA_TRY(cudf::detail::memcpy_async(
-      d_field_descs.data(), h_field_descs.data(), num_scalar * sizeof(field_descriptor), stream));
+    auto h_pinned_field_descs = make_pinned_staging_copy(h_field_descs, stream);
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
+                                             h_pinned_field_descs.data(),
+                                             h_pinned_field_descs.size() * sizeof(field_descriptor),
+                                             stream));
 
     rmm::device_uvector<field_location> d_locations(
       static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
@@ -613,8 +633,11 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
-        d_field_lookup.data(), h_field_lookup.data(), h_field_lookup.size() * sizeof(int), stream));
+      auto h_pinned_field_lookup = make_pinned_staging_copy(h_field_lookup, stream);
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_lookup.data(),
+                                               h_pinned_field_lookup.data(),
+                                               h_pinned_field_lookup.size() * sizeof(int),
+                                               stream));
     }
 
     launch_scan_all_fields(*d_in,
@@ -716,7 +739,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
         std::vector<std::unique_ptr<scalar_buf_pair>> bufs;
         bufs.reserve(nf);
-        std::vector<batched_scalar_desc> h_descs(nf);
+        auto h_descs = cudf::detail::make_pinned_vector_async<batched_scalar_desc>(nf, stream);
 
         for (int j = 0; j < nf; j++) {
           int li   = idxs[j];
@@ -747,7 +770,7 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
       // Varint launcher for type T with zigzag ZZ
       auto varint_launch = [&](int nf,
-                               std::vector<batched_scalar_desc>& h_descs,
+                               auto& h_descs,
                                std::vector<std::unique_ptr<scalar_buf_pair>>& bufs,
                                size_t elem_size,
                                auto kernel_fn) {
@@ -994,9 +1017,10 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     if (!h_scan_descs.empty()) {
       rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
         h_scan_descs.size(), stream, scratch_mr);
+      auto h_pinned_scan_descs = make_pinned_staging_copy(h_scan_descs, stream);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_scan_descs.data(),
-                                               h_scan_descs.data(),
-                                               h_scan_descs.size() * sizeof(h_scan_descs[0]),
+                                               h_pinned_scan_descs.data(),
+                                               h_pinned_scan_descs.size() * sizeof(h_scan_descs[0]),
                                                stream));
 
       // Build field_number -> scan_desc_index lookup. `build_lookup_table` returns {} when
@@ -1007,9 +1031,12 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
       rmm::device_uvector<int> d_fn_to_scan(0, stream, scratch_mr);
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
+        auto h_pinned_fn_to_scan = make_pinned_staging_copy(h_fn_to_scan, stream);
         d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
-        CUDF_CUDA_TRY(cudf::detail::memcpy_async(
-          d_fn_to_scan.data(), h_fn_to_scan.data(), h_fn_to_scan.size() * sizeof(int), stream));
+        CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_scan.data(),
+                                                 h_pinned_fn_to_scan.data(),
+                                                 h_pinned_fn_to_scan.size() * sizeof(int),
+                                                 stream));
         fn_to_scan_size = static_cast<int>(h_fn_to_scan.size());
       }
 

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -162,16 +162,6 @@ struct repeated_field_work {
   }
 };
 
-template <typename T>
-cudf::detail::host_vector<T> make_pinned_staging_copy(std::vector<T> const& source,
-                                                      rmm::cuda_stream_view stream)
-{
-  // Stream-ordered pinned deallocation keeps this staging safe without a local sync.
-  auto staging = cudf::detail::make_pinned_vector_async<T>(source.size(), stream);
-  std::copy(source.begin(), source.end(), staging.begin());
-  return staging;
-}
-
 }  // namespace
 
 std::unique_ptr<cudf::column> make_null_column_with_schema(
@@ -517,9 +507,6 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
         return "Protobuf decode error: schema exceeds maximum supported repeated fields per "
                "kernel (" +
                std::to_string(MAX_REPEATED_FIELDS_PER_KERNEL) + ")";
-      case ERR_MISSING_ENUM_META:
-        return "Protobuf decode error: missing or mismatched enum metadata for enum-as-string "
-               "field";
       case ERR_REPEATED_COUNT_MISMATCH:
         return "Protobuf decode error: repeated-field count/scan mismatch";
       default: return "Protobuf decode error: unknown error";
@@ -565,26 +552,20 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
   rmm::device_uvector<int> d_fn_to_nested(0, stream, scratch_mr);
 
   if (num_repeated > 0 || num_nested > 0) {
-    auto h_fn_to_rep =
-      build_index_lookup_table(schema.data(), repeated_field_indices.data(), num_repeated);
-    auto h_fn_to_nested =
-      build_index_lookup_table(schema.data(), nested_field_indices.data(), num_nested);
+    auto h_fn_to_rep = build_pinned_index_lookup_table(
+      schema.data(), repeated_field_indices.data(), num_repeated, stream);
+    auto h_fn_to_nested = build_pinned_index_lookup_table(
+      schema.data(), nested_field_indices.data(), num_nested, stream);
 
     if (!h_fn_to_rep.empty()) {
-      auto h_pinned_fn_to_rep = make_pinned_staging_copy(h_fn_to_rep, stream);
-      d_fn_to_rep             = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_rep.data(),
-                                               h_pinned_fn_to_rep.data(),
-                                               h_pinned_fn_to_rep.size() * sizeof(int),
-                                               stream));
+      d_fn_to_rep = rmm::device_uvector<int>(h_fn_to_rep.size(), stream, scratch_mr);
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+        d_fn_to_rep.data(), h_fn_to_rep.data(), h_fn_to_rep.size() * sizeof(int), stream));
     }
     if (!h_fn_to_nested.empty()) {
-      auto h_pinned_fn_to_nested = make_pinned_staging_copy(h_fn_to_nested, stream);
       d_fn_to_nested = rmm::device_uvector<int>(h_fn_to_nested.size(), stream, scratch_mr);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_nested.data(),
-                                               h_pinned_fn_to_nested.data(),
-                                               h_pinned_fn_to_nested.size() * sizeof(int),
-                                               stream));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+        d_fn_to_nested.data(), h_fn_to_nested.data(), h_fn_to_nested.size() * sizeof(int), stream));
     }
 
     launch_count_repeated_fields(*d_in,
@@ -611,7 +592,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
   // Process scalar fields using scan + extract infrastructure
   if (num_scalar > 0) {
-    std::vector<field_descriptor> h_field_descs(num_scalar);
+    auto h_field_descs =
+      cudf::detail::make_pinned_vector_async<field_descriptor>(num_scalar, stream);
     for (int i = 0; i < num_scalar; i++) {
       int schema_idx                      = scalar_field_indices[i];
       h_field_descs[i].field_number       = schema[schema_idx].field_number;
@@ -621,24 +603,20 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
 
     rmm::device_uvector<field_descriptor> d_field_descs(
       num_scalar, stream, cudf::get_current_device_resource_ref());
-    auto h_pinned_field_descs = make_pinned_staging_copy(h_field_descs, stream);
     CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_descs.data(),
-                                             h_pinned_field_descs.data(),
-                                             h_pinned_field_descs.size() * sizeof(field_descriptor),
+                                             h_field_descs.data(),
+                                             h_field_descs.size() * sizeof(field_descriptor),
                                              stream));
 
     rmm::device_uvector<field_location> d_locations(
       static_cast<size_t>(num_rows) * num_scalar, stream, cudf::get_current_device_resource_ref());
 
-    auto h_field_lookup = build_field_lookup_table(h_field_descs.data(), num_scalar);
+    auto h_field_lookup = build_pinned_field_lookup_table(h_field_descs.data(), num_scalar, stream);
     rmm::device_uvector<int> d_field_lookup(
       h_field_lookup.size(), stream, cudf::get_current_device_resource_ref());
     if (!h_field_lookup.empty()) {
-      auto h_pinned_field_lookup = make_pinned_staging_copy(h_field_lookup, stream);
-      CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_field_lookup.data(),
-                                               h_pinned_field_lookup.data(),
-                                               h_pinned_field_lookup.size() * sizeof(int),
-                                               stream));
+      CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+        d_field_lookup.data(), h_field_lookup.data(), h_field_lookup.size() * sizeof(int), stream));
     }
 
     launch_scan_all_fields(*d_in,
@@ -747,12 +725,12 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
           int si   = scalar_field_indices[li];
           bool hd  = schema[si].has_default_value;
           auto& bp = *bufs.emplace_back(std::make_unique<scalar_buf_pair>(stream, mr));
-          bp.valid = rmm::device_uvector<bool>(
-            std::max(1, num_rows), stream, cudf::get_current_device_resource_ref());
+          bp.valid =
+            rmm::device_uvector<bool>(num_rows, stream, cudf::get_current_device_resource_ref());
           // BOOL8 default comes from default_bools (converted to 0/1 int)
           bool is_bool  = (cudf::data_type{schema[si].output_type}.id() == cudf::type_id::BOOL8);
-          int64_t def_i = hd ? (is_bool ? (default_bools[si] ? 1 : 0) : default_ints[si]) : 0;
-          h_descs[j]    = {li, nullptr, bp.valid.data(), hd, def_i, hd ? default_floats[si] : 0.0};
+          int64_t def_i = is_bool ? (default_bools[si] ? 1 : 0) : default_ints[si];
+          h_descs[j]    = {li, nullptr, bp.valid.data(), hd, def_i, default_floats[si]};
         }
 
         // kernel_launcher allocates out_bytes, sets h_descs[j].output, and launches kernel
@@ -845,9 +823,9 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
                                                       blocks,
                                                       threads,
                                                       has_def,
-                                                      has_def ? field_meta.default_int : 0,
-                                                      has_def ? field_meta.default_float : 0.0,
-                                                      has_def ? field_meta.default_bool : false,
+                                                      field_meta.default_int,
+                                                      field_meta.default_float,
+                                                      field_meta.default_bool,
                                                       field_meta.default_string,
                                                       schema_idx,
                                                       enum_valid_values,
@@ -878,8 +856,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
             rmm::device_uvector<int32_t> out(
               num_rows, stream, cudf::get_current_device_resource_ref());
             rmm::device_uvector<bool> valid(
-              (num_rows > 0 ? num_rows : 1), stream, cudf::get_current_device_resource_ref());
-            int64_t def_int = has_def ? field_meta.default_int : 0;
+              num_rows, stream, cudf::get_current_device_resource_ref());
+            int64_t def_int = field_meta.default_int;
             top_level_location_provider loc_provider{
               list_offsets, base_offset, d_locations.data(), i, num_scalar};
             extract_varint_kernel<int32_t, false, top_level_location_provider>
@@ -1001,49 +979,46 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     }
 
     // Phase B: allocate occurrence buffers and launch the combined scan kernel.
-    std::vector<repeated_field_scan_desc> h_scan_descs;
-    h_scan_descs.reserve(num_repeated);
+    auto h_scan_descs =
+      cudf::detail::make_pinned_vector_async<repeated_field_scan_desc>(num_repeated, stream);
+    int num_scan_descs = 0;
 
     for (auto& w : rep_work) {
       if (w.total_count > 0) {
         w.occurrences = std::make_unique<rmm::device_uvector<repeated_occurrence>>(
           w.total_count, stream, scratch_mr);
-        h_scan_descs.push_back({schema[w.schema_idx].field_number,
-                                static_cast<int>(schema[w.schema_idx].wire_type),
-                                w.offsets.data(),
-                                w.occurrences->data()});
+        h_scan_descs[num_scan_descs++] = {schema[w.schema_idx].field_number,
+                                          static_cast<int>(schema[w.schema_idx].wire_type),
+                                          w.offsets.data(),
+                                          w.occurrences->data()};
       }
     }
 
-    if (!h_scan_descs.empty()) {
+    if (num_scan_descs > 0) {
       rmm::device_uvector<repeated_field_scan_desc> d_scan_descs(
-        h_scan_descs.size(), stream, scratch_mr);
-      auto h_pinned_scan_descs = make_pinned_staging_copy(h_scan_descs, stream);
+        num_scan_descs, stream, scratch_mr);
       CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_scan_descs.data(),
-                                               h_pinned_scan_descs.data(),
-                                               h_pinned_scan_descs.size() * sizeof(h_scan_descs[0]),
+                                               h_scan_descs.data(),
+                                               num_scan_descs * sizeof(h_scan_descs[0]),
                                                stream));
 
-      // Build field_number -> scan_desc_index lookup. `build_lookup_table` returns {} when
+      // Build field_number -> scan_desc_index lookup. The helper returns an empty table when
       // max field_number exceeds FIELD_LOOKUP_TABLE_MAX (would over-allocate); the kernel
       // detects this via fn_to_scan_size == 0 and falls back to a linear scan.
-      auto h_fn_to_scan = build_lookup_table([&](int i) { return h_scan_descs[i].field_number; },
-                                             static_cast<int>(h_scan_descs.size()));
+      auto h_fn_to_scan = build_pinned_lookup_table(
+        [&](int i) { return h_scan_descs[i].field_number; }, num_scan_descs, stream);
       rmm::device_uvector<int> d_fn_to_scan(0, stream, scratch_mr);
       int fn_to_scan_size = 0;
       if (!h_fn_to_scan.empty()) {
-        auto h_pinned_fn_to_scan = make_pinned_staging_copy(h_fn_to_scan, stream);
         d_fn_to_scan = rmm::device_uvector<int>(h_fn_to_scan.size(), stream, scratch_mr);
-        CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_fn_to_scan.data(),
-                                                 h_pinned_fn_to_scan.data(),
-                                                 h_pinned_fn_to_scan.size() * sizeof(int),
-                                                 stream));
+        CUDF_CUDA_TRY(cudf::detail::memcpy_async(
+          d_fn_to_scan.data(), h_fn_to_scan.data(), h_fn_to_scan.size() * sizeof(int), stream));
         fn_to_scan_size = static_cast<int>(h_fn_to_scan.size());
       }
 
       launch_scan_all_repeated_occurrences(*d_in,
                                            d_scan_descs.data(),
-                                           static_cast<int>(h_scan_descs.size()),
+                                           num_scan_descs,
                                            d_error.data(),
                                            fn_to_scan_size > 0 ? d_fn_to_scan.data() : nullptr,
                                            fn_to_scan_size,
@@ -1265,8 +1240,8 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
     launch_extract_strided_locations(
       d_nested_locations.data(), ni, num_nested, d_parent_locs.data(), num_rows, stream);
 
-    // Invalid enum values inside a nested struct should null only the enum field, not the
-    // top-level row. Malformed data still propagates via the scan kernel directly.
+    // Keep row-force-null tracking for nested required-field failures, but do not let invalid
+    // nested enum values null the top-level row.
     auto nested_col = build_nested_struct_column(
       message_data,
       message_data_size,

--- a/src/main/cpp/src/protobuf/protobuf.cu
+++ b/src/main/cpp/src/protobuf/protobuf.cu
@@ -897,16 +897,15 @@ std::unique_ptr<cudf::column> decode_protobuf_to_struct(cudf::column_view const&
             CUDF_EXPECTS(!valid_enums.empty() && valid_enums.size() == enum_name_bytes.size(),
                          "Protobuf decode error: missing or mismatched enum metadata for "
                          "enum-as-string field");
-            column_map[schema_idx] = build_enum_string_column(
-              out,
-              valid,
-              valid_enums,
-              enum_name_bytes,
-              pinned_staging_buffers,
-              d_row_force_null,
-              num_rows,
-              stream,
-              mr);
+            column_map[schema_idx] = build_enum_string_column(out,
+                                                              valid,
+                                                              valid_enums,
+                                                              enum_name_bytes,
+                                                              pinned_staging_buffers,
+                                                              d_row_force_null,
+                                                              num_rows,
+                                                              stream,
+                                                              mr);
           } else {
             // Regular protobuf STRING (length-delimited)
             bool has_def_str    = has_def;

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -16,6 +16,7 @@
 
 #include "protobuf/protobuf_kernels.cuh"
 
+#include <cudf/detail/utilities/cuda_memcpy.hpp>
 #include <cudf/lists/detail/lists_column_factories.hpp>
 #include <cudf/strings/detail/strings_column_factories.cuh>
 
@@ -65,7 +66,7 @@ std::unique_ptr<cudf::column> make_null_column(cudf::data_type dtype,
       return cudf::make_fixed_width_column(dtype, num_rows, cudf::mask_state::ALL_NULL, stream, mr);
     case cudf::type_id::STRING: {
       rmm::device_uvector<cudf::strings::detail::string_index_pair> pairs(num_rows, stream, mr);
-      thrust::fill(rmm::exec_policy_nosync(stream),
+      thrust::fill(rmm::exec_policy_nosync(stream, mr),
                    pairs.data(),
                    pairs.end(),
                    cudf::strings::detail::string_index_pair{nullptr, 0});
@@ -119,7 +120,7 @@ std::unique_ptr<cudf::column> make_null_list_column_with_child(
   rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<int32_t> offsets(num_rows + 1, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream), offsets.begin(), offsets.end(), 0);
+  thrust::fill(rmm::exec_policy_nosync(stream, mr), offsets.begin(), offsets.end(), 0);
   auto offsets_col = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
                                                     num_rows + 1,
                                                     offsets.release(),
@@ -251,9 +252,9 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   bool propagate_invalid_rows)
 {
   auto lookup = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
-  rmm::device_uvector<bool> d_item_has_invalid_enum(
-    num_rows, stream, cudf::get_current_device_resource_ref());
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<bool> d_item_has_invalid_enum(num_rows, stream, scratch_mr);
+  thrust::fill(rmm::exec_policy_nosync(stream, scratch_mr),
                d_item_has_invalid_enum.begin(),
                d_item_has_invalid_enum.end(),
                false);
@@ -313,7 +314,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   // (elem_valid was already populated by extract_varint_kernel: true for success, false for
   // failure)
   rmm::device_uvector<bool> d_elem_has_invalid_enum(total_count, stream, scratch_mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, scratch_mr),
                d_elem_has_invalid_enum.begin(),
                d_elem_has_invalid_enum.end(),
                false);
@@ -326,7 +327,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
                               stream);
 
   rmm::device_uvector<int32_t> d_top_row_indices(total_count, stream, scratch_mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, scratch_mr),
                     d_occurrences.begin(),
                     d_occurrences.end(),
                     d_top_row_indices.begin(),
@@ -454,10 +455,9 @@ std::unique_ptr<cudf::column> build_repeated_string_column(
 /**
  * Build a STRUCT column for a nested protobuf message.
  *
- * 3b.2 scope: only scalar numeric/bool children are fully decoded. STRING/LIST<UINT8>/STRUCT
- * children, repeated children, and proto2 required-field checks land in subsequent PRs
- * (3b.3 / 3b.4 / 3b.5 / 3b.6); for now those child slots are filled with typed null columns
- * so the output schema is still well-formed.
+ * Scalar, string, bytes, enum-as-string, default values, proto2 required-field checks,
+ * and recursive STRUCT children are decoded. Repeated children are still emitted as
+ * typed null LIST columns.
  */
 std::unique_ptr<cudf::column> build_nested_struct_column(
   uint8_t const* message_data,
@@ -511,11 +511,10 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   rmm::device_uvector<field_descriptor> d_child_field_descs(
     std::max(num_child_fields, 1), stream, scratch_mr);
   if (num_child_fields > 0) {
-    CUDF_CUDA_TRY(cudaMemcpyAsync(d_child_field_descs.data(),
-                                  h_child_field_descs.data(),
-                                  num_child_fields * sizeof(field_descriptor),
-                                  cudaMemcpyHostToDevice,
-                                  stream.value()));
+    CUDF_CUDA_TRY(cudf::detail::memcpy_async(d_child_field_descs.data(),
+                                             h_child_field_descs.data(),
+                                             num_child_fields * sizeof(field_descriptor),
+                                             stream));
   }
 
   auto const child_location_count = static_cast<size_t>(num_rows) * num_child_fields;
@@ -523,7 +522,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
     std::max(child_location_count, size_t{1}), stream, scratch_mr);
   // Scan over every child descriptor (including repeated ones) so STRICT-mode wire-type
   // validation still runs on repeated occurrences. Repeated child slots in d_child_locations
-  // are not consumed; 3b.5 / 3b.6 produce them via dedicated count/scan kernels.
+  // are reserved for a dedicated nested repeated count/scan path.
   launch_scan_nested_message_fields(message_data,
                                     message_data_size,
                                     list_offsets,
@@ -538,6 +537,18 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                     top_row_indices,
                                     stream);
 
+  maybe_check_required_fields(d_child_locations.data(),
+                              child_field_indices,
+                              schema,
+                              num_rows,
+                              nullptr,
+                              0,
+                              d_parent_locs.data(),
+                              d_row_force_null.size() > 0 ? d_row_force_null.data() : nullptr,
+                              top_row_indices,
+                              d_error.data(),
+                              stream);
+
   std::vector<std::unique_ptr<cudf::column>> struct_children;
   for (int ci = 0; ci < num_child_fields; ci++) {
     int child_schema_idx = child_field_indices[ci];
@@ -546,8 +557,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
     bool has_def         = schema[child_schema_idx].has_default_value;
     bool is_repeated     = schema[child_schema_idx].is_repeated;
 
-    // Repeated children inside nested messages land in 3b.5 / 3b.6; emit a typed null LIST
-    // so the struct schema is still well-formed.
+    // Keep the struct schema well-formed until nested repeated children are decoded.
     if (is_repeated) {
       struct_children.push_back(
         make_null_column_with_schema(schema, child_schema_idx, num_fields, num_rows, stream, mr));
@@ -592,14 +602,142 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                propagate_invalid_rows));
         break;
       }
-      case cudf::type_id::STRING:
-      case cudf::type_id::LIST:  // bytes represented as LIST<UINT8>
-      case cudf::type_id::STRUCT:
-        // Nested string/bytes/enum-as-string (3b.3) and recursive struct (3b.4) children are
-        // not decoded yet; emit a typed null column so the output schema still matches.
-        struct_children.push_back(
-          make_null_column_with_schema(schema, child_schema_idx, num_fields, num_rows, stream, mr));
+      case cudf::type_id::STRING: {
+        nested_location_provider loc_provider{list_offsets,
+                                              base_offset,
+                                              d_parent_locs.data(),
+                                              d_child_locations.data(),
+                                              ci,
+                                              num_child_fields};
+        if (enc == encoding_value(proto_encoding::ENUM_STRING)) {
+          rmm::device_uvector<int32_t> out(num_rows, stream, mr);
+          rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
+          extract_varint_kernel<int32_t, false, nested_location_provider>
+            <<<blocks, threads, 0, stream.value()>>>(message_data,
+                                                     loc_provider,
+                                                     num_rows,
+                                                     out.data(),
+                                                     valid.data(),
+                                                     d_error.data(),
+                                                     has_def,
+                                                     has_def ? ctx.default_ints[child_schema_idx]
+                                                             : 0);
+          if (child_schema_idx < static_cast<int>(ctx.enum_valid_values.size()) &&
+              child_schema_idx < static_cast<int>(ctx.enum_names.size()) &&
+              !ctx.enum_valid_values[child_schema_idx].empty() &&
+              ctx.enum_valid_values[child_schema_idx].size() ==
+                ctx.enum_names[child_schema_idx].size()) {
+            struct_children.push_back(
+              build_enum_string_column(out,
+                                       valid,
+                                       ctx.enum_valid_values[child_schema_idx],
+                                       ctx.enum_names[child_schema_idx],
+                                       d_row_force_null,
+                                       num_rows,
+                                       stream,
+                                       mr,
+                                       top_row_indices,
+                                       propagate_invalid_rows));
+          } else {
+            set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
+            struct_children.push_back(make_null_column(dt, num_rows, stream, mr));
+          }
+        } else {
+          auto valid_fn = [plocs = d_parent_locs.data(),
+                           flocs = d_child_locations.data(),
+                           ci,
+                           num_child_fields,
+                           has_def] __device__(cudf::size_type row) {
+            return (plocs[row].offset >= 0 &&
+                    flocs[flat_index(static_cast<size_t>(row),
+                                     static_cast<size_t>(num_child_fields),
+                                     static_cast<size_t>(ci))]
+                        .offset >= 0) ||
+                   has_def;
+          };
+          struct_children.push_back(
+            extract_and_build_string_or_bytes_column(false,
+                                                     message_data,
+                                                     num_rows,
+                                                     loc_provider,
+                                                     loc_provider,
+                                                     valid_fn,
+                                                     has_def,
+                                                     ctx.default_strings[child_schema_idx],
+                                                     d_error,
+                                                     stream,
+                                                     mr));
+        }
         break;
+      }
+      case cudf::type_id::LIST: {  // bytes represented as LIST<UINT8>
+        nested_location_provider loc_provider{list_offsets,
+                                              base_offset,
+                                              d_parent_locs.data(),
+                                              d_child_locations.data(),
+                                              ci,
+                                              num_child_fields};
+        auto valid_fn = [plocs = d_parent_locs.data(),
+                         flocs = d_child_locations.data(),
+                         ci,
+                         num_child_fields,
+                         has_def] __device__(cudf::size_type row) {
+          return (plocs[row].offset >= 0 && flocs[flat_index(static_cast<size_t>(row),
+                                                             static_cast<size_t>(num_child_fields),
+                                                             static_cast<size_t>(ci))]
+                                                .offset >= 0) ||
+                 has_def;
+        };
+        struct_children.push_back(
+          extract_and_build_string_or_bytes_column(true,
+                                                   message_data,
+                                                   num_rows,
+                                                   loc_provider,
+                                                   loc_provider,
+                                                   valid_fn,
+                                                   has_def,
+                                                   ctx.default_strings[child_schema_idx],
+                                                   d_error,
+                                                   stream,
+                                                   mr));
+        break;
+      }
+      case cudf::type_id::STRUCT: {
+        auto gc_indices = find_child_field_indices(schema, num_fields, child_schema_idx);
+        if (gc_indices.empty()) {
+          struct_children.push_back(make_null_column_with_schema(
+            schema, child_schema_idx, num_fields, num_rows, stream, mr));
+          break;
+        }
+
+        rmm::device_uvector<field_location> d_gc_parent_locs(num_rows, stream, scratch_mr);
+        launch_compute_grandchild_parent_locations(d_parent_locs.data(),
+                                                   d_child_locations.data(),
+                                                   ci,
+                                                   num_child_fields,
+                                                   d_gc_parent_locs.data(),
+                                                   num_rows,
+                                                   d_error.data(),
+                                                   stream);
+        struct_children.push_back(build_nested_struct_column(message_data,
+                                                             message_data_size,
+                                                             list_offsets,
+                                                             base_offset,
+                                                             d_gc_parent_locs,
+                                                             gc_indices,
+                                                             schema,
+                                                             num_fields,
+                                                             ctx,
+                                                             d_row_force_null,
+                                                             d_error,
+                                                             num_rows,
+                                                             stream,
+                                                             mr,
+                                                             top_row_indices,
+                                                             depth + 1,
+                                                             propagate_invalid_rows));
+        break;
+      }
       default:
         // List the supported/deferred types above explicitly so a newly-introduced output type
         // fails loudly here instead of silently decoding as all-null.
@@ -609,7 +747,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
 
   rmm::device_uvector<bool> struct_valid(num_rows, stream, scratch_mr);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, scratch_mr),
     thrust::make_counting_iterator<cudf::size_type>(0),
     thrust::make_counting_iterator<cudf::size_type>(num_rows),
     struct_valid.data(),

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -159,14 +159,16 @@ struct enum_string_lookup_tables {
 enum_string_lookup_tables make_enum_string_lookup_tables(
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   auto d_valid_enums = cudf::detail::make_device_uvector_async(
     valid_enums, stream, cudf::get_current_device_resource_ref());
 
-  auto h_name_offsets =
-    cudf::detail::make_pinned_vector_async<int32_t>(valid_enums.size() + 1, stream);
+  auto& h_name_offsets = keep_pinned_staging(
+    cudf::detail::make_pinned_vector_async<int32_t>(valid_enums.size() + 1, stream),
+    pinned_staging_buffers);
   h_name_offsets[0]        = 0;
   int64_t total_name_chars = 0;
   for (size_t k = 0; k < enum_name_bytes.size(); ++k) {
@@ -176,8 +178,10 @@ enum_string_lookup_tables make_enum_string_lookup_tables(
     h_name_offsets[k + 1] = static_cast<int32_t>(total_name_chars);
   }
 
-  auto h_name_chars = cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream);
-  int32_t cursor    = 0;
+  auto& h_name_chars = keep_pinned_staging(
+    cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream),
+    pinned_staging_buffers);
+  int32_t cursor = 0;
   for (auto const& name : enum_name_bytes) {
     if (!name.empty()) {
       std::copy(name.data(), name.data() + name.size(), h_name_chars.data() + cursor);
@@ -244,6 +248,7 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   rmm::device_uvector<bool>& valid,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   int num_rows,
   rmm::cuda_stream_view stream,
@@ -251,7 +256,8 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   int32_t const* top_row_indices,
   bool propagate_invalid_rows)
 {
-  auto lookup           = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+  auto lookup = make_enum_string_lookup_tables(
+    valid_enums, enum_name_bytes, pinned_staging_buffers, stream, mr);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
   rmm::device_uvector<bool> d_item_has_invalid_enum(num_rows, stream, scratch_mr);
   thrust::fill(rmm::exec_policy_nosync(stream, scratch_mr),
@@ -286,6 +292,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   int num_rows,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -294,7 +301,8 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   auto const rep_blocks =
     static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
-  auto const lookup     = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+  auto const lookup = make_enum_string_lookup_tables(
+    valid_enums, enum_name_bytes, pinned_staging_buffers, stream, mr);
 
   // 1. Extract enum integer values from occurrences
   rmm::device_uvector<int32_t> enum_ints(total_count, stream, scratch_mr);
@@ -469,6 +477,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
   schema_context_view ctx,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,
@@ -498,8 +507,9 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   int num_child_fields = static_cast<int>(child_field_indices.size());
 
   // Stage child field descriptors through pinned memory so the H2D stays stream-async.
-  auto h_child_field_descs =
-    cudf::detail::make_pinned_vector_async<field_descriptor>(num_child_fields, stream);
+  auto& h_child_field_descs = keep_pinned_staging(
+    cudf::detail::make_pinned_vector_async<field_descriptor>(num_child_fields, stream),
+    pinned_staging_buffers);
   for (int i = 0; i < num_child_fields; i++) {
     int child_idx                             = child_field_indices[i];
     h_child_field_descs[i].field_number       = schema[child_idx].field_number;
@@ -547,6 +557,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                               d_row_force_null.size() > 0 ? d_row_force_null.data() : nullptr,
                               top_row_indices,
                               d_error.data(),
+                              pinned_staging_buffers,
                               stream);
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
@@ -632,6 +643,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                        valid,
                                        ctx.enum_valid_values[child_schema_idx],
                                        ctx.enum_names[child_schema_idx],
+                                       pinned_staging_buffers,
                                        d_row_force_null,
                                        num_rows,
                                        stream,
@@ -744,6 +756,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                                              schema,
                                                              num_fields,
                                                              ctx,
+                                                             pinned_staging_buffers,
                                                              d_row_force_null,
                                                              d_error,
                                                              num_rows,

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -21,6 +21,7 @@
 #include <cudf/strings/detail/strings_column_factories.cuh>
 
 #include <algorithm>
+#include <string>
 
 namespace spark_rapids_jni::protobuf::detail {
 
@@ -250,7 +251,7 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
   int32_t const* top_row_indices,
-  bool propagate_invalid_rows)
+  bool propagate_invalid_enum_rows)
 {
   auto lookup           = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
@@ -271,7 +272,7 @@ std::unique_ptr<cudf::column> build_enum_string_column(
                                        d_row_force_null,
                                        num_rows,
                                        top_row_indices,
-                                       propagate_invalid_rows,
+                                       propagate_invalid_enum_rows,
                                        stream);
   return build_enum_string_values_column(enum_values, valid, lookup, num_rows, stream, mr);
 }
@@ -477,7 +478,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   rmm::device_async_resource_ref mr,
   int32_t const* top_row_indices,
   int depth,
-  bool propagate_invalid_rows)
+  bool propagate_invalid_enum_rows)
 {
   CUDF_EXPECTS(depth < MAX_NESTING_DEPTH,
                "Nested protobuf struct depth exceeds supported decode recursion limit");
@@ -566,6 +567,16 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
       continue;
     }
 
+    nested_location_provider loc_provider{list_offsets,
+                                          base_offset,
+                                          d_parent_locs.data(),
+                                          d_child_locations.data(),
+                                          ci,
+                                          num_child_fields};
+    auto valid_fn = [loc_provider, has_def] __device__(cudf::size_type row) {
+      return has_def || loc_provider.valid(row);
+    };
+
     switch (dt.id()) {
       case cudf::type_id::BOOL8:
       case cudf::type_id::INT32:
@@ -574,91 +585,59 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
       case cudf::type_id::UINT64:
       case cudf::type_id::FLOAT32:
       case cudf::type_id::FLOAT64: {
-        nested_location_provider loc_provider{list_offsets,
-                                              base_offset,
-                                              d_parent_locs.data(),
-                                              d_child_locations.data(),
-                                              ci,
-                                              num_child_fields};
-        struct_children.push_back(
-          extract_typed_column(dt,
-                               enc,
-                               message_data,
-                               loc_provider,
-                               num_rows,
-                               blocks,
-                               threads,
-                               has_def,
-                               has_def ? ctx.default_ints[child_schema_idx] : 0,
-                               has_def ? ctx.default_floats[child_schema_idx] : 0.0,
-                               has_def ? ctx.default_bools[child_schema_idx] : false,
-                               ctx.default_strings[child_schema_idx],
-                               child_schema_idx,
-                               ctx.enum_valid_values,
-                               ctx.enum_names,
-                               d_row_force_null,
-                               d_error,
-                               stream,
-                               mr,
-                               top_row_indices,
-                               propagate_invalid_rows));
+        struct_children.push_back(extract_typed_column(dt,
+                                                       enc,
+                                                       message_data,
+                                                       loc_provider,
+                                                       num_rows,
+                                                       blocks,
+                                                       threads,
+                                                       has_def,
+                                                       ctx.default_ints[child_schema_idx],
+                                                       ctx.default_floats[child_schema_idx],
+                                                       ctx.default_bools[child_schema_idx],
+                                                       ctx.default_strings[child_schema_idx],
+                                                       child_schema_idx,
+                                                       ctx.enum_valid_values,
+                                                       ctx.enum_names,
+                                                       d_row_force_null,
+                                                       d_error,
+                                                       stream,
+                                                       mr,
+                                                       top_row_indices,
+                                                       propagate_invalid_enum_rows));
         break;
       }
-      case cudf::type_id::STRING: {
-        nested_location_provider loc_provider{list_offsets,
-                                              base_offset,
-                                              d_parent_locs.data(),
-                                              d_child_locations.data(),
-                                              ci,
-                                              num_child_fields};
-        if (enc == encoding_value(proto_encoding::ENUM_STRING)) {
+      case cudf::type_id::STRING:
+      case cudf::type_id::LIST: {  // bytes represented as LIST<UINT8>
+        bool const is_enum_string =
+          dt.id() == cudf::type_id::STRING && enc == encoding_value(proto_encoding::ENUM_STRING);
+        if (is_enum_string) {
           rmm::device_uvector<int32_t> out(num_rows, stream, mr);
-          rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
+          rmm::device_uvector<bool> valid(num_rows, stream, mr);
           extract_varint_kernel<int32_t, false, nested_location_provider>
-            <<<blocks, threads, 0, stream.value()>>>(
-              message_data,
-              loc_provider,
-              num_rows,
-              out.data(),
-              valid.data(),
-              d_error.data(),
-              has_def,
-              has_def ? ctx.default_ints[child_schema_idx] : 0);
-          if (child_schema_idx < static_cast<int>(ctx.enum_valid_values.size()) &&
-              child_schema_idx < static_cast<int>(ctx.enum_names.size()) &&
-              !ctx.enum_valid_values[child_schema_idx].empty() &&
-              ctx.enum_valid_values[child_schema_idx].size() ==
-                ctx.enum_names[child_schema_idx].size()) {
-            struct_children.push_back(
-              build_enum_string_column(out,
-                                       valid,
-                                       ctx.enum_valid_values[child_schema_idx],
-                                       ctx.enum_names[child_schema_idx],
-                                       d_row_force_null,
-                                       num_rows,
-                                       stream,
-                                       mr,
-                                       top_row_indices,
-                                       propagate_invalid_rows));
-          } else {
-            set_error_once_async(d_error.data(), ERR_MISSING_ENUM_META, stream);
-            struct_children.push_back(make_null_column(dt, num_rows, stream, mr));
-          }
-        } else {
-          auto valid_fn = [plocs = d_parent_locs.data(),
-                           flocs = d_child_locations.data(),
-                           ci,
-                           num_child_fields,
-                           has_def] __device__(cudf::size_type row) {
-            return (plocs[row].offset >= 0 &&
-                    flocs[flat_index(static_cast<size_t>(row),
-                                     static_cast<size_t>(num_child_fields),
-                                     static_cast<size_t>(ci))]
-                        .offset >= 0) ||
-                   has_def;
-          };
+            <<<blocks, threads, 0, stream.value()>>>(message_data,
+                                                     loc_provider,
+                                                     num_rows,
+                                                     out.data(),
+                                                     valid.data(),
+                                                     d_error.data(),
+                                                     has_def,
+                                                     ctx.default_ints[child_schema_idx]);
           struct_children.push_back(
-            extract_and_build_string_or_bytes_column(false,
+            build_enum_string_column(out,
+                                     valid,
+                                     ctx.enum_valid_values[child_schema_idx],
+                                     ctx.enum_names[child_schema_idx],
+                                     d_row_force_null,
+                                     num_rows,
+                                     stream,
+                                     mr,
+                                     top_row_indices,
+                                     propagate_invalid_enum_rows));
+        } else {
+          struct_children.push_back(
+            extract_and_build_string_or_bytes_column(dt.id() == cudf::type_id::LIST,
                                                      message_data,
                                                      num_rows,
                                                      loc_provider,
@@ -672,62 +651,9 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
         }
         break;
       }
-      case cudf::type_id::LIST: {  // bytes represented as LIST<UINT8>
-        nested_location_provider loc_provider{list_offsets,
-                                              base_offset,
-                                              d_parent_locs.data(),
-                                              d_child_locations.data(),
-                                              ci,
-                                              num_child_fields};
-        auto valid_fn = [plocs = d_parent_locs.data(),
-                         flocs = d_child_locations.data(),
-                         ci,
-                         num_child_fields,
-                         has_def] __device__(cudf::size_type row) {
-          return (plocs[row].offset >= 0 && flocs[flat_index(static_cast<size_t>(row),
-                                                             static_cast<size_t>(num_child_fields),
-                                                             static_cast<size_t>(ci))]
-                                                .offset >= 0) ||
-                 has_def;
-        };
-        struct_children.push_back(
-          extract_and_build_string_or_bytes_column(true,
-                                                   message_data,
-                                                   num_rows,
-                                                   loc_provider,
-                                                   loc_provider,
-                                                   valid_fn,
-                                                   has_def,
-                                                   ctx.default_strings[child_schema_idx],
-                                                   d_error,
-                                                   stream,
-                                                   mr));
-        break;
-      }
       case cudf::type_id::STRUCT: {
+        // Recursive linear child lookup is fine for realistic schemas; precompute if it gets hot.
         auto gc_indices = find_child_field_indices(schema, num_fields, child_schema_idx);
-        if (gc_indices.empty()) {
-          rmm::device_uvector<bool> child_valid(num_rows, stream, scratch_mr);
-          thrust::transform(rmm::exec_policy_nosync(stream, scratch_mr),
-                            thrust::make_counting_iterator<cudf::size_type>(0),
-                            thrust::make_counting_iterator<cudf::size_type>(num_rows),
-                            child_valid.data(),
-                            [plocs = d_parent_locs.data(),
-                             flocs = d_child_locations.data(),
-                             ci,
-                             num_child_fields] __device__(cudf::size_type row) {
-                              return plocs[row].offset >= 0 &&
-                                     flocs[flat_index(static_cast<size_t>(row),
-                                                      static_cast<size_t>(num_child_fields),
-                                                      static_cast<size_t>(ci))]
-                                         .offset >= 0;
-                            });
-          auto [mask, null_count] = make_null_mask_from_valid(child_valid, num_rows, stream, mr);
-          struct_children.push_back(
-            cudf::make_structs_column(num_rows, {}, null_count, std::move(mask), stream, mr));
-          break;
-        }
-
         rmm::device_uvector<field_location> d_gc_parent_locs(num_rows, stream, scratch_mr);
         launch_compute_grandchild_parent_locations(d_parent_locs.data(),
                                                    d_child_locations.data(),
@@ -753,13 +679,14 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                                              mr,
                                                              top_row_indices,
                                                              depth + 1,
-                                                             propagate_invalid_rows));
+                                                             propagate_invalid_enum_rows));
         break;
       }
       default:
         // List the supported/deferred types above explicitly so a newly-introduced output type
         // fails loudly here instead of silently decoding as all-null.
-        CUDF_FAIL("Protobuf decode: unsupported nested child output type");
+        CUDF_FAIL("Protobuf decode: unsupported nested child output type id=" +
+                  std::to_string(static_cast<int>(dt.id())));
     }
   }
 

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -251,7 +251,7 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   int32_t const* top_row_indices,
   bool propagate_invalid_rows)
 {
-  auto lookup = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
+  auto lookup           = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
   rmm::device_uvector<bool> d_item_has_invalid_enum(num_rows, stream, scratch_mr);
   thrust::fill(rmm::exec_policy_nosync(stream, scratch_mr),
@@ -613,15 +613,15 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
           rmm::device_uvector<int32_t> out(num_rows, stream, mr);
           rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
           extract_varint_kernel<int32_t, false, nested_location_provider>
-            <<<blocks, threads, 0, stream.value()>>>(message_data,
-                                                     loc_provider,
-                                                     num_rows,
-                                                     out.data(),
-                                                     valid.data(),
-                                                     d_error.data(),
-                                                     has_def,
-                                                     has_def ? ctx.default_ints[child_schema_idx]
-                                                             : 0);
+            <<<blocks, threads, 0, stream.value()>>>(
+              message_data,
+              loc_provider,
+              num_rows,
+              out.data(),
+              valid.data(),
+              d_error.data(),
+              has_def,
+              has_def ? ctx.default_ints[child_schema_idx] : 0);
           if (child_schema_idx < static_cast<int>(ctx.enum_valid_values.size()) &&
               child_schema_idx < static_cast<int>(ctx.enum_names.size()) &&
               !ctx.enum_valid_values[child_schema_idx].empty() &&

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -159,16 +159,15 @@ struct enum_string_lookup_tables {
 enum_string_lookup_tables make_enum_string_lookup_tables(
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   auto d_valid_enums = cudf::detail::make_device_uvector_async(
     valid_enums, stream, cudf::get_current_device_resource_ref());
 
-  auto& h_name_offsets = keep_pinned_staging(
-    cudf::detail::make_pinned_vector_async<int32_t>(valid_enums.size() + 1, stream),
-    pinned_staging_buffers);
+  // Stream-ordered pinned deallocation keeps these staging buffers safe without a local sync.
+  auto h_name_offsets =
+    cudf::detail::make_pinned_vector_async<int32_t>(valid_enums.size() + 1, stream);
   h_name_offsets[0]        = 0;
   int64_t total_name_chars = 0;
   for (size_t k = 0; k < enum_name_bytes.size(); ++k) {
@@ -178,10 +177,8 @@ enum_string_lookup_tables make_enum_string_lookup_tables(
     h_name_offsets[k + 1] = static_cast<int32_t>(total_name_chars);
   }
 
-  auto& h_name_chars =
-    keep_pinned_staging(cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream),
-                        pinned_staging_buffers);
-  int32_t cursor = 0;
+  auto h_name_chars = cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream);
+  int32_t cursor    = 0;
   for (auto const& name : enum_name_bytes) {
     if (!name.empty()) {
       std::copy(name.data(), name.data() + name.size(), h_name_chars.data() + cursor);
@@ -248,7 +245,6 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   rmm::device_uvector<bool>& valid,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   int num_rows,
   rmm::cuda_stream_view stream,
@@ -256,8 +252,7 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   int32_t const* top_row_indices,
   bool propagate_invalid_rows)
 {
-  auto lookup = make_enum_string_lookup_tables(
-    valid_enums, enum_name_bytes, pinned_staging_buffers, stream, mr);
+  auto lookup           = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
   rmm::device_uvector<bool> d_item_has_invalid_enum(num_rows, stream, scratch_mr);
   thrust::fill(rmm::exec_policy_nosync(stream, scratch_mr),
@@ -292,7 +287,6 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   int num_rows,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -301,8 +295,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   auto const rep_blocks =
     static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
-  auto const lookup     = make_enum_string_lookup_tables(
-    valid_enums, enum_name_bytes, pinned_staging_buffers, stream, mr);
+  auto const lookup     = make_enum_string_lookup_tables(valid_enums, enum_name_bytes, stream, mr);
 
   // 1. Extract enum integer values from occurrences
   rmm::device_uvector<int32_t> enum_ints(total_count, stream, scratch_mr);
@@ -477,7 +470,6 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
   schema_context_view ctx,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,
@@ -507,9 +499,9 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   int num_child_fields = static_cast<int>(child_field_indices.size());
 
   // Stage child field descriptors through pinned memory so the H2D stays stream-async.
-  auto& h_child_field_descs = keep_pinned_staging(
-    cudf::detail::make_pinned_vector_async<field_descriptor>(num_child_fields, stream),
-    pinned_staging_buffers);
+  // Stream-ordered pinned deallocation keeps this staging safe without a local sync.
+  auto h_child_field_descs =
+    cudf::detail::make_pinned_vector_async<field_descriptor>(num_child_fields, stream);
   for (int i = 0; i < num_child_fields; i++) {
     int child_idx                             = child_field_indices[i];
     h_child_field_descs[i].field_number       = schema[child_idx].field_number;
@@ -557,7 +549,6 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                               d_row_force_null.size() > 0 ? d_row_force_null.data() : nullptr,
                               top_row_indices,
                               d_error.data(),
-                              pinned_staging_buffers,
                               stream);
 
   std::vector<std::unique_ptr<cudf::column>> struct_children;
@@ -643,7 +634,6 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                        valid,
                                        ctx.enum_valid_values[child_schema_idx],
                                        ctx.enum_names[child_schema_idx],
-                                       pinned_staging_buffers,
                                        d_row_force_null,
                                        num_rows,
                                        stream,
@@ -756,7 +746,6 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                                              schema,
                                                              num_fields,
                                                              ctx,
-                                                             pinned_staging_buffers,
                                                              d_row_force_null,
                                                              d_error,
                                                              num_rows,

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -178,9 +178,9 @@ enum_string_lookup_tables make_enum_string_lookup_tables(
     h_name_offsets[k + 1] = static_cast<int32_t>(total_name_chars);
   }
 
-  auto& h_name_chars = keep_pinned_staging(
-    cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream),
-    pinned_staging_buffers);
+  auto& h_name_chars =
+    keep_pinned_staging(cudf::detail::make_pinned_vector_async<uint8_t>(total_name_chars, stream),
+                        pinned_staging_buffers);
   int32_t cursor = 0;
   for (auto const& name : enum_name_bytes) {
     if (!name.empty()) {
@@ -301,7 +301,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   auto const rep_blocks =
     static_cast<int>((total_count + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
   auto const scratch_mr = cudf::get_current_device_resource_ref();
-  auto const lookup = make_enum_string_lookup_tables(
+  auto const lookup     = make_enum_string_lookup_tables(
     valid_enums, enum_name_bytes, pinned_staging_buffers, stream, mr);
 
   // 1. Extract enum integer values from occurrences

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -289,7 +289,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -368,7 +368,7 @@ std::unique_ptr<cudf::column> build_repeated_string_column(
   int total_count,
   int num_rows,
   bool is_bytes,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -472,7 +472,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   int num_fields,
   schema_context_view ctx,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   int num_rows,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -705,8 +705,24 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
       case cudf::type_id::STRUCT: {
         auto gc_indices = find_child_field_indices(schema, num_fields, child_schema_idx);
         if (gc_indices.empty()) {
-          struct_children.push_back(make_null_column_with_schema(
-            schema, child_schema_idx, num_fields, num_rows, stream, mr));
+          rmm::device_uvector<bool> child_valid(num_rows, stream, scratch_mr);
+          thrust::transform(rmm::exec_policy_nosync(stream, scratch_mr),
+                            thrust::make_counting_iterator<cudf::size_type>(0),
+                            thrust::make_counting_iterator<cudf::size_type>(num_rows),
+                            child_valid.data(),
+                            [plocs = d_parent_locs.data(),
+                             flocs = d_child_locations.data(),
+                             ci,
+                             num_child_fields] __device__(cudf::size_type row) {
+                              return plocs[row].offset >= 0 &&
+                                     flocs[flat_index(static_cast<size_t>(row),
+                                                      static_cast<size_t>(num_child_fields),
+                                                      static_cast<size_t>(ci))]
+                                         .offset >= 0;
+                            });
+          auto [mask, null_count] = make_null_mask_from_valid(child_valid, num_rows, stream, mr);
+          struct_children.push_back(
+            cudf::make_structs_column(num_rows, {}, null_count, std::move(mask), stream, mr));
           break;
         }
 

--- a/src/main/cpp/src/protobuf/protobuf_builders.cu
+++ b/src/main/cpp/src/protobuf/protobuf_builders.cu
@@ -573,9 +573,6 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                           d_child_locations.data(),
                                           ci,
                                           num_child_fields};
-    auto valid_fn = [loc_provider, has_def] __device__(cudf::size_type row) {
-      return has_def || loc_provider.valid(row);
-    };
 
     switch (dt.id()) {
       case cudf::type_id::BOOL8:
@@ -636,6 +633,9 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
                                      top_row_indices,
                                      propagate_invalid_enum_rows));
         } else {
+          auto valid_fn = [loc_provider, has_def] __device__(cudf::size_type row) {
+            return has_def || loc_provider.valid(row);
+          };
           struct_children.push_back(
             extract_and_build_string_or_bytes_column(dt.id() == cudf::type_id::LIST,
                                                      message_data,

--- a/src/main/cpp/src/protobuf/protobuf_device_helpers.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_device_helpers.cuh
@@ -59,11 +59,11 @@ __device__ inline bool read_varint(uint8_t const* cur,
   return false;
 }
 
-__device__ inline void set_error_once(int* error_flag, int error_code)
+__device__ inline void set_error_once(int* error_flag, protobuf_error error)
 {
   int expected = 0;
   cuda::atomic_ref<int, cuda::thread_scope_device> ref(*error_flag);
-  ref.compare_exchange_strong(expected, error_code, cuda::memory_order_relaxed);
+  ref.compare_exchange_strong(expected, error_code(error), cuda::memory_order_relaxed);
 }
 
 // Store a decoded varint into an output slot. BOOL8 (uint8_t) follows protobuf's
@@ -78,7 +78,7 @@ __device__ __forceinline__ void write_varint_value(T* dst, uint64_t val)
   }
 }
 
-void set_error_once_async(int* error_flag, int error_code, rmm::cuda_stream_view stream);
+void set_error_once_async(int* error_flag, protobuf_error error, rmm::cuda_stream_view stream);
 
 __device__ inline int get_wire_type_size(int wt, uint8_t const* cur, uint8_t const* end)
 {
@@ -236,7 +236,7 @@ __device__ inline bool check_message_bounds(T start,
                                             int* error_flag)
 {
   if (start < 0 || end_pos < start || end_pos > total_size) {
-    set_error_once(error_flag, ERR_BOUNDS);
+    set_error_once(error_flag, protobuf_error::BOUNDS);
     return false;
   }
   return true;
@@ -255,14 +255,14 @@ __device__ inline bool decode_tag(uint8_t const*& cur,
   uint64_t key;
   int key_bytes;
   if (!read_varint(cur, end, key, key_bytes)) {
-    set_error_once(error_flag, ERR_VARINT);
+    set_error_once(error_flag, protobuf_error::VARINT);
     return false;
   }
 
   cur += key_bytes;
   uint64_t fn = key >> 3;
   if (fn == 0 || fn > static_cast<uint64_t>(MAX_FIELD_NUMBER)) {
-    set_error_once(error_flag, ERR_FIELD_NUMBER);
+    set_error_once(error_flag, protobuf_error::FIELD_NUMBER);
     return false;
   }
   tag.field_number = static_cast<int>(fn);

--- a/src/main/cpp/src/protobuf/protobuf_device_helpers.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_device_helpers.cuh
@@ -59,11 +59,11 @@ __device__ inline bool read_varint(uint8_t const* cur,
   return false;
 }
 
-__device__ inline void set_error_once(int* error_flag, protobuf_error error)
+__device__ inline void set_error_once(protobuf_error* error_flag, protobuf_error error)
 {
-  int expected = 0;
-  cuda::atomic_ref<int, cuda::thread_scope_device> ref(*error_flag);
-  ref.compare_exchange_strong(expected, error_code(error), cuda::memory_order_relaxed);
+  auto expected = protobuf_error::NONE;
+  cuda::atomic_ref<protobuf_error, cuda::thread_scope_device> ref(*error_flag);
+  ref.compare_exchange_strong(expected, error, cuda::memory_order_relaxed);
 }
 
 // Store a decoded varint into an output slot. BOOL8 (uint8_t) follows protobuf's
@@ -78,7 +78,9 @@ __device__ __forceinline__ void write_varint_value(T* dst, uint64_t val)
   }
 }
 
-void set_error_once_async(int* error_flag, protobuf_error error, rmm::cuda_stream_view stream);
+void set_error_once_async(protobuf_error* error_flag,
+                          protobuf_error error,
+                          rmm::cuda_stream_view stream);
 
 __device__ inline int get_wire_type_size(int wt, uint8_t const* cur, uint8_t const* end)
 {
@@ -233,7 +235,7 @@ template <std::integral T = int32_t>
 __device__ inline bool check_message_bounds(T start,
                                             T end_pos,
                                             cudf::size_type total_size,
-                                            int* error_flag)
+                                            protobuf_error* error_flag)
 {
   if (start < 0 || end_pos < start || end_pos > total_size) {
     set_error_once(error_flag, protobuf_error::BOUNDS);
@@ -250,7 +252,7 @@ struct proto_tag {
 __device__ inline bool decode_tag(uint8_t const*& cur,
                                   uint8_t const* end,
                                   proto_tag& tag,
-                                  int* error_flag)
+                                  protobuf_error* error_flag)
 {
   uint64_t key;
   int key_bytes;

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -62,12 +62,12 @@ struct schema_context_view {
  * Build a host-side direct-mapped lookup table: field_number -> index.
  * @param get_field_number Callable: (int i) -> field_number for the i-th entry.
  * @param num_entries Number of entries.
- * @return Empty pinned vector if the max field number exceeds the threshold.
+ * @return Empty vector if the max field number exceeds the threshold.
  */
 template <typename FieldNumberFn>
-inline cudf::detail::host_vector<int> build_pinned_lookup_table(FieldNumberFn get_field_number,
-                                                                int num_entries,
-                                                                rmm::cuda_stream_view stream)
+inline cudf::detail::host_vector<int> build_lookup_table(FieldNumberFn get_field_number,
+                                                         int num_entries,
+                                                         rmm::cuda_stream_view stream)
 {
   int max_fn = 0;
   for (int i = 0; i < num_entries; i++) {
@@ -84,22 +84,22 @@ inline cudf::detail::host_vector<int> build_pinned_lookup_table(FieldNumberFn ge
   return table;
 }
 
-inline cudf::detail::host_vector<int> build_pinned_index_lookup_table(
+inline cudf::detail::host_vector<int> build_index_lookup_table(
   nested_field_descriptor const* schema,
   int const* field_indices,
   int num_indices,
   rmm::cuda_stream_view stream)
 {
-  return build_pinned_lookup_table(
+  return build_lookup_table(
     [&](int i) { return schema[field_indices[i]].field_number; }, num_indices, stream);
 }
 
-inline cudf::detail::host_vector<int> build_pinned_field_lookup_table(field_descriptor const* descs,
-                                                                      int num_fields,
-                                                                      rmm::cuda_stream_view stream)
+template <typename FieldDesc>
+inline cudf::detail::host_vector<int> build_field_lookup_table(FieldDesc const* descs,
+                                                               int num_fields,
+                                                               rmm::cuda_stream_view stream)
 {
-  return build_pinned_lookup_table(
-    [&](int i) { return descs[i].field_number; }, num_fields, stream);
+  return build_lookup_table([&](int i) { return descs[i].field_number; }, num_fields, stream);
 }
 
 /**

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -207,7 +207,7 @@ void maybe_check_required_fields(field_location const* locations,
                                  field_location const* parent_locs,
                                  bool* row_force_null,
                                  int32_t const* top_row_indices,
-                                 int* error_flag,
+                                 protobuf_error* error_flag,
                                  rmm::cuda_stream_view stream);
 
 void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_invalid,
@@ -289,7 +289,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 
@@ -303,7 +303,7 @@ std::unique_ptr<cudf::column> build_repeated_string_column(
   int total_count,
   int num_rows,
   bool is_bytes,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 
@@ -318,7 +318,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   int num_fields,
   schema_context_view ctx,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   int num_rows,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
@@ -338,7 +338,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
   int num_fields,
   schema_context_view ctx,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
   int32_t const* top_row_indices,
@@ -360,7 +360,7 @@ std::unique_ptr<cudf::column> build_repeated_struct_column(
   std::vector<nested_field_descriptor> const& schema,
   schema_context_view ctx,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error_top,
+  rmm::device_uvector<protobuf_error>& d_error_top,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -21,6 +21,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/utilities/host_vector.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -61,34 +62,44 @@ struct schema_context_view {
  * Build a host-side direct-mapped lookup table: field_number -> index.
  * @param get_field_number Callable: (int i) -> field_number for the i-th entry.
  * @param num_entries Number of entries.
- * @return Empty vector if the max field number exceeds the threshold.
+ * @return Empty pinned vector if the max field number exceeds the threshold.
  */
 template <typename FieldNumberFn>
-inline std::vector<int> build_lookup_table(FieldNumberFn get_field_number, int num_entries)
+inline cudf::detail::host_vector<int> build_pinned_lookup_table(FieldNumberFn get_field_number,
+                                                                int num_entries,
+                                                                rmm::cuda_stream_view stream)
 {
   int max_fn = 0;
   for (int i = 0; i < num_entries; i++) {
     max_fn = std::max(max_fn, get_field_number(i));
   }
-  if (max_fn > FIELD_LOOKUP_TABLE_MAX) { return {}; }
-  std::vector<int> table(max_fn + 1, -1);
+  if (max_fn > FIELD_LOOKUP_TABLE_MAX) {
+    return cudf::detail::make_pinned_vector_async<int>(0, stream);
+  }
+  auto table = cudf::detail::make_pinned_vector_async<int>(max_fn + 1, stream);
+  std::fill(table.begin(), table.end(), -1);
   for (int i = 0; i < num_entries; i++) {
     table[get_field_number(i)] = i;
   }
   return table;
 }
 
-inline std::vector<int> build_index_lookup_table(nested_field_descriptor const* schema,
-                                                 int const* field_indices,
-                                                 int num_indices)
+inline cudf::detail::host_vector<int> build_pinned_index_lookup_table(
+  nested_field_descriptor const* schema,
+  int const* field_indices,
+  int num_indices,
+  rmm::cuda_stream_view stream)
 {
-  return build_lookup_table([&](int i) { return schema[field_indices[i]].field_number; },
-                            num_indices);
+  return build_pinned_lookup_table(
+    [&](int i) { return schema[field_indices[i]].field_number; }, num_indices, stream);
 }
 
-inline std::vector<int> build_field_lookup_table(field_descriptor const* descs, int num_fields)
+inline cudf::detail::host_vector<int> build_pinned_field_lookup_table(field_descriptor const* descs,
+                                                                      int num_fields,
+                                                                      rmm::cuda_stream_view stream)
 {
-  return build_lookup_table([&](int i) { return descs[i].field_number; }, num_fields);
+  return build_pinned_lookup_table(
+    [&](int i) { return descs[i].field_number; }, num_fields, stream);
 }
 
 /**
@@ -250,8 +261,8 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   int num_rows,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  int32_t const* top_row_indices = nullptr,
-  bool propagate_invalid_rows    = true);
+  int32_t const* top_row_indices   = nullptr,
+  bool propagate_invalid_enum_rows = true);
 
 // Wrap offsets + child into a LIST column, propagating the input's null mask. Note: when
 // `binary_input` has no nulls, `mr` is effectively unused — only the with-nulls path
@@ -313,7 +324,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   rmm::device_async_resource_ref mr,
   int32_t const* top_row_indices,
   int depth,
-  bool propagate_invalid_rows = true);
+  bool propagate_invalid_enum_rows = true);
 
 std::unique_ptr<cudf::column> build_repeated_child_list_column(
   uint8_t const* message_data,
@@ -332,7 +343,7 @@ std::unique_ptr<cudf::column> build_repeated_child_list_column(
   rmm::device_async_resource_ref mr,
   int32_t const* top_row_indices,
   int depth,
-  bool propagate_invalid_rows = true);
+  bool propagate_invalid_enum_rows = true);
 
 std::unique_ptr<cudf::column> build_repeated_struct_column(
   cudf::column_view const& binary_input,

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -21,6 +21,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/utilities/host_vector.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -30,9 +31,46 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace spark_rapids_jni::protobuf::detail {
+
+// Pinned host buffers used as async-copy sources must outlive the stream work that reads them.
+struct pinned_staging_buffer {
+  virtual ~pinned_staging_buffer() = default;
+};
+
+template <typename T>
+struct typed_pinned_staging_buffer : pinned_staging_buffer {
+  cudf::detail::host_vector<T> data;
+
+  explicit typed_pinned_staging_buffer(cudf::detail::host_vector<T>&& data) : data(std::move(data))
+  {
+  }
+};
+
+using pinned_staging_buffer_store = std::vector<std::unique_ptr<pinned_staging_buffer>>;
+
+template <typename T>
+cudf::detail::host_vector<T>& keep_pinned_staging(cudf::detail::host_vector<T>&& staging,
+                                                  pinned_staging_buffer_store& store)
+{
+  auto holder = std::make_unique<typed_pinned_staging_buffer<T>>(std::move(staging));
+  auto& data  = holder->data;
+  store.push_back(std::move(holder));
+  return data;
+}
+
+template <typename T>
+cudf::detail::host_vector<T>& make_pinned_staging_copy(std::vector<T> const& source,
+                                                       rmm::cuda_stream_view stream,
+                                                       pinned_staging_buffer_store& store)
+{
+  auto staging = cudf::detail::make_pinned_vector_async<T>(source.size(), stream);
+  std::copy(source.begin(), source.end(), staging.begin());
+  return keep_pinned_staging(std::move(staging), store);
+}
 
 // ============================================================================
 // Schema-context bundle
@@ -197,6 +235,7 @@ void maybe_check_required_fields(field_location const* locations,
                                  bool* row_force_null,
                                  int32_t const* top_row_indices,
                                  int* error_flag,
+                                 pinned_staging_buffer_store& pinned_staging_buffers,
                                  rmm::cuda_stream_view stream);
 
 void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_invalid,
@@ -246,6 +285,7 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   rmm::device_uvector<bool>& valid,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   int num_rows,
   rmm::cuda_stream_view stream,
@@ -277,6 +317,7 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   int num_rows,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -306,6 +347,7 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
   schema_context_view ctx,
+  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,

--- a/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
+++ b/src/main/cpp/src/protobuf/protobuf_host_helpers.hpp
@@ -21,7 +21,6 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/utilities/host_vector.hpp>
-#include <cudf/detail/utilities/vector_factories.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -31,46 +30,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <utility>
 #include <vector>
 
 namespace spark_rapids_jni::protobuf::detail {
-
-// Pinned host buffers used as async-copy sources must outlive the stream work that reads them.
-struct pinned_staging_buffer {
-  virtual ~pinned_staging_buffer() = default;
-};
-
-template <typename T>
-struct typed_pinned_staging_buffer : pinned_staging_buffer {
-  cudf::detail::host_vector<T> data;
-
-  explicit typed_pinned_staging_buffer(cudf::detail::host_vector<T>&& data) : data(std::move(data))
-  {
-  }
-};
-
-using pinned_staging_buffer_store = std::vector<std::unique_ptr<pinned_staging_buffer>>;
-
-template <typename T>
-cudf::detail::host_vector<T>& keep_pinned_staging(cudf::detail::host_vector<T>&& staging,
-                                                  pinned_staging_buffer_store& store)
-{
-  auto holder = std::make_unique<typed_pinned_staging_buffer<T>>(std::move(staging));
-  auto& data  = holder->data;
-  store.push_back(std::move(holder));
-  return data;
-}
-
-template <typename T>
-cudf::detail::host_vector<T>& make_pinned_staging_copy(std::vector<T> const& source,
-                                                       rmm::cuda_stream_view stream,
-                                                       pinned_staging_buffer_store& store)
-{
-  auto staging = cudf::detail::make_pinned_vector_async<T>(source.size(), stream);
-  std::copy(source.begin(), source.end(), staging.begin());
-  return keep_pinned_staging(std::move(staging), store);
-}
 
 // ============================================================================
 // Schema-context bundle
@@ -235,7 +197,6 @@ void maybe_check_required_fields(field_location const* locations,
                                  bool* row_force_null,
                                  int32_t const* top_row_indices,
                                  int* error_flag,
-                                 pinned_staging_buffer_store& pinned_staging_buffers,
                                  rmm::cuda_stream_view stream);
 
 void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_invalid,
@@ -285,7 +246,6 @@ std::unique_ptr<cudf::column> build_enum_string_column(
   rmm::device_uvector<bool>& valid,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   int num_rows,
   rmm::cuda_stream_view stream,
@@ -317,7 +277,6 @@ std::unique_ptr<cudf::column> build_repeated_enum_string_column(
   int num_rows,
   cudf::detail::host_vector<int32_t> const& valid_enums,
   std::vector<cudf::detail::host_vector<uint8_t>> const& enum_name_bytes,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
@@ -347,7 +306,6 @@ std::unique_ptr<cudf::column> build_nested_struct_column(
   std::vector<nested_field_descriptor> const& schema,
   int num_fields,
   schema_context_view ctx,
-  pinned_staging_buffer_store& pinned_staging_buffers,
   rmm::device_uvector<bool>& d_row_force_null,
   rmm::device_uvector<int>& d_error,
   int num_rows,

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -1006,7 +1006,7 @@ void maybe_check_required_fields(field_location const* locations,
 {
   if (num_rows == 0 || field_indices.empty()) { return; }
 
-  bool has_required = false;
+  bool has_required   = false;
   auto& h_is_required = keep_pinned_staging(
     cudf::detail::make_pinned_vector_async<uint8_t>(field_indices.size(), stream),
     pinned_staging_buffers);

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -612,8 +612,7 @@ CUDF_KERNEL void compute_grandchild_parent_locations_kernel(field_location const
   }
 
   auto const abs_offset = static_cast<int64_t>(parent_loc.offset) + child_loc.offset;
-  if (abs_offset < cuda::std::numeric_limits<int32_t>::min() ||
-      abs_offset > cuda::std::numeric_limits<int32_t>::max()) {
+  if (abs_offset > cuda::std::numeric_limits<int32_t>::max()) {
     gc_parent_locs[row] = {-1, 0};
     set_error_once(error_flag, ERR_OVERFLOW);
     return;

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -1001,15 +1001,14 @@ void maybe_check_required_fields(field_location const* locations,
                                  bool* row_force_null,
                                  int32_t const* top_row_indices,
                                  int* error_flag,
-                                 pinned_staging_buffer_store& pinned_staging_buffers,
                                  rmm::cuda_stream_view stream)
 {
   if (num_rows == 0 || field_indices.empty()) { return; }
 
-  bool has_required   = false;
-  auto& h_is_required = keep_pinned_staging(
-    cudf::detail::make_pinned_vector_async<uint8_t>(field_indices.size(), stream),
-    pinned_staging_buffers);
+  // Stream-ordered pinned deallocation keeps this staging safe without a local sync.
+  bool has_required = false;
+  auto h_is_required =
+    cudf::detail::make_pinned_vector_async<uint8_t>(field_indices.size(), stream);
   for (size_t i = 0; i < field_indices.size(); ++i) {
     h_is_required[i] = schema[field_indices[i]].is_required ? 1 : 0;
     has_required |= (h_is_required[i] != 0);

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -38,7 +38,7 @@ namespace {
 // Pass 1: Scan all fields kernel - records (offset, length) for each field
 // ============================================================================
 
-CUDF_KERNEL void set_error_if_unset_kernel(int* error_flag, protobuf_error error)
+CUDF_KERNEL void set_error_if_unset_kernel(protobuf_error* error_flag, protobuf_error error)
 {
   if (blockIdx.x == 0 && threadIdx.x == 0) { set_error_once(error_flag, error); }
 }
@@ -67,7 +67,7 @@ CUDF_KERNEL void set_error_if_unset_kernel(int* error_flag, protobuf_error error
 __device__ bool scan_message_field_locations(uint8_t const* msg_base,
                                              uint8_t const* msg_end,
                                              field_location* out,
-                                             int* error_flag,
+                                             protobuf_error* error_flag,
                                              auto&& lookup_desc_idx,
                                              auto&& is_repeated_field,
                                              auto&& get_expected_wire_type,
@@ -141,7 +141,7 @@ CUDF_KERNEL void scan_all_fields_kernel(
   int const* field_lookup,    // direct-mapped lookup table (nullable)
   int field_lookup_size,      // size of lookup table (0 if null)
   field_location* locations,  // [num_rows * num_fields] row-major
-  int* error_flag,
+  protobuf_error* error_flag,
   bool* row_has_invalid_data)
 {
   auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -215,7 +215,7 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
                                       uint8_t const* msg_base,
                                       int wt,
                                       int expected_wt,
-                                      int* error_flag,
+                                      protobuf_error* error_flag,
                                       F&& f)
 {
   bool is_packed = (wt == wire_type_value(proto_wire_type::LEN) &&
@@ -317,7 +317,7 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
                                               field_location* nested_locations,
                                               int num_nested_fields,
                                               int const* nested_field_indices,
-                                              int* error_flag,
+                                              protobuf_error* error_flag,
                                               int const* fn_to_rep_idx,
                                               int fn_to_rep_size,
                                               int const* fn_to_nested_idx,
@@ -434,7 +434,7 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
 CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view const d_in,
                                                       repeated_field_scan_desc const* scan_descs,
                                                       int num_scan_fields,
-                                                      int* error_flag,
+                                                      protobuf_error* error_flag,
                                                       int const* fn_to_desc_idx,
                                                       int fn_to_desc_size)
 {
@@ -531,7 +531,7 @@ CUDF_KERNEL void scan_nested_message_fields_kernel(uint8_t const* message_data,
                                                    field_descriptor const* field_descs,
                                                    int num_fields,
                                                    field_location* output_locations,
-                                                   int* error_flag,
+                                                   protobuf_error* error_flag,
                                                    bool* row_has_invalid_data,
                                                    int32_t const* top_row_indices)
 {
@@ -599,7 +599,7 @@ CUDF_KERNEL void compute_grandchild_parent_locations_kernel(field_location const
                                                             int num_child_fields,
                                                             field_location* gc_parent_locs,
                                                             int num_rows,
-                                                            int* error_flag)
+                                                            protobuf_error* error_flag)
 {
   int row = blockIdx.x * blockDim.x + threadIdx.x;
   if (row >= num_rows) return;
@@ -643,7 +643,7 @@ CUDF_KERNEL void check_required_fields_kernel(
   field_location const* parent_locs,          // [num_rows] optional parent presence for nested rows
   bool* row_force_null,            // [top_level_num_rows] optional permissive row nulling
   int32_t const* top_row_indices,  // [num_rows] optional nested-row -> top-row mapping
-  int* error_flag)
+  protobuf_error* error_flag)
 {
   auto row = static_cast<cudf::size_type>(blockIdx.x * blockDim.x + threadIdx.x);
   if (row >= num_rows) return;
@@ -784,7 +784,9 @@ CUDF_KERNEL void copy_enum_string_chars_kernel(
 // Host wrapper functions — callable from other translation units
 // ============================================================================
 
-void set_error_once_async(int* error_flag, protobuf_error error, rmm::cuda_stream_view stream)
+void set_error_once_async(protobuf_error* error_flag,
+                          protobuf_error error,
+                          rmm::cuda_stream_view stream)
 {
   set_error_if_unset_kernel<<<1, 1, 0, stream.value()>>>(error_flag, error);
   CUDF_CUDA_TRY(cudaPeekAtLastError());
@@ -796,7 +798,7 @@ void launch_scan_all_fields(cudf::column_device_view const& d_in,
                             int const* field_lookup,
                             int field_lookup_size,
                             field_location* locations,
-                            int* error_flag,
+                            protobuf_error* error_flag,
                             bool* row_has_invalid_data,
                             int num_rows,
                             rmm::cuda_stream_view stream)
@@ -823,7 +825,7 @@ void launch_count_repeated_fields(cudf::column_device_view const& d_in,
                                   field_location* nested_locations,
                                   int num_nested_fields,
                                   int const* nested_field_indices,
-                                  int* error_flag,
+                                  protobuf_error* error_flag,
                                   int const* fn_to_rep_idx,
                                   int fn_to_rep_size,
                                   int const* fn_to_nested_idx,
@@ -854,7 +856,7 @@ void launch_count_repeated_fields(cudf::column_device_view const& d_in,
 void launch_scan_all_repeated_occurrences(cudf::column_device_view const& d_in,
                                           repeated_field_scan_desc const* scan_descs,
                                           int num_scan_fields,
-                                          int* error_flag,
+                                          protobuf_error* error_flag,
                                           int const* fn_to_desc_idx,
                                           int fn_to_desc_size,
                                           int num_rows,
@@ -888,7 +890,7 @@ void launch_scan_nested_message_fields(uint8_t const* message_data,
                                        field_descriptor const* field_descs,
                                        int num_fields,
                                        field_location* output_locations,
-                                       int* error_flag,
+                                       protobuf_error* error_flag,
                                        bool* row_has_invalid_data,
                                        int32_t const* top_row_indices,
                                        rmm::cuda_stream_view stream)
@@ -917,7 +919,7 @@ void launch_compute_grandchild_parent_locations(field_location const* parent_loc
                                                 int num_child_fields,
                                                 field_location* gc_parent_locs,
                                                 int num_rows,
-                                                int* error_flag,
+                                                protobuf_error* error_flag,
                                                 rmm::cuda_stream_view stream)
 {
   if (num_rows == 0) return;
@@ -988,7 +990,7 @@ void maybe_check_required_fields(field_location const* locations,
                                  field_location const* parent_locs,
                                  bool* row_force_null,
                                  int32_t const* top_row_indices,
-                                 int* error_flag,
+                                 protobuf_error* error_flag,
                                  rmm::cuda_stream_view stream)
 {
   if (num_rows == 0 || field_indices.empty()) { return; }

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -519,7 +519,7 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
 
 /**
  * Scan one nested message per parent row to locate its direct singleton child fields.
- * Repeated children are intentionally left to a separate count/scan path (3b.5/3b.6);
+ * Repeated children are intentionally left to a separate count/scan path;
  * this kernel only records last-one-wins locations for non-repeated descendants.
  */
 CUDF_KERNEL void scan_nested_message_fields_kernel(uint8_t const* message_data,
@@ -574,8 +574,8 @@ CUDF_KERNEL void scan_nested_message_fields_kernel(uint8_t const* message_data,
   auto get_expected_wire_type = [&](int f) { return field_descs[f].expected_wire_type; };
   auto validate_repeated =
     [&](int f, uint8_t const* cur, uint8_t const* msg_end, uint8_t const* msg_base, int wt) {
-      // Values come from the dedicated nested repeated count/scan path (3b.5/3b.6); here we only
-      // validate the occurrence so strict/permissive errors surface.
+      // Values come from the dedicated nested repeated path; here we only validate the occurrence
+      // so strict/permissive errors surface.
       auto noop = []([[maybe_unused]] int32_t off, [[maybe_unused]] int32_t len) { return true; };
       return walk_repeated_element(
         cur, msg_end, msg_base, wt, get_expected_wire_type(f), error_flag, noop);
@@ -591,6 +591,35 @@ CUDF_KERNEL void scan_nested_message_fields_kernel(uint8_t const* message_data,
                                     validate_repeated)) {
     mark_row_error();
   }
+}
+
+CUDF_KERNEL void compute_grandchild_parent_locations_kernel(field_location const* parent_locs,
+                                                            field_location const* child_locs,
+                                                            int child_idx,
+                                                            int num_child_fields,
+                                                            field_location* gc_parent_locs,
+                                                            int num_rows,
+                                                            int* error_flag)
+{
+  int row = blockIdx.x * blockDim.x + threadIdx.x;
+  if (row >= num_rows) return;
+
+  auto const& parent_loc = parent_locs[row];
+  auto const& child_loc  = child_locs[flat_index(row, num_child_fields, child_idx)];
+  if (parent_loc.offset < 0 || child_loc.offset < 0) {
+    gc_parent_locs[row] = {-1, 0};
+    return;
+  }
+
+  auto const abs_offset = static_cast<int64_t>(parent_loc.offset) + child_loc.offset;
+  if (abs_offset < cuda::std::numeric_limits<int32_t>::min() ||
+      abs_offset > cuda::std::numeric_limits<int32_t>::max()) {
+    gc_parent_locs[row] = {-1, 0};
+    set_error_once(error_flag, ERR_OVERFLOW);
+    return;
+  }
+
+  gc_parent_locs[row] = {static_cast<int32_t>(abs_offset), child_loc.length};
 }
 
 /**
@@ -895,6 +924,21 @@ void launch_scan_nested_message_fields(uint8_t const* message_data,
     top_row_indices);
 }
 
+void launch_compute_grandchild_parent_locations(field_location const* parent_locs,
+                                                field_location const* child_locs,
+                                                int child_idx,
+                                                int num_child_fields,
+                                                field_location* gc_parent_locs,
+                                                int num_rows,
+                                                int* error_flag,
+                                                rmm::cuda_stream_view stream)
+{
+  if (num_rows == 0) return;
+  auto const blocks = static_cast<int>((num_rows + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
+  compute_grandchild_parent_locations_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
+    parent_locs, child_locs, child_idx, num_child_fields, gc_parent_locs, num_rows, error_flag);
+}
+
 void launch_validate_enum_values(int32_t const* values,
                                  bool* valid,
                                  bool* row_has_invalid_enum,
@@ -997,10 +1041,11 @@ void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_
 {
   if (num_items == 0 || row_invalid.size() == 0 || !propagate_to_rows) return;
 
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
   if (top_row_indices == nullptr) {
     CUDF_EXPECTS(static_cast<size_t>(num_items) <= row_invalid.size(),
                  "enum invalid-row propagation exceeded row buffer");
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, scratch_mr),
                       row_invalid.begin(),
                       row_invalid.begin() + num_items,
                       item_invalid.begin(),
@@ -1016,7 +1061,7 @@ void propagate_invalid_enum_flags_to_rows(rmm::device_uvector<bool> const& item_
   // Although every racing write stores the same value (`true`), non-atomic concurrent writes
   // to the same address are UB under the CUDA memory model. Use atomic_ref like set_error_once.
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, scratch_mr),
     thrust::make_counting_iterator(0),
     thrust::make_counting_iterator(num_items),
     [item_invalid = item_invalid.data(),
@@ -1040,13 +1085,13 @@ void validate_enum_and_propagate_rows(rmm::device_uvector<int32_t> const& values
 {
   if (num_items == 0 || valid_enums.empty()) return;
 
+  auto const scratch_mr = cudf::get_current_device_resource_ref();
   auto const blocks  = static_cast<int>((num_items + THREADS_PER_BLOCK - 1u) / THREADS_PER_BLOCK);
-  auto d_valid_enums = cudf::detail::make_device_uvector_async(
-    valid_enums, stream, cudf::get_current_device_resource_ref());
+  auto d_valid_enums = cudf::detail::make_device_uvector_async(valid_enums, stream, scratch_mr);
 
-  rmm::device_uvector<bool> item_invalid(
-    num_items, stream, cudf::get_current_device_resource_ref());
-  thrust::fill(rmm::exec_policy_nosync(stream), item_invalid.begin(), item_invalid.end(), false);
+  rmm::device_uvector<bool> item_invalid(num_items, stream, scratch_mr);
+  thrust::fill(
+    rmm::exec_policy_nosync(stream, scratch_mr), item_invalid.begin(), item_invalid.end(), false);
   validate_enum_values_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream.value()>>>(
     values.data(),
     valid.data(),

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -38,9 +38,9 @@ namespace {
 // Pass 1: Scan all fields kernel - records (offset, length) for each field
 // ============================================================================
 
-CUDF_KERNEL void set_error_if_unset_kernel(int* error_flag, int error_code)
+CUDF_KERNEL void set_error_if_unset_kernel(int* error_flag, protobuf_error error)
 {
-  if (blockIdx.x == 0 && threadIdx.x == 0) { set_error_once(error_flag, error_code); }
+  if (blockIdx.x == 0 && threadIdx.x == 0) { set_error_once(error_flag, error); }
 }
 
 /**
@@ -82,7 +82,7 @@ __device__ bool scan_message_field_locations(uint8_t const* msg_base,
       if (is_repeated_field(f)) {
         if (!on_repeated(f, cur, msg_end, msg_base, wt)) { return false; }
       } else if (wt != get_expected_wire_type(f)) {
-        set_error_once(error_flag, ERR_WIRE_TYPE);
+        set_error_once(error_flag, protobuf_error::WIRE_TYPE);
         return false;
       } else {
         // Record this field's location relative to the message start (last one wins).
@@ -92,17 +92,17 @@ __device__ bool scan_message_field_locations(uint8_t const* msg_base,
           uint64_t len;
           int len_bytes;
           if (!read_varint(cur, msg_end, len, len_bytes)) {
-            set_error_once(error_flag, ERR_VARINT);
+            set_error_once(error_flag, protobuf_error::VARINT);
             return false;
           }
           if (len > static_cast<uint64_t>(msg_end - cur - len_bytes) ||
               len > static_cast<uint64_t>(cuda::std::numeric_limits<int>::max())) {
-            set_error_once(error_flag, ERR_OVERFLOW);
+            set_error_once(error_flag, protobuf_error::OVERFLOW);
             return false;
           }
           int32_t data_location;
           if (!checked_add_int32(data_offset, len_bytes, data_location)) {
-            set_error_once(error_flag, ERR_OVERFLOW);
+            set_error_once(error_flag, protobuf_error::OVERFLOW);
             return false;
           }
           if (out != nullptr) { out[f] = {data_location, static_cast<int32_t>(len)}; }
@@ -110,7 +110,7 @@ __device__ bool scan_message_field_locations(uint8_t const* msg_base,
           // Fixed-width / varint: record the offset and the wire-type-derived size.
           int field_size = get_wire_type_size(wt, cur, msg_end);
           if (field_size < 0) {
-            set_error_once(error_flag, ERR_FIELD_SIZE);
+            set_error_once(error_flag, protobuf_error::FIELD_SIZE);
             return false;
           }
           if (out != nullptr) { out[f] = {data_offset, field_size}; }
@@ -121,7 +121,7 @@ __device__ bool scan_message_field_locations(uint8_t const* msg_base,
     // Advance to the next field regardless of whether this one matched the schema.
     uint8_t const* next;
     if (!skip_field(cur, msg_end, wt, next)) {
-      set_error_once(error_flag, ERR_SKIP);
+      set_error_once(error_flag, protobuf_error::SKIP);
       return false;
     }
     cur = next;
@@ -222,7 +222,7 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
                     expected_wt != wire_type_value(proto_wire_type::LEN));
 
   if (!is_packed && wt != expected_wt) {
-    set_error_once(error_flag, ERR_WIRE_TYPE);
+    set_error_once(error_flag, protobuf_error::WIRE_TYPE);
     return false;
   }
 
@@ -230,12 +230,12 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
     uint64_t packed_len;
     int len_bytes;
     if (!read_varint(cur, msg_end, packed_len, len_bytes)) {
-      set_error_once(error_flag, ERR_VARINT);
+      set_error_once(error_flag, protobuf_error::VARINT);
       return false;
     }
     uint8_t const* packed_start = cur + len_bytes;
     if (packed_len > static_cast<uint64_t>(msg_end - packed_start)) {
-      set_error_once(error_flag, ERR_OVERFLOW);
+      set_error_once(error_flag, protobuf_error::OVERFLOW);
       return false;
     }
     uint8_t const* packed_end = packed_start + packed_len;
@@ -252,7 +252,7 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
           int32_t elem_offset = static_cast<int32_t>(p - msg_base);
           uint64_t dummy;
           if (!read_varint(p, packed_end, dummy, vbytes)) {
-            set_error_once(error_flag, ERR_VARINT);
+            set_error_once(error_flag, protobuf_error::VARINT);
             return false;
           }
           if (!f(elem_offset, vbytes)) return false;
@@ -263,7 +263,7 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
       case wire_type_value(proto_wire_type::I64BIT): {
         int const width = (expected_wt == wire_type_value(proto_wire_type::I32BIT)) ? 4 : 8;
         if ((packed_len % width) != 0) {
-          set_error_once(error_flag, ERR_FIXED_LEN);
+          set_error_once(error_flag, protobuf_error::FIXED_LEN);
           return false;
         }
         for (uint8_t const* p = packed_start; p < packed_end; p += width) {
@@ -276,7 +276,7 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
         // Unreachable on a well-formed config: only VARINT / I32BIT / I64BIT are valid for
         // packed wire types here (LEN is already filtered out above by the !is_packed path).
         // Fail loudly rather than silently swallowing an unexpected expected_wt.
-        set_error_once(error_flag, ERR_WIRE_TYPE);
+        set_error_once(error_flag, protobuf_error::WIRE_TYPE);
         return false;
     }
   } else {
@@ -287,7 +287,7 @@ __device__ bool walk_repeated_element(uint8_t const* cur,
     // actions and avoids re-validating field bounds twice.
     int32_t data_offset, data_length;
     if (!get_field_data_location(cur, msg_end, wt, data_offset, data_length)) {
-      set_error_once(error_flag, ERR_FIELD_SIZE);
+      set_error_once(error_flag, protobuf_error::FIELD_SIZE);
       return false;
     }
     int32_t abs_offset = static_cast<int32_t>(cur - msg_base) + data_offset;
@@ -390,18 +390,18 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
           fn, fn_to_nested_idx, fn_to_nested_size, nested_field_indices, num_nested_fields);
         f >= 0) {
       if (wt != wire_type_value(proto_wire_type::LEN)) {
-        set_error_once(error_flag, ERR_WIRE_TYPE);
+        set_error_once(error_flag, protobuf_error::WIRE_TYPE);
         return;
       }
       uint64_t len;
       int len_bytes;
       if (!read_varint(cur, msg_end, len, len_bytes)) {
-        set_error_once(error_flag, ERR_VARINT);
+        set_error_once(error_flag, protobuf_error::VARINT);
         return;
       }
       if (len > static_cast<uint64_t>(msg_end - cur - len_bytes) ||
           len > static_cast<uint64_t>(cuda::std::numeric_limits<int>::max())) {
-        set_error_once(error_flag, ERR_OVERFLOW);
+        set_error_once(error_flag, protobuf_error::OVERFLOW);
         return;
       }
       // cur - msg_base is bounded by the message length (<= INT32_MAX via check_message_bounds),
@@ -410,7 +410,7 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
       int const data_offset = static_cast<int>(cur - msg_base);
       int32_t data_location;
       if (!checked_add_int32(data_offset, len_bytes, data_location)) {
-        set_error_once(error_flag, ERR_OVERFLOW);
+        set_error_once(error_flag, protobuf_error::OVERFLOW);
         return;
       }
       nested_locations[flat_index(row, num_nested_fields, f)] = {data_location,
@@ -420,7 +420,7 @@ CUDF_KERNEL void count_repeated_fields_kernel(cudf::column_device_view const d_i
     // Skip to next field
     uint8_t const* next;
     if (!skip_field(cur, msg_end, wt, next)) {
-      set_error_once(error_flag, ERR_SKIP);
+      set_error_once(error_flag, protobuf_error::SKIP);
       return;
     }
     cur = next;
@@ -459,7 +459,7 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
   // failure mode (overrunning `write_idx` below) is silent UB — `assert` is a no-op under
   // NDEBUG and would leave the OOB write live in release.
   if (num_scan_fields > MAX_REPEATED_FIELDS_PER_KERNEL) {
-    set_error_once(error_flag, ERR_SCHEMA_TOO_LARGE);
+    set_error_once(error_flag, protobuf_error::SCHEMA_TOO_LARGE);
     return;
   }
   int write_idx[MAX_REPEATED_FIELDS_PER_KERNEL];
@@ -483,7 +483,7 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
       int const we     = scan_descs[f].row_offsets[row + 1];
       auto scan_action = [&](int32_t off, int32_t len) {
         if (wi >= we) {
-          set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+          set_error_once(error_flag, protobuf_error::REPEATED_COUNT_MISMATCH);
           return false;
         }
         occs[wi] = {row_i32, off, len};
@@ -507,7 +507,7 @@ CUDF_KERNEL void scan_all_repeated_occurrences_kernel(cudf::column_device_view c
 
   for (int f = 0; f < num_scan_fields; f++) {
     if (write_idx[f] != scan_descs[f].row_offsets[row + 1]) {
-      set_error_once(error_flag, ERR_REPEATED_COUNT_MISMATCH);
+      set_error_once(error_flag, protobuf_error::REPEATED_COUNT_MISMATCH);
       return;
     }
   }
@@ -606,7 +606,7 @@ CUDF_KERNEL void compute_grandchild_parent_locations_kernel(field_location const
 
   nested_location_provider loc_provider{
     nullptr, 0, parent_locs, child_locs, child_idx, num_child_fields};
-  gc_parent_locs[row] = loc_provider.get_nested_parent_location(row, error_flag);
+  gc_parent_locs[row] = loc_provider.get_rebased_child_location(row, error_flag);
 }
 
 /**
@@ -660,7 +660,7 @@ CUDF_KERNEL void check_required_fields_kernel(
         row_force_null[top_row] = true;
       }
       // Required field is missing - set error flag
-      set_error_once(error_flag, ERR_REQUIRED);
+      set_error_once(error_flag, protobuf_error::REQUIRED);
       return;  // No need to check other fields for this row
     }
   }
@@ -784,9 +784,9 @@ CUDF_KERNEL void copy_enum_string_chars_kernel(
 // Host wrapper functions — callable from other translation units
 // ============================================================================
 
-void set_error_once_async(int* error_flag, int error_code, rmm::cuda_stream_view stream)
+void set_error_once_async(int* error_flag, protobuf_error error, rmm::cuda_stream_view stream)
 {
-  set_error_if_unset_kernel<<<1, 1, 0, stream.value()>>>(error_flag, error_code);
+  set_error_if_unset_kernel<<<1, 1, 0, stream.value()>>>(error_flag, error);
   CUDF_CUDA_TRY(cudaPeekAtLastError());
 }
 

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -1001,13 +1001,15 @@ void maybe_check_required_fields(field_location const* locations,
                                  bool* row_force_null,
                                  int32_t const* top_row_indices,
                                  int* error_flag,
+                                 pinned_staging_buffer_store& pinned_staging_buffers,
                                  rmm::cuda_stream_view stream)
 {
   if (num_rows == 0 || field_indices.empty()) { return; }
 
   bool has_required = false;
-  auto h_is_required =
-    cudf::detail::make_pinned_vector_async<uint8_t>(field_indices.size(), stream);
+  auto& h_is_required = keep_pinned_staging(
+    cudf::detail::make_pinned_vector_async<uint8_t>(field_indices.size(), stream),
+    pinned_staging_buffers);
   for (size_t i = 0; i < field_indices.size(); ++i) {
     h_is_required[i] = schema[field_indices[i]].is_required ? 1 : 0;
     has_required |= (h_is_required[i] != 0);

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cu
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cu
@@ -604,21 +604,9 @@ CUDF_KERNEL void compute_grandchild_parent_locations_kernel(field_location const
   int row = blockIdx.x * blockDim.x + threadIdx.x;
   if (row >= num_rows) return;
 
-  auto const& parent_loc = parent_locs[row];
-  auto const& child_loc  = child_locs[flat_index(row, num_child_fields, child_idx)];
-  if (parent_loc.offset < 0 || child_loc.offset < 0) {
-    gc_parent_locs[row] = {-1, 0};
-    return;
-  }
-
-  auto const abs_offset = static_cast<int64_t>(parent_loc.offset) + child_loc.offset;
-  if (abs_offset > cuda::std::numeric_limits<int32_t>::max()) {
-    gc_parent_locs[row] = {-1, 0};
-    set_error_once(error_flag, ERR_OVERFLOW);
-    return;
-  }
-
-  gc_parent_locs[row] = {static_cast<int32_t>(abs_offset), child_loc.length};
+  nested_location_provider loc_provider{
+    nullptr, 0, parent_locs, child_locs, child_idx, num_child_fields};
+  gc_parent_locs[row] = loc_provider.get_nested_parent_location(row, error_flag);
 }
 
 /**

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -35,6 +35,7 @@
 
 #include <cub/device/device_memcpy.cuh>
 #include <cuda/functional>
+#include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -93,16 +94,32 @@ struct nested_location_provider {
   int field_idx;
   int num_fields;
 
-  __device__ inline field_location get(int thread_idx, int32_t& data_offset) const
+  __device__ inline field_location get_nested_parent_location(int thread_idx, int* error_flag) const
   {
     auto ploc = parent_locations[thread_idx];
     auto cloc = child_locations[flat_index(thread_idx, num_fields, field_idx)];
-    if (ploc.offset >= 0 && cloc.offset >= 0) {
-      data_offset = row_offsets[thread_idx] - base_offset + ploc.offset + cloc.offset;
-    } else {
-      cloc.offset = -1;
+    if (ploc.offset < 0 || cloc.offset < 0) { return {-1, 0}; }
+
+    auto const offset = static_cast<int64_t>(ploc.offset) + cloc.offset;
+    if (offset > cuda::std::numeric_limits<int32_t>::max()) {
+      if (error_flag != nullptr) { set_error_once(error_flag, ERR_OVERFLOW); }
+      return {-1, 0};
     }
-    return cloc;
+    return {static_cast<int32_t>(offset), cloc.length};
+  }
+
+  __device__ inline field_location get(int thread_idx, int32_t& data_offset) const
+  {
+    auto child_parent_loc = get_nested_parent_location(thread_idx, nullptr);
+    if (child_parent_loc.offset < 0) { return child_parent_loc; }
+
+    data_offset = row_offsets[thread_idx] - base_offset + child_parent_loc.offset;
+    return child_locations[flat_index(thread_idx, num_fields, field_idx)];
+  }
+
+  __device__ inline bool valid(int thread_idx) const
+  {
+    return get_nested_parent_location(thread_idx, nullptr).offset >= 0;
   }
 };
 
@@ -444,10 +461,7 @@ void launch_compute_grandchild_parent_locations(field_location const* parent_loc
 // Host-side template helpers that launch CUDA kernels
 // ============================================================================
 
-// Build a row-aligned null mask from `valid[row]` boolean flags. The caller must ensure
-// `valid.size() >= num_rows`. If a caller pads `valid` to keep a device_uvector non-empty,
-// it must pass the logical `num_rows` separately so the mask matches the row count rather
-// than the backing buffer length.
+// Build a row-aligned null mask from `valid[row]` boolean flags.
 template <typename T>
 inline std::pair<rmm::device_buffer, cudf::size_type> make_null_mask_from_valid(
   rmm::device_uvector<T> const& valid,
@@ -474,7 +488,7 @@ std::unique_ptr<cudf::column> extract_and_build_scalar_column(cudf::data_type dt
                                                               rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<T> out(num_rows, stream, mr);
-  rmm::device_uvector<bool> valid((num_rows > 0 ? num_rows : 1), stream, mr);
+  rmm::device_uvector<bool> valid(num_rows, stream, mr);
   if (num_rows == 0) {
     return std::make_unique<cudf::column>(dt, 0, out.release(), rmm::device_buffer{}, 0);
   }
@@ -723,8 +737,8 @@ inline std::unique_ptr<cudf::column> extract_typed_column(
   rmm::device_uvector<int>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  int32_t const* top_row_indices = nullptr,
-  bool propagate_invalid_rows    = true)
+  int32_t const* top_row_indices   = nullptr,
+  bool propagate_invalid_enum_rows = true)
 {
   switch (dt.id()) {
     case cudf::type_id::BOOL8: {
@@ -774,7 +788,7 @@ inline std::unique_ptr<cudf::column> extract_typed_column(
                                            d_row_force_null,
                                            num_items,
                                            top_row_indices,
-                                           propagate_invalid_rows,
+                                           propagate_invalid_enum_rows,
                                            stream);
         }
       }

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -94,7 +94,8 @@ struct nested_location_provider {
   int field_idx;
   int num_fields;
 
-  __device__ inline field_location get_nested_parent_location(int thread_idx, int* error_flag) const
+  // Rebase child offsets from the parent message to the row for recursive STRUCT decode.
+  __device__ inline field_location get_rebased_child_location(int thread_idx, int* error_flag) const
   {
     auto ploc = parent_locations[thread_idx];
     auto cloc = child_locations[flat_index(thread_idx, num_fields, field_idx)];
@@ -102,7 +103,7 @@ struct nested_location_provider {
 
     auto const offset = static_cast<int64_t>(ploc.offset) + cloc.offset;
     if (offset > cuda::std::numeric_limits<int32_t>::max()) {
-      if (error_flag != nullptr) { set_error_once(error_flag, ERR_OVERFLOW); }
+      if (error_flag != nullptr) { set_error_once(error_flag, protobuf_error::OVERFLOW); }
       return {-1, 0};
     }
     return {static_cast<int32_t>(offset), cloc.length};
@@ -110,7 +111,7 @@ struct nested_location_provider {
 
   __device__ inline field_location get(int thread_idx, int32_t& data_offset) const
   {
-    auto child_parent_loc = get_nested_parent_location(thread_idx, nullptr);
+    auto child_parent_loc = get_rebased_child_location(thread_idx, nullptr);
     if (child_parent_loc.offset < 0) { return child_parent_loc; }
 
     data_offset = row_offsets[thread_idx] - base_offset + child_parent_loc.offset;
@@ -119,7 +120,7 @@ struct nested_location_provider {
 
   __device__ inline bool valid(int thread_idx) const
   {
-    return get_nested_parent_location(thread_idx, nullptr).offset >= 0;
+    return get_rebased_child_location(thread_idx, nullptr).offset >= 0;
   }
 };
 
@@ -195,7 +196,7 @@ CUDF_KERNEL void extract_varint_kernel(uint8_t const* message_data,
   uint64_t v;
   int n;
   if (!read_varint(cur, cur_end, v, n)) {
-    set_error_once(error_flag, ERR_VARINT);
+    set_error_once(error_flag, protobuf_error::VARINT);
     if (valid) valid[idx] = false;
     return;
   }
@@ -236,7 +237,7 @@ CUDF_KERNEL void extract_fixed_kernel(uint8_t const* message_data,
 
   if constexpr (WT == wire_type_value(proto_wire_type::I32BIT)) {
     if (loc.length < 4) {
-      set_error_once(error_flag, ERR_FIXED_LEN);
+      set_error_once(error_flag, protobuf_error::FIXED_LEN);
       if (valid) valid[idx] = false;
       return;
     }
@@ -244,7 +245,7 @@ CUDF_KERNEL void extract_fixed_kernel(uint8_t const* message_data,
     memcpy(&value, &raw, sizeof(value));
   } else {
     if (loc.length < 8) {
-      set_error_once(error_flag, ERR_FIXED_LEN);
+      set_error_once(error_flag, protobuf_error::FIXED_LEN);
       if (valid) valid[idx] = false;
       return;
     }
@@ -305,7 +306,7 @@ CUDF_KERNEL void extract_varint_batched_kernel(uint8_t const* message_data,
   uint64_t v;
   int n;
   if (!read_varint(cur, end, v, n)) {
-    set_error_once(error_flag, ERR_VARINT);
+    set_error_once(error_flag, protobuf_error::VARINT);
     desc.valid[row] = false;
     return;
   }
@@ -353,7 +354,7 @@ CUDF_KERNEL void extract_fixed_batched_kernel(uint8_t const* message_data,
 
   if constexpr (WT == wire_type_value(proto_wire_type::I32BIT)) {
     if (loc.length < 4) {
-      set_error_once(error_flag, ERR_FIXED_LEN);
+      set_error_once(error_flag, protobuf_error::FIXED_LEN);
       desc.valid[row] = false;
       return;
     }
@@ -361,7 +362,7 @@ CUDF_KERNEL void extract_fixed_batched_kernel(uint8_t const* message_data,
     memcpy(&value, &raw, sizeof(value));
   } else {
     if (loc.length < 8) {
-      set_error_once(error_flag, ERR_FIXED_LEN);
+      set_error_once(error_flag, protobuf_error::FIXED_LEN);
       desc.valid[row] = false;
       return;
     }

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -95,7 +95,8 @@ struct nested_location_provider {
   int num_fields;
 
   // Rebase child offsets from the parent message to the row for recursive STRUCT decode.
-  __device__ inline field_location get_rebased_child_location(int thread_idx, int* error_flag) const
+  __device__ inline field_location get_rebased_child_location(int thread_idx,
+                                                              protobuf_error* error_flag) const
   {
     auto ploc = parent_locations[thread_idx];
     auto cloc = child_locations[flat_index(thread_idx, num_fields, field_idx)];
@@ -170,7 +171,7 @@ CUDF_KERNEL void extract_varint_kernel(uint8_t const* message_data,
                                        int total_items,
                                        OutputType* out,
                                        bool* valid,
-                                       int* error_flag,
+                                       protobuf_error* error_flag,
                                        bool has_default      = false,
                                        int64_t default_value = 0)
 {
@@ -212,7 +213,7 @@ CUDF_KERNEL void extract_fixed_kernel(uint8_t const* message_data,
                                       int total_items,
                                       OutputType* out,
                                       bool* valid,
-                                      int* error_flag,
+                                      protobuf_error* error_flag,
                                       bool has_default         = false,
                                       OutputType default_value = OutputType{})
 {
@@ -279,7 +280,7 @@ CUDF_KERNEL void extract_varint_batched_kernel(uint8_t const* message_data,
                                                batched_scalar_desc const* descs,
                                                int num_descs,
                                                int num_rows,
-                                               int* error_flag)
+                                               protobuf_error* error_flag)
 {
   int row = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
   int fi  = static_cast<int>(blockIdx.y);
@@ -324,7 +325,7 @@ CUDF_KERNEL void extract_fixed_batched_kernel(uint8_t const* message_data,
                                               batched_scalar_desc const* descs,
                                               int num_descs,
                                               int num_rows,
-                                              int* error_flag)
+                                              protobuf_error* error_flag)
 {
   int row = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
   int fi  = static_cast<int>(blockIdx.y);
@@ -411,7 +412,7 @@ void launch_count_repeated_fields(cudf::column_device_view const& d_in,
                                   field_location* nested_locations,
                                   int num_nested_fields,
                                   int const* nested_field_indices,
-                                  int* error_flag,
+                                  protobuf_error* error_flag,
                                   int const* fn_to_rep_idx,
                                   int fn_to_rep_size,
                                   int const* fn_to_nested_idx,
@@ -422,7 +423,7 @@ void launch_count_repeated_fields(cudf::column_device_view const& d_in,
 void launch_scan_all_repeated_occurrences(cudf::column_device_view const& d_in,
                                           repeated_field_scan_desc const* scan_descs,
                                           int num_scan_fields,
-                                          int* error_flag,
+                                          protobuf_error* error_flag,
                                           int const* fn_to_desc_idx,
                                           int fn_to_desc_size,
                                           int num_rows,
@@ -444,7 +445,7 @@ void launch_scan_nested_message_fields(uint8_t const* message_data,
                                        field_descriptor const* field_descs,
                                        int num_fields,
                                        field_location* output_locations,
-                                       int* error_flag,
+                                       protobuf_error* error_flag,
                                        bool* row_has_invalid_data,
                                        int32_t const* top_row_indices,
                                        rmm::cuda_stream_view stream);
@@ -455,7 +456,7 @@ void launch_compute_grandchild_parent_locations(field_location const* parent_loc
                                                 int num_child_fields,
                                                 field_location* gc_parent_locs,
                                                 int num_rows,
-                                                int* error_flag,
+                                                protobuf_error* error_flag,
                                                 rmm::cuda_stream_view stream);
 
 // ============================================================================
@@ -510,7 +511,7 @@ inline void extract_integer_into_buffers(uint8_t const* message_data,
                                          bool enable_zigzag,
                                          T* out_ptr,
                                          bool* valid_ptr,
-                                         int* error_ptr,
+                                         protobuf_error* error_ptr,
                                          rmm::cuda_stream_view stream)
 {
   if (enable_zigzag && encoding == encoding_value(proto_encoding::ZIGZAG)) {
@@ -560,19 +561,20 @@ inline void extract_integer_into_buffers(uint8_t const* message_data,
 }
 
 template <typename T, typename LocationProvider>
-std::unique_ptr<cudf::column> extract_and_build_integer_column(cudf::data_type dt,
-                                                               uint8_t const* message_data,
-                                                               LocationProvider const& loc_provider,
-                                                               int num_rows,
-                                                               int blocks,
-                                                               int threads,
-                                                               rmm::device_uvector<int>& d_error,
-                                                               bool has_default,
-                                                               int64_t default_value,
-                                                               int encoding,
-                                                               bool enable_zigzag,
-                                                               rmm::cuda_stream_view stream,
-                                                               rmm::device_async_resource_ref mr)
+std::unique_ptr<cudf::column> extract_and_build_integer_column(
+  cudf::data_type dt,
+  uint8_t const* message_data,
+  LocationProvider const& loc_provider,
+  int num_rows,
+  int blocks,
+  int threads,
+  rmm::device_uvector<protobuf_error>& d_error,
+  bool has_default,
+  int64_t default_value,
+  int encoding,
+  bool enable_zigzag,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
 {
   return extract_and_build_scalar_column<T>(
     dt,
@@ -617,7 +619,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
   ValidityFn validity_fn,
   bool has_default,
   cudf::detail::host_vector<uint8_t> const& default_bytes,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -735,7 +737,7 @@ inline std::unique_ptr<cudf::column> extract_typed_column(
   std::vector<cudf::detail::host_vector<int32_t>> const& enum_valid_values,
   std::vector<std::vector<cudf::detail::host_vector<uint8_t>>> const& enum_names,
   rmm::device_uvector<bool>& d_row_force_null,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
   int32_t const* top_row_indices   = nullptr,
@@ -892,7 +894,7 @@ inline std::unique_ptr<cudf::column> build_repeated_scalar_column(
   rmm::device_uvector<repeated_occurrence>& d_occurrences,
   int total_count,
   int num_rows,
-  rmm::device_uvector<int>& d_error,
+  rmm::device_uvector<protobuf_error>& d_error,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -964,7 +966,7 @@ void launch_scan_all_fields(cudf::column_device_view const& d_in,
                             int const* field_lookup,
                             int field_lookup_size,
                             field_location* locations,
-                            int* error_flag,
+                            protobuf_error* error_flag,
                             bool* row_has_invalid_data,
                             int num_rows,
                             rmm::cuda_stream_view stream);

--- a/src/main/cpp/src/protobuf/protobuf_kernels.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_kernels.cuh
@@ -431,6 +431,15 @@ void launch_scan_nested_message_fields(uint8_t const* message_data,
                                        int32_t const* top_row_indices,
                                        rmm::cuda_stream_view stream);
 
+void launch_compute_grandchild_parent_locations(field_location const* parent_locs,
+                                                field_location const* child_locs,
+                                                int child_idx,
+                                                int num_child_fields,
+                                                field_location* gc_parent_locs,
+                                                int num_rows,
+                                                int* error_flag,
+                                                rmm::cuda_stream_view stream);
+
 // ============================================================================
 // Host-side template helpers that launch CUDA kernels
 // ============================================================================
@@ -672,7 +681,7 @@ inline std::unique_ptr<cudf::column> extract_and_build_string_or_bytes_column(
   }
 
   rmm::device_uvector<bool> valid(num_rows, stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, mr),
                     thrust::make_counting_iterator<cudf::size_type>(0),
                     thrust::make_counting_iterator<cudf::size_type>(num_rows),
                     valid.data(),

--- a/src/main/cpp/src/protobuf/protobuf_types.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_types.cuh
@@ -18,6 +18,8 @@
 
 #include "protobuf/protobuf.hpp"
 
+#include <string>
+
 namespace spark_rapids_jni::protobuf::detail {
 
 // Protobuf varint encoding uses at most 10 bytes to represent a 64-bit value.
@@ -27,21 +29,19 @@ constexpr int MAX_VARINT_BYTES = 10;
 constexpr int THREADS_PER_BLOCK = 256;
 
 enum class protobuf_error : int {
-  NONE                    = 0,
-  BOUNDS                  = 1,
-  VARINT                  = 2,
-  FIELD_NUMBER            = 3,
-  WIRE_TYPE               = 4,
-  OVERFLOW                = 5,
-  FIELD_SIZE              = 6,
-  SKIP                    = 7,
-  FIXED_LEN               = 8,
-  REQUIRED                = 9,
-  SCHEMA_TOO_LARGE        = 10,
-  REPEATED_COUNT_MISMATCH = 11,
+  NONE = 0,
+  BOUNDS,
+  VARINT,
+  FIELD_NUMBER,
+  WIRE_TYPE,
+  OVERFLOW,
+  FIELD_SIZE,
+  SKIP,
+  FIXED_LEN,
+  REQUIRED,
+  SCHEMA_TOO_LARGE,
+  REPEATED_COUNT_MISMATCH,
 };
-
-CUDF_HOST_DEVICE constexpr int error_code(protobuf_error error) { return static_cast<int>(error); }
 
 // Threshold for using a direct-mapped lookup table for field_number -> field_index.
 // Field numbers above this threshold fall back to linear search.
@@ -53,6 +53,30 @@ constexpr int FIELD_LOOKUP_TABLE_MAX = 4096;
 // cost 4x the per-thread footprint and pressure occupancy. Validated at the host level so the
 // error surface depends on the schema, not on which fields happen to have data in a given batch.
 constexpr int MAX_REPEATED_FIELDS_PER_KERNEL = 32;
+
+inline std::string error_message(protobuf_error error)
+{
+  switch (error) {
+    using enum protobuf_error;
+    case NONE: return "Protobuf decode error: none";
+    case BOUNDS: return "Protobuf decode error: message data out of bounds";
+    case VARINT: return "Protobuf decode error: invalid or truncated varint";
+    case FIELD_NUMBER: return "Protobuf decode error: invalid field number";
+    case WIRE_TYPE: return "Protobuf decode error: unexpected wire type";
+    case OVERFLOW: return "Protobuf decode error: length-delimited field overflows message";
+    case FIELD_SIZE: return "Protobuf decode error: invalid field size";
+    case SKIP: return "Protobuf decode error: unable to skip unknown field";
+    case FIXED_LEN: return "Protobuf decode error: invalid fixed-width or packed field length";
+    case REQUIRED: return "Protobuf decode error: missing required field";
+    case SCHEMA_TOO_LARGE:
+      return "Protobuf decode error: schema exceeds maximum supported repeated fields per "
+             "kernel (" +
+             std::to_string(MAX_REPEATED_FIELDS_PER_KERNEL) + ")";
+    case REPEATED_COUNT_MISMATCH:
+      return "Protobuf decode error: repeated-field count/scan mismatch";
+  }
+  return "Protobuf decode error: unknown error";
+}
 
 /**
  * Structure to record field location within a message.

--- a/src/main/cpp/src/protobuf/protobuf_types.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_types.cuh
@@ -26,18 +26,22 @@ constexpr int MAX_VARINT_BYTES = 10;
 // CUDA kernel launch configuration.
 constexpr int THREADS_PER_BLOCK = 256;
 
-// Error codes for kernel error reporting.
-constexpr int ERR_BOUNDS                  = 1;
-constexpr int ERR_VARINT                  = 2;
-constexpr int ERR_FIELD_NUMBER            = 3;
-constexpr int ERR_WIRE_TYPE               = 4;
-constexpr int ERR_OVERFLOW                = 5;
-constexpr int ERR_FIELD_SIZE              = 6;
-constexpr int ERR_SKIP                    = 7;
-constexpr int ERR_FIXED_LEN               = 8;
-constexpr int ERR_REQUIRED                = 9;
-constexpr int ERR_SCHEMA_TOO_LARGE        = 10;
-constexpr int ERR_REPEATED_COUNT_MISMATCH = 11;
+enum class protobuf_error : int {
+  NONE                    = 0,
+  BOUNDS                  = 1,
+  VARINT                  = 2,
+  FIELD_NUMBER            = 3,
+  WIRE_TYPE               = 4,
+  OVERFLOW                = 5,
+  FIELD_SIZE              = 6,
+  SKIP                    = 7,
+  FIXED_LEN               = 8,
+  REQUIRED                = 9,
+  SCHEMA_TOO_LARGE        = 10,
+  REPEATED_COUNT_MISMATCH = 11,
+};
+
+CUDF_HOST_DEVICE constexpr int error_code(protobuf_error error) { return static_cast<int>(error); }
 
 // Threshold for using a direct-mapped lookup table for field_number -> field_index.
 // Field numbers above this threshold fall back to linear search.

--- a/src/main/cpp/src/protobuf/protobuf_types.cuh
+++ b/src/main/cpp/src/protobuf/protobuf_types.cuh
@@ -37,8 +37,7 @@ constexpr int ERR_SKIP                    = 7;
 constexpr int ERR_FIXED_LEN               = 8;
 constexpr int ERR_REQUIRED                = 9;
 constexpr int ERR_SCHEMA_TOO_LARGE        = 10;
-constexpr int ERR_MISSING_ENUM_META       = 11;
-constexpr int ERR_REPEATED_COUNT_MISMATCH = 12;
+constexpr int ERR_REPEATED_COUNT_MISMATCH = 11;
 
 // Threshold for using a direct-mapped lookup table for field_number -> field_index.
 // Field numbers above this threshold fall back to linear search.

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -1246,7 +1246,8 @@ public class ProtobufTest {
       assertFalse(hostStruct.isNull(0), "Present required field should keep row 0 valid");
       assertTrue(hostStruct.isNull(1), "Null input row should produce null struct row");
       assertEquals(1, idCol.getNullCount(), "The required child value should be null on the null input row");
-      assertTrue(hostId.isNull(1), "Null input row should produce a null child value, not ERR_REQUIRED");
+      assertTrue(hostId.isNull(1),
+          "Null input row should produce a null child value, not protobuf_error::REQUIRED");
     }
   }
 
@@ -2691,10 +2692,9 @@ public class ProtobufTest {
   void testNestedMessageVarlenChildren() {
     // message Inner { string name = 1; bytes payload = 2; }
     // message Outer { Inner inner = 1; }
-    byte[] payload = new byte[]{1, 2, 3};
     Byte[] innerMessage = concat(
         box(tag(1, WT_LEN)), encodeString("alice"),
-        box(tag(2, WT_LEN)), encodeBytes(payload));
+        box(tag(2, WT_LEN)), encodeBytes(new byte[]{1, 2, 3}));
     Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(innerMessage));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
@@ -2982,6 +2982,27 @@ public class ProtobufTest {
   }
 
   @Test
+  void testMalformedChildlessNestedMessage_FailsFast() {
+    // message Empty {}
+    // message Outer { Empty inner = 1; }
+    // The childless Inner body contains an unknown field with a truncated varint value.
+    Byte[] malformedInner = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte) 0x80});
+    Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(malformedInner));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector result = Protobuf.decodeToStruct(
+            input.getColumn(0),
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.STRUCT)
+                .build(),
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
   void testRecursiveChildlessNestedMessage_PreservesPresence() {
     // message Empty {}
     // message Middle { Empty empty = 1; }
@@ -3253,7 +3274,7 @@ public class ProtobufTest {
 
   @Test
   void testSchemaWithTooManyRepeatedFields() {
-    // Hits ERR_SCHEMA_TOO_LARGE: the scan_all_repeated_occurrences_kernel stack-array
+    // Hits protobuf_error::SCHEMA_TOO_LARGE: the scan_all_repeated_occurrences_kernel stack-array
     // guard rejects schemas with more than 32 top-level repeated fields.
     int n = 33;
     ProtobufSchemaDescriptorBuilder builder = new ProtobufSchemaDescriptorBuilder();

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -2544,26 +2544,6 @@ public class ProtobufTest {
   }
 
   @Test
-  void testZeroLengthNestedMessage() {
-    Byte[] row = concat(
-        box(tag(1, WT_LEN)),
-        box(encodeVarint(0)));
-
-    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
-         ColumnVector result = Protobuf.decodeToStruct(
-             input.getColumn(0),
-             new ProtobufSchemaDescriptorBuilder()
-                 .addField(1, DType.STRUCT).down()
-                     .addField(1, DType.INT32)
-                 .up()
-                 .build(),
-             false)) {
-      assertNotNull(result);
-      assertEquals(DType.STRUCT, result.getType());
-    }
-  }
-
-  @Test
   void testRepeatedFieldOutputShape() {
     // Schema: message Msg { repeated int32 values = 1; }
     ProtobufSchemaDescriptor schema = new ProtobufSchemaDescriptorBuilder()
@@ -2690,6 +2670,227 @@ public class ProtobufTest {
              ColumnVector expOuter = ColumnVector.makeStruct(expInner)) {
           AssertUtils.assertStructColumnsAreEqual(expOuter, result);
         }
+    }
+  }
+
+  @Test
+  void testNestedMessageVarlenChildren() {
+    // message Inner { string name = 1; bytes payload = 2; }
+    // message Outer { Inner inner = 1; }
+    byte[] payload = new byte[]{1, 2, 3};
+    Byte[] innerMessage = concat(
+        box(tag(1, WT_LEN)), box(encodeVarint(5)), box("alice".getBytes()),
+        box(tag(2, WT_LEN)), box(encodeVarint(payload.length)), box(payload));
+    Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(innerMessage));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedName = ColumnVector.fromStrings("alice");
+         ColumnVector expectedPayload = ColumnVector.fromLists(
+             new ListType(true, new BasicType(true, DType.UINT8)),
+             Arrays.asList((byte) 1, (byte) 2, (byte) 3));
+         ColumnVector expectedInner = ColumnVector.makeStruct(expectedName, expectedPayload);
+         ColumnVector expectedOuter = ColumnVector.makeStruct(expectedInner);
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.STRING)
+                     .addField(2, DType.LIST)
+                 .up()
+                 .build(),
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedOuter, actual);
+    }
+  }
+
+  @Test
+  void testNestedMessageStringDefault() {
+    // message Inner { optional string name = 1 [default = "missing"]; }
+    // message Outer { Inner inner = 1; }
+    Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(new Byte[]{}));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedName = ColumnVector.fromStrings("missing");
+         ColumnVector expectedInner = ColumnVector.makeStruct(expectedName);
+         ColumnVector expectedOuter = ColumnVector.makeStruct(expectedInner);
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.STRING).defaultValue("missing".getBytes())
+                 .up()
+                 .build(),
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedOuter, actual);
+    }
+  }
+
+  @Test
+  void testDeepNestedMessageDepth3() {
+    // message Inner  { int32 a = 1; string b = 2; bool c = 3; }
+    // message Middle { Inner inner = 1; int64 m = 2; }
+    // message Outer  { Middle middle = 1; float score = 2; }
+    Byte[] inner = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(7)),
+        box(tag(2, WT_LEN)), box(encodeVarint(3)), box("abc".getBytes()),
+        box(tag(3, WT_VARINT)), box(encodeVarint(1)));
+    Byte[] middle = concat(
+        box(tag(1, WT_LEN)), encodeMessage(inner),
+        box(tag(2, WT_VARINT)), box(encodeVarint(123L)));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), encodeMessage(middle),
+        box(tag(2, WT_32BIT)), box(encodeFloat(1.25f)));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector expectedA = ColumnVector.fromBoxedInts(7);
+         ColumnVector expectedB = ColumnVector.fromStrings("abc");
+         ColumnVector expectedC = ColumnVector.fromBoxedBooleans(true);
+         ColumnVector expectedInner = ColumnVector.makeStruct(expectedA, expectedB, expectedC);
+         ColumnVector expectedM = ColumnVector.fromBoxedLongs(123L);
+         ColumnVector expectedMiddle = ColumnVector.makeStruct(expectedInner, expectedM);
+         ColumnVector expectedScore = ColumnVector.fromBoxedFloats(1.25f);
+         ColumnVector expectedOuter = ColumnVector.makeStruct(expectedMiddle, expectedScore);
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.STRUCT).down()
+                         .addField(1, DType.INT32)
+                         .addField(2, DType.STRING)
+                         .addField(3, DType.BOOL8)
+                     .up()
+                     .addField(2, DType.INT64)
+                 .up()
+                 .addField(2, DType.FLOAT32)
+                 .build(),
+             false)) {
+      AssertUtils.assertStructColumnsAreEqual(expectedOuter, actual);
+    }
+  }
+
+  @Test
+  void testNestedEnumAsStringInvalidKeepsSiblingFieldsVisible() {
+    // message Outer { int32 id = 1; Inner inner = 2; string name = 3; }
+    // message Inner { enum Status { UNKNOWN=0; OK=1; BAD=2; } Status status = 1;
+    //                 int32 count = 2; }
+    Byte[] innerValid = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(10)));
+    Byte[] innerInvalid = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(999)),
+        box(tag(2, WT_VARINT)), box(encodeVarint(20)));
+    Byte[] row0 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+        box(tag(2, WT_LEN)), encodeMessage(innerValid),
+        box(tag(3, WT_LEN)), box(encodeVarint(2)), box("ok".getBytes()));
+    Byte[] row1 = concat(
+        box(tag(1, WT_VARINT)), box(encodeVarint(2)),
+        box(tag(2, WT_LEN)), encodeMessage(innerInvalid),
+        box(tag(3, WT_LEN)), box(encodeVarint(3)), box("bad".getBytes()));
+    byte[][] enumNames = new byte[][]{
+        "UNKNOWN".getBytes(), "OK".getBytes(), "BAD".getBytes()};
+
+    try (Table input = new Table.TestBuilder().column(row0, row1).build();
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.INT32)
+                 .addField(2, DType.STRUCT).down()
+                     .addField(1, DType.STRING).encoding(Protobuf.ENC_ENUM_STRING)
+                         .enumMetadata(new int[]{0, 1, 2}, enumNames)
+                     .addField(2, DType.INT32)
+                 .up()
+                 .addField(3, DType.STRING)
+                 .build(),
+             false);
+         ColumnVector inner = actual.getChildColumnView(1).copyToColumnVector();
+         ColumnVector status = inner.getChildColumnView(0).copyToColumnVector();
+         ColumnVector count = inner.getChildColumnView(1).copyToColumnVector();
+         HostColumnVector hostOuter = actual.copyToHost();
+         HostColumnVector hostInner = inner.copyToHost();
+         HostColumnVector hostStatus = status.copyToHost();
+         HostColumnVector hostCount = count.copyToHost()) {
+      assertEquals(0, actual.getNullCount(), "Invalid nested enum should not null outer rows");
+      assertFalse(hostOuter.isNull(0));
+      assertFalse(hostOuter.isNull(1));
+      assertEquals(0, inner.getNullCount(), "Nested struct rows should stay present");
+      assertFalse(hostInner.isNull(1));
+      assertEquals("OK", hostStatus.getJavaString(0));
+      assertTrue(hostStatus.isNull(1), "Unknown nested enum should null only the enum field");
+      assertEquals(20, hostCount.getInt(1));
+    }
+  }
+
+  @Test
+  void testRequiredFieldInsideNestedMessageMissing_Failfast() {
+    // message Outer { Inner inner = 1; }
+    // message Inner { required int32 id = 1; optional string note = 2; }
+    Byte[] inner = concat(box(tag(2, WT_LEN)), box(encodeVarint(4)), box("oops".getBytes()));
+    Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(inner));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
+      assertThrows(ai.rapids.cudf.CudfException.class, () -> {
+        try (ColumnVector ignored = Protobuf.decodeToStruct(
+            input.getColumn(0),
+            new ProtobufSchemaDescriptorBuilder()
+                .addField(1, DType.STRUCT).down()
+                    .addField(1, DType.INT32).required()
+                    .addField(2, DType.STRING)
+                .up()
+                .build(),
+            true)) {
+        }
+      });
+    }
+  }
+
+  @Test
+  void testRequiredFieldInsideNestedMessageMissing_Permissive() {
+    // message Outer { Inner inner = 1; string name = 2; }
+    // message Inner { required int32 id = 1; optional string note = 2; }
+    Byte[] inner = concat(box(tag(2, WT_LEN)), box(encodeVarint(4)), box("oops".getBytes()));
+    Byte[] row = concat(
+        box(tag(1, WT_LEN)), encodeMessage(inner),
+        box(tag(2, WT_LEN)), box(encodeVarint(7)), box("outside".getBytes()));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.INT32).required()
+                     .addField(2, DType.STRING)
+                 .up()
+                 .addField(2, DType.STRING)
+                 .build(),
+             false)) {
+      assertSingleNullStructRow(actual,
+          "Missing nested required field should null the outer row in PERMISSIVE mode");
+    }
+  }
+
+  @Test
+  void testAbsentNestedParentSkipsRequiredChildCheck_Failfast() {
+    // message Outer { optional Inner inner = 1; }
+    // message Inner { required int32 id = 1; }
+    Byte[] row = new Byte[0];
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector actual = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.INT32).required()
+                 .up()
+                 .build(),
+             true);
+         ColumnVector inner = actual.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostOuter = actual.copyToHost();
+         HostColumnVector hostInner = inner.copyToHost()) {
+      assertEquals(0, actual.getNullCount(), "Outer row should remain valid");
+      assertFalse(hostOuter.isNull(0), "Top-level row should not be null");
+      assertEquals(1, inner.getNullCount(), "Absent nested parent should stay null");
+      assertTrue(hostInner.isNull(0), "Missing optional nested struct should skip child required");
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -2967,6 +2967,39 @@ public class ProtobufTest {
   }
 
   @Test
+  void testRecursiveChildlessNestedMessage_PreservesPresence() {
+    // message Empty {}
+    // message Middle { Empty empty = 1; }
+    // message Outer { Middle middle = 1; }
+    Byte[] middleWithEmpty = concat(box(tag(1, WT_LEN)), encodeMessage(new Byte[]{}));
+    Byte[][] rows = new Byte[][]{
+        concat(box(tag(1, WT_LEN)), encodeMessage(middleWithEmpty)),
+        concat(box(tag(1, WT_LEN)), encodeMessage(new Byte[]{})),
+        new Byte[]{}};
+
+    try (Table input = new Table.TestBuilder().column(rows).build();
+         ColumnVector result = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT).down()
+                     .addField(1, DType.STRUCT)
+                 .up()
+                 .build(),
+             false);
+         ColumnVector middle = result.getChildColumnView(0).copyToColumnVector();
+         ColumnVector empty = middle.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostMiddle = middle.copyToHost();
+         HostColumnVector hostEmpty = empty.copyToHost()) {
+      assertFalse(hostMiddle.isNull(0), "Present middle should produce a valid STRUCT");
+      assertFalse(hostEmpty.isNull(0), "Present empty child should produce a valid STRUCT<>");
+      assertFalse(hostMiddle.isNull(1), "Present middle should stay valid when empty is absent");
+      assertTrue(hostEmpty.isNull(1), "Missing empty child should produce a null STRUCT<>");
+      assertTrue(hostMiddle.isNull(2), "Missing middle should produce a null STRUCT");
+      assertTrue(hostEmpty.isNull(2), "Empty child should inherit missing middle nullability");
+    }
+  }
+
+  @Test
   void testNestedRepeatedWrongWireType_FailsFast() {
     // message Inner { repeated int32 x = 1; }
     // message Outer { Inner inner = 1; }

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -3003,6 +3003,54 @@ public class ProtobufTest {
   }
 
   @Test
+  void testMalformedChildlessNestedMessage_PermissiveReturnsNull() {
+    // message Empty {}
+    // message Outer { Empty inner = 1; }
+    // The childless Inner body contains an unknown field with a truncated varint value.
+    Byte[] malformedInner = concat(box(tag(1, WT_VARINT)), new Byte[]{(byte) 0x80});
+    Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(malformedInner));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT)
+                 .build(),
+             false);
+         ColumnVector inner = result.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostResult = result.copyToHost();
+         HostColumnVector hostInner = inner.copyToHost()) {
+      assertEquals(1, result.getNullCount(), "Malformed childless nested message should null row");
+      assertTrue(hostResult.isNull(0), "Malformed row should be null in permissive mode");
+      assertEquals(1, inner.getNullCount(), "Child null should reflect the top-level null row");
+      assertTrue(hostInner.isNull(0), "Childless nested struct should be null for malformed row");
+    }
+  }
+
+  @Test
+  void testChildlessNestedMessageWithWellFormedUnknownField_IsPresent() {
+    // message Empty {}
+    // message Outer { Empty inner = 1; }
+    // Unknown fields inside a childless message are still scanned and skipped.
+    Byte[] innerWithUnknown = concat(box(tag(7, WT_VARINT)), box(encodeVarint(123)));
+    Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(innerWithUnknown));
+
+    try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
+         ColumnVector result = Protobuf.decodeToStruct(
+             input.getColumn(0),
+             new ProtobufSchemaDescriptorBuilder()
+                 .addField(1, DType.STRUCT)
+                 .build(),
+             true);
+         ColumnVector inner = result.getChildColumnView(0).copyToColumnVector();
+         HostColumnVector hostInner = inner.copyToHost()) {
+      assertEquals(0, result.getNullCount(), "Well-formed unknown child field should pass");
+      assertEquals(0, inner.getNullCount(), "Present childless message should stay valid");
+      assertFalse(hostInner.isNull(0), "Present childless message should produce a valid STRUCT<>");
+    }
+  }
+
+  @Test
   void testRecursiveChildlessNestedMessage_PreservesPresence() {
     // message Empty {}
     // message Middle { Empty empty = 1; }

--- a/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/ProtobufTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -127,9 +128,22 @@ public class ProtobufTest {
     return out;
   }
 
+  /** Encode a length-delimited byte sequence: varint length prefix followed by the bytes. */
+  private static Byte[] encodeBytes(Byte[] bytes) {
+    return concat(box(encodeVarint(bytes.length)), bytes);
+  }
+
+  private static Byte[] encodeBytes(byte[] bytes) {
+    return encodeBytes(box(bytes));
+  }
+
+  private static Byte[] encodeString(String value) {
+    return encodeBytes(value.getBytes(StandardCharsets.UTF_8));
+  }
+
   /** Encode a length-delimited submessage: varint length prefix followed by the message bytes. */
   private static Byte[] encodeMessage(Byte[] messageBytes) {
-    return concat(box(encodeVarint(messageBytes.length)), messageBytes);
+    return encodeBytes(messageBytes);
   }
 
   private static void assertSingleNullStructRow(ColumnVector actual, String message) {
@@ -2679,8 +2693,8 @@ public class ProtobufTest {
     // message Outer { Inner inner = 1; }
     byte[] payload = new byte[]{1, 2, 3};
     Byte[] innerMessage = concat(
-        box(tag(1, WT_LEN)), box(encodeVarint(5)), box("alice".getBytes()),
-        box(tag(2, WT_LEN)), box(encodeVarint(payload.length)), box(payload));
+        box(tag(1, WT_LEN)), encodeString("alice"),
+        box(tag(2, WT_LEN)), encodeBytes(payload));
     Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(innerMessage));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
@@ -2732,11 +2746,11 @@ public class ProtobufTest {
     // message Outer  { Middle middle = 1; float score = 2; }
     Byte[] inner = concat(
         box(tag(1, WT_VARINT)), box(encodeVarint(7)),
-        box(tag(2, WT_LEN)), box(encodeVarint(3)), box("abc".getBytes()),
+        box(tag(2, WT_LEN)), encodeString("abc"),
         box(tag(3, WT_VARINT)), box(encodeVarint(1)));
     Byte[] middle = concat(
         box(tag(1, WT_LEN)), encodeMessage(inner),
-        box(tag(2, WT_VARINT)), box(encodeVarint(123L)));
+        box(tag(2, WT_VARINT)), box(encodeVarint(123)));
     Byte[] row = concat(
         box(tag(1, WT_LEN)), encodeMessage(middle),
         box(tag(2, WT_32BIT)), box(encodeFloat(1.25f)));
@@ -2779,18 +2793,19 @@ public class ProtobufTest {
     Byte[] innerInvalid = concat(
         box(tag(1, WT_VARINT)), box(encodeVarint(999)),
         box(tag(2, WT_VARINT)), box(encodeVarint(20)));
-    Byte[] row0 = concat(
-        box(tag(1, WT_VARINT)), box(encodeVarint(1)),
-        box(tag(2, WT_LEN)), encodeMessage(innerValid),
-        box(tag(3, WT_LEN)), box(encodeVarint(2)), box("ok".getBytes()));
-    Byte[] row1 = concat(
-        box(tag(1, WT_VARINT)), box(encodeVarint(2)),
-        box(tag(2, WT_LEN)), encodeMessage(innerInvalid),
-        box(tag(3, WT_LEN)), box(encodeVarint(3)), box("bad".getBytes()));
+    Byte[][] rows = new Byte[][]{
+        concat(
+            box(tag(1, WT_VARINT)), box(encodeVarint(1)),
+            box(tag(2, WT_LEN)), encodeMessage(innerValid),
+            box(tag(3, WT_LEN)), encodeString("ok")),
+        concat(
+            box(tag(1, WT_VARINT)), box(encodeVarint(2)),
+            box(tag(2, WT_LEN)), encodeMessage(innerInvalid),
+            box(tag(3, WT_LEN)), encodeString("bad"))};
     byte[][] enumNames = new byte[][]{
         "UNKNOWN".getBytes(), "OK".getBytes(), "BAD".getBytes()};
 
-    try (Table input = new Table.TestBuilder().column(row0, row1).build();
+    try (Table input = new Table.TestBuilder().column(rows).build();
          ColumnVector actual = Protobuf.decodeToStruct(
              input.getColumn(0),
              new ProtobufSchemaDescriptorBuilder()
@@ -2825,7 +2840,7 @@ public class ProtobufTest {
   void testRequiredFieldInsideNestedMessageMissing_Failfast() {
     // message Outer { Inner inner = 1; }
     // message Inner { required int32 id = 1; optional string note = 2; }
-    Byte[] inner = concat(box(tag(2, WT_LEN)), box(encodeVarint(4)), box("oops".getBytes()));
+    Byte[] inner = concat(box(tag(2, WT_LEN)), encodeString("oops"));
     Byte[] row = concat(box(tag(1, WT_LEN)), encodeMessage(inner));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build()) {
@@ -2848,10 +2863,10 @@ public class ProtobufTest {
   void testRequiredFieldInsideNestedMessageMissing_Permissive() {
     // message Outer { Inner inner = 1; string name = 2; }
     // message Inner { required int32 id = 1; optional string note = 2; }
-    Byte[] inner = concat(box(tag(2, WT_LEN)), box(encodeVarint(4)), box("oops".getBytes()));
+    Byte[] inner = concat(box(tag(2, WT_LEN)), encodeString("oops"));
     Byte[] row = concat(
         box(tag(1, WT_LEN)), encodeMessage(inner),
-        box(tag(2, WT_LEN)), box(encodeVarint(7)), box("outside".getBytes()));
+        box(tag(2, WT_LEN)), encodeString("outside"));
 
     try (Table input = new Table.TestBuilder().column(new Byte[][]{row}).build();
          ColumnVector actual = Protobuf.decodeToStruct(


### PR DESCRIPTION
## Description

This PR extends the protobuf JNI decoder for non-repeated nested messages.

It adds support for:

- nested string, bytes, and enum-as-string child fields
- nested string defaults and proto2 required-field checks
- recursive nested `STRUCT` children by computing grandchild parent locations on device
- depth-3 nested message decoding tests

Repeated children inside nested messages are intentionally still emitted as typed null `LIST`
columns. Repeated `MessageType` support remains out of scope for a follow-up PR.

## Validation

- `git diff --check`
- Verified touched protobuf C++ files do not contain raw `cudaMemcpyAsync`,
  `rmm::exec_policy(...)`, or single-argument `rmm::exec_policy_nosync(stream)` calls.