### PR TITLE
Reduce ORC DST rule probing complexity

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcDstRuleExtractor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcDstRuleExtractor.java
@@ -266,31 +266,34 @@ final class OrcDstRuleExtractor {
   }
 
   private static DstRule extractDstRuleByProbing(TimeZone tz, int refYear) {
+    DstTransitions transitions = findDstTransitionsByProbing(tz, refYear);
+    if (transitions == null || !transitions.hasBothTransitions()) {
+      return null;
+    }
+
+    return buildDstRuleFromProbedTransitions(tz, transitions);
+  }
+
+  private static DstTransitions findDstTransitionsByProbing(TimeZone tz, int refYear) {
     long janFirst = OrcTimezoneInfo.utcMillisForDate(refYear, 1, 1);
     long nextJanFirst = OrcTimezoneInfo.utcMillisForDate(refYear + 1, 1, 1);
 
-    long dstOnTransition = -1;
-    long dstOffTransition = -1;
     int initialOffset = tz.getOffset(janFirst - 1);
     int prevOffset = initialOffset;
     long step = 3_600_000L; // 1 hour
+    DstTransitions transitions = new DstTransitions(initialOffset);
 
     for (long ms = janFirst; ms < nextJanFirst; ms += step) {
       int curOffset = tz.getOffset(ms);
-      if (curOffset != prevOffset) {
-        long exactMs = OrcTimezoneInfo.binarySearchTransition(tz, ms - step, ms);
-        if (curOffset > prevOffset) {
-          // More than one DST-on transition in the same year would mean this
-          // year doesn't fit a SimpleTimeZone-style two-transition rule; let
-          // the caller fall back to extractDstRuleFromZoneRules.
-          if (dstOnTransition >= 0) return null;
-          dstOnTransition = exactMs;
-        } else {
-          if (dstOffTransition >= 0) return null;
-          dstOffTransition = exactMs;
-        }
-        prevOffset = curOffset;
+      if (curOffset == prevOffset) {
+        continue;
       }
+
+      long exactMs = OrcTimezoneInfo.binarySearchTransition(tz, ms - step, ms);
+      if (!transitions.recordTransition(prevOffset, curOffset, exactMs)) {
+        return null;
+      }
+      prevOffset = curOffset;
       // SimpleTimeZone-style zones have exactly two transitions per year.
       // Once both are recorded and the running offset is back to the year-
       // start standard offset, the remainder of the year is a no-op tail
@@ -298,19 +301,20 @@ final class OrcDstRuleExtractor {
       // change would correctly trigger the "more than one DST-on/off"
       // early-return above, so the only thing this break can skip is
       // wasted probes -- ~720-2200 calls per year on common DST zones.
-      if (dstOnTransition >= 0 && dstOffTransition >= 0 && prevOffset == initialOffset) {
+      if (transitions.hasCompleteRuleAtOffset(prevOffset)) {
         break;
       }
     }
 
-    if (dstOnTransition < 0 || dstOffTransition < 0) {
-      return null;
-    }
+    return transitions;
+  }
 
+  private static DstRule buildDstRuleFromProbedTransitions(TimeZone tz,
+      DstTransitions transitions) {
     DstRule rule = new DstRule();
     rule.dstSavings = tz.getDSTSavings();
 
-    int[] startFields = decodeTransition(dstOnTransition, tz.getRawOffset());
+    int[] startFields = decodeTransition(transitions.dstOnTransition, tz.getRawOffset());
     rule.startMonth = startFields[0];
     rule.startDay = startFields[1];
     rule.startDayOfWeek = startFields[2];
@@ -319,7 +323,7 @@ final class OrcDstRuleExtractor {
     rule.startTimeMode = DstRule.TIME_MODE_STANDARD;
     rule.startMode = startFields[4];
 
-    int[] endFields = decodeTransition(dstOffTransition, tz.getRawOffset());
+    int[] endFields = decodeTransition(transitions.dstOffTransition, tz.getRawOffset());
     rule.endMonth = endFields[0];
     rule.endDay = endFields[1];
     rule.endDayOfWeek = endFields[2];
@@ -328,6 +332,53 @@ final class OrcDstRuleExtractor {
     rule.endMode = endFields[4];
 
     return rule;
+  }
+
+  private static final class DstTransitions {
+    private static final long MISSING_TRANSITION = -1;
+
+    private final int initialOffset;
+    private long dstOnTransition = MISSING_TRANSITION;
+    private long dstOffTransition = MISSING_TRANSITION;
+
+    private DstTransitions(int initialOffset) {
+      this.initialOffset = initialOffset;
+    }
+
+    private boolean recordTransition(int prevOffset, int curOffset, long exactMs) {
+      if (curOffset > prevOffset) {
+        return recordDstOnTransition(exactMs);
+      }
+      return recordDstOffTransition(exactMs);
+    }
+
+    private boolean recordDstOnTransition(long exactMs) {
+      // More than one DST-on transition in the same year would mean this year
+      // doesn't fit a SimpleTimeZone-style two-transition rule; let the caller
+      // fall back to extractDstRuleFromZoneRules.
+      if (dstOnTransition != MISSING_TRANSITION) {
+        return false;
+      }
+      dstOnTransition = exactMs;
+      return true;
+    }
+
+    private boolean recordDstOffTransition(long exactMs) {
+      if (dstOffTransition != MISSING_TRANSITION) {
+        return false;
+      }
+      dstOffTransition = exactMs;
+      return true;
+    }
+
+    private boolean hasCompleteRuleAtOffset(int offset) {
+      return hasBothTransitions() && offset == initialOffset;
+    }
+
+    private boolean hasBothTransitions() {
+      return dstOnTransition != MISSING_TRANSITION
+          && dstOffTransition != MISSING_TRANSITION;
+    }
   }
 
   /**

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -725,6 +725,61 @@ public class OrcTimezoneInfoTest {
   }
 
   @Test
+  void testExtractDstRuleByProbingReturnsNullOnMultipleDstOffTransitions() {
+    // extractDstRuleByProbing returns null when probing finds more than one
+    // offset-decreasing transition in a year. This is the symmetric counterpart
+    // of testExtractDstRuleByProbingReturnsNullOnMultipleDstOnTransitions: it
+    // exercises the second-DST-off early-return in DstTransitions
+    // .recordDstOffTransition, which no other test reaches.
+    //
+    // This synthetic TimeZone springs forward once (March 2nd Sunday) and falls
+    // back twice (July 1st Sunday and November 1st Sunday). The first fall-back
+    // records dstOffTransition; the second trips the "more than one DST-off"
+    // guard, so recordTransition returns false and probing returns null. The
+    // ZoneRules supplies no recurring transition rules, so Path A also returns
+    // null (empty getTransitionRules early-out). The terminal "Failed to
+    // extract" IllegalStateException confirms probing returned null due to the
+    // multiple-DST-off guard rather than some other reason.
+    TimeZone tz = new TimeZone() {
+      @Override public int getOffset(long instant) {
+        int year = LocalDate.ofEpochDay(Math.floorDiv(instant, 86_400_000L)).getYear();
+        long forward = nthDayOfWeekUtcMs(year, Month.MARCH, DayOfWeek.SUNDAY, 2) + 2 * 3_600_000L;
+        long back1 = nthDayOfWeekUtcMs(year, Month.JULY, DayOfWeek.SUNDAY, 1) + 1 * 3_600_000L;
+        long back2 = nthDayOfWeekUtcMs(year, Month.NOVEMBER, DayOfWeek.SUNDAY, 1) + 1 * 3_600_000L;
+        if (instant >= forward && instant < back1) return 2 * 3_600_000;
+        if (instant >= back1 && instant < back2) return 1 * 3_600_000;
+        return 0;
+      }
+      @Override public int getOffset(int era, int year, int month, int day, int dow, int ms) {
+        return 0;
+      }
+      @Override public int getRawOffset() { return 0; }
+      @Override public void setRawOffset(int offsetMillis) {}
+      @Override public boolean useDaylightTime() { return true; }
+      @Override public int getDSTSavings() { return 2 * 3_600_000; }
+      @Override public boolean inDaylightTime(Date date) { return false; }
+    };
+    tz.setID("Synthetic/MultipleDstOff");
+    ZoneOffset base = ZoneOffset.UTC;
+    // A single historical transition is enough to make rules.isFixedOffset()
+    // return false (without it the entry-point short-circuit at the top of
+    // extractDstRule would return null before probing runs). The
+    // transitionRules list stays empty so Path A also returns null on the
+    // "empty getTransitionRules()" early-out, leaving the terminal
+    // "Failed to extract" throw as the expected outcome.
+    ZoneOffsetTransition historicalTransition = ZoneOffsetTransition.of(
+        LocalDateTime.of(1900, 1, 1, 0, 0), ZoneOffset.ofHours(-1), base);
+    ZoneRules rules = ZoneRules.of(base, base,
+        Collections.emptyList(),
+        Collections.singletonList(historicalTransition),
+        Collections.emptyList());
+    IllegalStateException ex = assertThrows(IllegalStateException.class,
+        () -> OrcDstRuleExtractor.extractDstRule("Synthetic/MultipleDstOff", tz, rules));
+    assertTrue(ex.getMessage().contains("Failed to extract"),
+        "expected 'Failed to extract' in terminal throw: " + ex.getMessage());
+  }
+
+  @Test
   void testExtractDstRuleViaZoneRulesFallback() {
     // Path A (ZoneRules fallback) success scenario. The custom TimeZone
     // observes a real +2h DST window but reports getDSTSavings()==+1h.


### PR DESCRIPTION
## Summary

Refactor `extractDstRuleByProbing` to reduce cognitive complexity while preserving the original probing behavior.

The transition scan now delegates transition collection to `findDstTransitionsByProbing`, keeps DST-on/off transition state in a small helper object, and builds the final `DstRule` after both transitions are found.

## Details

- Preserve the original one-hour probing loop and binary search for exact transition instants.
- Preserve duplicate DST-on / DST-off detection and fallback behavior by returning `null`.
- Preserve early break once both transitions are found and the running offset returns to the initial offset.
- Reduce the maximum method cognitive complexity below the threshold of 15.

## Validation

Ran:

```bash
./build/run-in-docker mvn -Dsubmodule.check.skip=true -Dtest=OrcTimezoneInfoTest test
```

Result:

```text
OrcTimezoneInfoTest: Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
```
