### PR TITLE
Quote non-finite float values for JSON casts

### DIFF
--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -117,7 +117,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toFloat(
 
 JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloat(JNIEnv* env,
                                                                                jclass,
-                                                                               jlong input_column)
+                                                                               jlong input_column,
+                                                                               jboolean json_string)
 {
   JNI_NULL_CHECK(env, input_column, "input column is null", 0);
 
@@ -127,7 +128,10 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloat(J
 
     auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
     return cudf::jni::release_as_jlong(
-      spark_rapids_jni::float_to_string(cv, cudf::get_default_stream()));
+      spark_rapids_jni::float_to_string(cv,
+                                        json_string,
+                                        cudf::get_default_stream(),
+                                        cudf::get_current_device_resource_ref()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -127,11 +127,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_fromFloat(J
     cudf::jni::auto_set_device(env);
 
     auto const& cv = *reinterpret_cast<cudf::column_view const*>(input_column);
-    return cudf::jni::release_as_jlong(
-      spark_rapids_jni::float_to_string(cv,
-                                        json_string,
-                                        cudf::get_default_stream(),
-                                        cudf::get_current_device_resource_ref()));
+    return cudf::jni::release_as_jlong(spark_rapids_jni::float_to_string(
+      cv, json_string, cudf::get_default_stream(), cudf::get_current_device_resource_ref()));
   }
   CATCH_CAST_EXCEPTION(env, 0);
 }

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -31,7 +31,7 @@ namespace spark_rapids_jni {
 namespace detail {
 namespace {
 
-template <typename FloatType>
+template <typename FloatType, bool json_string>
 struct float_to_string_fn {
   cudf::column_device_view d_floats;
   cudf::size_type* d_sizes;
@@ -43,7 +43,7 @@ struct float_to_string_fn {
     auto const value        = d_floats.element<FloatType>(idx);
     bool constexpr is_float = cuda::std::is_same_v<FloatType, float>;
     return static_cast<cudf::size_type>(
-      ftos_converter::compute_ftos_size(static_cast<double>(value), is_float));
+      ftos_converter::compute_ftos_size(static_cast<double>(value), is_float, json_string));
   }
 
   __device__ void float_to_string(cudf::size_type idx) const
@@ -51,7 +51,7 @@ struct float_to_string_fn {
     auto const value        = d_floats.element<FloatType>(idx);
     bool constexpr is_float = cuda::std::is_same_v<FloatType, float>;
     auto const output       = d_chars + d_offsets[idx];
-    ftos_converter::float_to_string(static_cast<double>(value), is_float, output);
+    ftos_converter::float_to_string(static_cast<double>(value), is_float, output, json_string);
   }
 
   __device__ void operator()(cudf::size_type idx) const
@@ -73,6 +73,7 @@ struct float_to_string_fn {
  *
  * The template function declaration ensures only float types are allowed.
  */
+template <bool json_string>
 struct dispatch_float_to_string_fn {
   template <typename FloatType, CUDF_ENABLE_IF(cuda::std::is_floating_point_v<FloatType>)>
   std::unique_ptr<cudf::column> operator()(cudf::column_view const& floats,
@@ -85,7 +86,7 @@ struct dispatch_float_to_string_fn {
     auto const input_ptr = cudf::column_device_view::create(floats, stream);
 
     auto [offsets, chars] = cudf::strings::detail::make_strings_children(
-      float_to_string_fn<FloatType>{*input_ptr}, strings_count, stream, mr);
+      float_to_string_fn<FloatType, json_string>{*input_ptr}, strings_count, stream, mr);
 
     return make_strings_column(strings_count,
                                std::move(offsets),
@@ -108,10 +109,14 @@ struct dispatch_float_to_string_fn {
 
 // This will convert all float column types into a strings column.
 std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
+                                              bool json_string,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
-  return type_dispatcher(floats.type(), dispatch_float_to_string_fn{}, floats, stream, mr);
+  return json_string
+           ? type_dispatcher(floats.type(), dispatch_float_to_string_fn<true>{}, floats, stream, mr)
+           : type_dispatcher(
+               floats.type(), dispatch_float_to_string_fn<false>{}, floats, stream, mr);
 }
 
 }  // namespace detail
@@ -121,8 +126,16 @@ std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr)
 {
+  return float_to_string(floats, false, stream, mr);
+}
+
+std::unique_ptr<cudf::column> float_to_string(cudf::column_view const& floats,
+                                              bool json_string,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::device_async_resource_ref mr)
+{
   SRJ_FUNC_RANGE();
-  return detail::float_to_string(floats, stream, mr);
+  return detail::float_to_string(floats, json_string, stream, mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/cast_float_to_string.cu
+++ b/src/main/cpp/src/cast_float_to_string.cu
@@ -40,18 +40,16 @@ struct float_to_string_fn {
 
   __device__ cudf::size_type compute_output_size(cudf::size_type idx) const
   {
-    auto const value        = d_floats.element<FloatType>(idx);
-    bool constexpr is_float = cuda::std::is_same_v<FloatType, float>;
+    auto const value = d_floats.element<FloatType>(idx);
     return static_cast<cudf::size_type>(
-      ftos_converter::compute_ftos_size(static_cast<double>(value), is_float, json_string));
+      ftos_converter::compute_ftos_size<FloatType, json_string>(value));
   }
 
   __device__ void float_to_string(cudf::size_type idx) const
   {
-    auto const value        = d_floats.element<FloatType>(idx);
-    bool constexpr is_float = cuda::std::is_same_v<FloatType, float>;
-    auto const output       = d_chars + d_offsets[idx];
-    ftos_converter::float_to_string(static_cast<double>(value), is_float, output, json_string);
+    auto const value  = d_floats.element<FloatType>(idx);
+    auto const output = d_chars + d_offsets[idx];
+    ftos_converter::float_to_string<FloatType, json_string>(value, output);
   }
 
   __device__ void operator()(cudf::size_type idx) const

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -79,7 +79,7 @@ std::unique_ptr<cudf::column> string_to_integer(
   bool ansi_mode,
   bool strip,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert a string column into an decimal column.
@@ -101,7 +101,7 @@ std::unique_ptr<cudf::column> string_to_decimal(
   bool ansi_mode,
   bool strip,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Convert a string column into an float column.
@@ -119,18 +119,18 @@ std::unique_ptr<cudf::column> string_to_float(
   cudf::strings_column_view const& string_col,
   bool ansi_mode,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> format_float(
   cudf::column_view const& input,
   int const digits,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 [[nodiscard]] std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
@@ -141,12 +141,12 @@ std::unique_ptr<cudf::column> float_to_string(
 std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> long_to_binary_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Parse a timestamp string column into an intermediate struct column.

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -132,6 +132,12 @@ std::unique_ptr<cudf::column> float_to_string(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
+std::unique_ptr<cudf::column> float_to_string(
+  cudf::column_view const& input,
+  bool json_string,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+
 std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   cudf::column_view const& input,
   rmm::cuda_stream_view stream,

--- a/src/main/cpp/src/cast_string.hpp
+++ b/src/main/cpp/src/cast_string.hpp
@@ -132,11 +132,11 @@ std::unique_ptr<cudf::column> float_to_string(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
 
-std::unique_ptr<cudf::column> float_to_string(
+[[nodiscard]] std::unique_ptr<cudf::column> float_to_string(
   cudf::column_view const& input,
   bool json_string,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 std::unique_ptr<cudf::column> decimal_to_non_ansi_string(
   cudf::column_view const& input,

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1156,35 +1156,21 @@ __device__ inline int copy_special_str_json(char* const result,
                                             bool const exponent,
                                             bool const mantissa)
 {
-  if (mantissa) {
-    memcpy(result, "\"NaN\"", 5);
-    return 5;
-  }
-  if (exponent) {
-    if (sign) {
-      memcpy(result, "\"-Infinity\"", 11);
-      return 11;
-    } else {
-      memcpy(result, "\"Infinity\"", 10);
-      return 10;
-    }
-  }
-  if (sign) {
-    memcpy(result, "-0.0", 4);
-    return 4;
-  } else {
-    memcpy(result, "0.0", 3);
-    return 3;
-  }
+  bool const quote = mantissa || exponent;
+  int const offset  = quote ? 1 : 0;
+  int const quotes  = quote ? 2 : 0;
+  if (quote) { result[0] = '"'; }
+  int const length = copy_special_str(result + offset, sign, exponent, mantissa);
+  if (quote) { result[offset + length] = '"'; }
+  return length + quotes;
 }
 
 __device__ inline int special_str_size_json(bool const sign,
                                             bool const exponent,
                                             bool const mantissa)
 {
-  if (mantissa) { return 5; }
-  if (exponent) { return sign + 10; }
-  return sign + 3;
+  int const quotes = (mantissa || exponent) ? 2 : 0;
+  return special_str_size(sign, exponent, mantissa) + quotes;
 }
 
 __device__ inline int d2s_buffered_n_json(double f, char* result)

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1226,7 +1226,7 @@ __device__ inline int compute_f2s_size_json(float value)
 template <typename FloatType, bool json_string = false>
 __device__ inline int compute_ftos_size(FloatType value)
 {
-  static_assert(cuda::std::is_floating_point_v<FloatType>);
+  static_assert(cuda::std::is_same_v<FloatType, float> || cuda::std::is_same_v<FloatType, double>);
   if constexpr (cuda::std::is_same_v<FloatType, float>) {
     if constexpr (json_string) {
       return compute_f2s_size_json(value);
@@ -1234,11 +1234,10 @@ __device__ inline int compute_ftos_size(FloatType value)
       return compute_f2s_size(value);
     }
   } else {
-    auto const promoted_value = static_cast<double>(value);
     if constexpr (json_string) {
-      return compute_d2s_size_json(promoted_value);
+      return compute_d2s_size_json(value);
     } else {
-      return compute_d2s_size(promoted_value);
+      return compute_d2s_size(value);
     }
   }
 }
@@ -1246,7 +1245,7 @@ __device__ inline int compute_ftos_size(FloatType value)
 template <typename FloatType, bool json_string = false>
 __device__ inline int float_to_string(FloatType value, char* output)
 {
-  static_assert(cuda::std::is_floating_point_v<FloatType>);
+  static_assert(cuda::std::is_same_v<FloatType, float> || cuda::std::is_same_v<FloatType, double>);
   if constexpr (cuda::std::is_same_v<FloatType, float>) {
     if constexpr (json_string) {
       return f2s_buffered_n_json(value, output);
@@ -1254,11 +1253,10 @@ __device__ inline int float_to_string(FloatType value, char* output)
       return f2s_buffered_n(value, output);
     }
   } else {
-    auto const promoted_value = static_cast<double>(value);
     if constexpr (json_string) {
-      return d2s_buffered_n_json(promoted_value, output);
+      return d2s_buffered_n_json(value, output);
     } else {
-      return d2s_buffered_n(promoted_value, output);
+      return d2s_buffered_n(value, output);
     }
   }
 }

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1156,12 +1156,15 @@ __device__ inline int copy_special_str_json(char* const result,
                                             bool const exponent,
                                             bool const mantissa)
 {
-  bool const quote = mantissa || exponent;
-  int const offset  = quote ? 1 : 0;
-  int const quotes  = quote ? 2 : 0;
-  if (quote) { result[0] = '"'; }
-  int const length = copy_special_str(result + offset, sign, exponent, mantissa);
-  if (quote) { result[offset + length] = '"'; }
+  int offset = 0;
+  int quotes = 0;
+  if (mantissa || exponent) {
+    result[0] = '"';
+    offset    = 1;
+    quotes    = 2;
+  }
+  int length = copy_special_str(result + offset, sign, exponent, mantissa);
+  if (mantissa || exponent) { result[offset + length] = '"'; }
   return length + quotes;
 }
 

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1226,7 +1226,7 @@ __device__ inline int compute_f2s_size_json(float value)
 template <typename FloatType, bool json_string = false>
 __device__ inline int compute_ftos_size(FloatType value)
 {
-  static_assert(cuda::std::is_same_v<FloatType, float> || cuda::std::is_same_v<FloatType, double>);
+  static_assert(cuda::std::is_floating_point_v<FloatType>);
   if constexpr (cuda::std::is_same_v<FloatType, float>) {
     if constexpr (json_string) {
       return compute_f2s_size_json(value);
@@ -1234,10 +1234,11 @@ __device__ inline int compute_ftos_size(FloatType value)
       return compute_f2s_size(value);
     }
   } else {
+    auto const promoted_value = static_cast<double>(value);
     if constexpr (json_string) {
-      return compute_d2s_size_json(value);
+      return compute_d2s_size_json(promoted_value);
     } else {
-      return compute_d2s_size(value);
+      return compute_d2s_size(promoted_value);
     }
   }
 }
@@ -1245,7 +1246,7 @@ __device__ inline int compute_ftos_size(FloatType value)
 template <typename FloatType, bool json_string = false>
 __device__ inline int float_to_string(FloatType value, char* output)
 {
-  static_assert(cuda::std::is_same_v<FloatType, float> || cuda::std::is_same_v<FloatType, double>);
+  static_assert(cuda::std::is_floating_point_v<FloatType>);
   if constexpr (cuda::std::is_same_v<FloatType, float>) {
     if constexpr (json_string) {
       return f2s_buffered_n_json(value, output);
@@ -1253,10 +1254,11 @@ __device__ inline int float_to_string(FloatType value, char* output)
       return f2s_buffered_n(value, output);
     }
   } else {
+    auto const promoted_value = static_cast<double>(value);
     if constexpr (json_string) {
-      return d2s_buffered_n_json(value, output);
+      return d2s_buffered_n_json(promoted_value, output);
     } else {
-      return d2s_buffered_n(value, output);
+      return d2s_buffered_n(promoted_value, output);
     }
   }
 }

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1156,7 +1156,10 @@ __device__ inline int copy_special_str_json(char* const result,
                                             bool const exponent,
                                             bool const mantissa)
 {
-  // no NaN in json
+  if (mantissa) {
+    memcpy(result, "\"NaN\"", 5);
+    return 5;
+  }
   if (exponent) {
     if (sign) {
       memcpy(result, "\"-Infinity\"", 11);
@@ -1179,7 +1182,7 @@ __device__ inline int special_str_size_json(bool const sign,
                                             bool const exponent,
                                             bool const mantissa)
 {
-  // no NaN in json
+  if (mantissa) { return 5; }
   if (exponent) { return sign + 10; }
   return sign + 3;
 }
@@ -1192,6 +1195,14 @@ __device__ inline int d2s_buffered_n_json(double f, char* result)
   return to_chars(v, sign, result);
 }
 
+__device__ inline int f2s_buffered_n_json(float f, char* result)
+{
+  bool sign = false, special = false;
+  floating_decimal_32 v = f2d(f, sign, special);
+  if (special) { return copy_special_str_json(result, sign, v.exponent, v.mantissa); }
+  return to_chars(v, sign, result);
+}
+
 __device__ inline int compute_d2s_size_json(double value)
 {
   bool sign = false, special = false;
@@ -1200,25 +1211,34 @@ __device__ inline int compute_d2s_size_json(double value)
   return d2s_size(v, sign);
 }
 
+__device__ inline int compute_f2s_size_json(float value)
+{
+  bool sign = false, special = false;
+  floating_decimal_32 v = f2d(value, sign, special);
+  if (special) { return special_str_size_json(sign, v.exponent, v.mantissa); }
+  return f2s_size(v, sign);
+}
+
 }  // namespace
 
 //===== APIs =====
 
-__device__ inline int compute_ftos_size(double value, bool is_float)
+__device__ inline int compute_ftos_size(double value, bool is_float, bool json_string = false)
 {
   if (is_float) {
-    return compute_f2s_size(value);
+    return json_string ? compute_f2s_size_json(value) : compute_f2s_size(value);
   } else {
-    return compute_d2s_size(value);
+    return json_string ? compute_d2s_size_json(value) : compute_d2s_size(value);
   }
 }
 
-__device__ inline int float_to_string(double value, bool is_float, char* output)
+__device__ inline int float_to_string(
+  double value, bool is_float, char* output, bool json_string = false)
 {
   if (is_float) {
-    return f2s_buffered_n(value, output);
+    return json_string ? f2s_buffered_n_json(value, output) : f2s_buffered_n(value, output);
   } else {
-    return d2s_buffered_n(value, output);
+    return json_string ? d2s_buffered_n_json(value, output) : d2s_buffered_n(value, output);
   }
 }
 

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1223,22 +1223,41 @@ __device__ inline int compute_f2s_size_json(float value)
 
 //===== APIs =====
 
-__device__ inline int compute_ftos_size(double value, bool is_float, bool json_string = false)
+template <typename FloatType, bool json_string = false>
+__device__ inline int compute_ftos_size(FloatType value)
 {
-  if (is_float) {
-    return json_string ? compute_f2s_size_json(value) : compute_f2s_size(value);
+  static_assert(cuda::std::is_same_v<FloatType, float> || cuda::std::is_same_v<FloatType, double>);
+  if constexpr (cuda::std::is_same_v<FloatType, float>) {
+    if constexpr (json_string) {
+      return compute_f2s_size_json(value);
+    } else {
+      return compute_f2s_size(value);
+    }
   } else {
-    return json_string ? compute_d2s_size_json(value) : compute_d2s_size(value);
+    if constexpr (json_string) {
+      return compute_d2s_size_json(value);
+    } else {
+      return compute_d2s_size(value);
+    }
   }
 }
 
-__device__ inline int float_to_string(
-  double value, bool is_float, char* output, bool json_string = false)
+template <typename FloatType, bool json_string = false>
+__device__ inline int float_to_string(FloatType value, char* output)
 {
-  if (is_float) {
-    return json_string ? f2s_buffered_n_json(value, output) : f2s_buffered_n(value, output);
+  static_assert(cuda::std::is_same_v<FloatType, float> || cuda::std::is_same_v<FloatType, double>);
+  if constexpr (cuda::std::is_same_v<FloatType, float>) {
+    if constexpr (json_string) {
+      return f2s_buffered_n_json(value, output);
+    } else {
+      return f2s_buffered_n(value, output);
+    }
   } else {
-    return json_string ? d2s_buffered_n_json(value, output) : d2s_buffered_n(value, output);
+    if constexpr (json_string) {
+      return d2s_buffered_n_json(value, output);
+    } else {
+      return d2s_buffered_n(value, output);
+    }
   }
 }
 

--- a/src/main/cpp/src/ftos_converter.cuh
+++ b/src/main/cpp/src/ftos_converter.cuh
@@ -1156,15 +1156,12 @@ __device__ inline int copy_special_str_json(char* const result,
                                             bool const exponent,
                                             bool const mantissa)
 {
-  int offset = 0;
-  int quotes = 0;
-  if (mantissa || exponent) {
-    result[0] = '"';
-    offset    = 1;
-    quotes    = 2;
-  }
-  int length = copy_special_str(result + offset, sign, exponent, mantissa);
-  if (mantissa || exponent) { result[offset + length] = '"'; }
+  bool const quote = mantissa || exponent;
+  int const offset = quote ? 1 : 0;
+  int const quotes = quote ? 2 : 0;
+  if (quote) { result[0] = '"'; }
+  int const length = copy_special_str(result + offset, sign, exponent, mantissa);
+  if (quote) { result[offset + length] = '"'; }
   return length + quotes;
 }
 

--- a/src/main/cpp/tests/cast_float_to_string.cpp
+++ b/src/main/cpp/tests/cast_float_to_string.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,48 @@ TEST_F(FloatToStringTests, FromFloats64)
                                                            "NaN",
                                                            "8.395422232327942E11",
                                                            "-0.0"};
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected, verbosity);
+}
+
+TEST_F(FloatToStringTests, FromFloats32ToJsonString)
+{
+  auto const floats =
+    cudf::test::fixed_width_column_wrapper<float>{100.0f,
+                                                  -4.0f,
+                                                  std::numeric_limits<float>::quiet_NaN(),
+                                                  std::numeric_limits<float>::infinity(),
+                                                  -std::numeric_limits<float>::infinity(),
+                                                  -0.0f};
+
+  auto results = spark_rapids_jni::float_to_string(floats,
+                                                   /*json_string=*/true,
+                                                   cudf::get_default_stream(),
+                                                   cudf::get_current_device_resource_ref());
+
+  auto const expected = cudf::test::strings_column_wrapper{
+    "100.0", "-4.0", "\"NaN\"", "\"Infinity\"", "\"-Infinity\"", "-0.0"};
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected, verbosity);
+}
+
+TEST_F(FloatToStringTests, FromFloats64ToJsonString)
+{
+  auto const floats =
+    cudf::test::fixed_width_column_wrapper<double>{100.0d,
+                                                   -4.0d,
+                                                   std::numeric_limits<double>::quiet_NaN(),
+                                                   std::numeric_limits<double>::infinity(),
+                                                   -std::numeric_limits<double>::infinity(),
+                                                   -0.0d};
+
+  auto results = spark_rapids_jni::float_to_string(floats,
+                                                   /*json_string=*/true,
+                                                   cudf::get_default_stream(),
+                                                   cudf::get_current_device_resource_ref());
+
+  auto const expected = cudf::test::strings_column_wrapper{
+    "100.0", "-4.0", "\"NaN\"", "\"Infinity\"", "\"-Infinity\"", "-0.0"};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected, verbosity);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -101,7 +101,18 @@ public class CastStrings {
    * @return the converted column
    */
   public static ColumnVector fromFloat(ColumnView cv) {
-    return new ColumnVector(fromFloat(cv.getNativeView()));
+    return fromFloat(cv, false);
+  }
+
+  /**
+   * Convert a float column to a string column.
+   *
+   * @param cv the column data to process
+   * @param jsonString true if non-finite values should be emitted as JSON strings.
+   * @return the converted column
+   */
+  public static ColumnVector fromFloat(ColumnView cv, boolean jsonString) {
+    return new ColumnVector(fromFloat(cv.getNativeView(), jsonString));
   }
 
   /**
@@ -377,7 +388,7 @@ public class CastStrings {
   private static native long toFloat(long nativeColumnView, boolean ansi_enabled, int dtype);
   private static native long fromDecimal(long nativeColumnView);
   private static native long fromFloatWithFormat(long nativeColumnView, int digits);
-  private static native long fromFloat(long nativeColumnView);
+  private static native long fromFloat(long nativeColumnView, boolean jsonString);
   private static native long fromLongToBinary(long nativeColumnView);
   private static native long toIntegersWithBase(long nativeColumnView, int base,
     boolean ansiEnabled, int dtype);

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -108,7 +108,7 @@ public class CastStrings {
    * Convert a float column to a string column.
    *
    * @param cv the column data to process
-   * @param jsonString true if non-finite values should be emitted as JSON strings.
+   * @param jsonString true if non-finite values should include JSON quotes, e.g. {@code "NaN"}.
    * @return the converted column
    */
   public static ColumnVector fromFloat(ColumnView cv, boolean jsonString) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/CastStrings.java
@@ -95,7 +95,7 @@ public class CastStrings {
   }
 
   /**
-   * Convert a float column to a string column.
+   * Convert a float or double column to a string column.
    *
    * @param cv the column data to process
    * @return the converted column
@@ -105,7 +105,7 @@ public class CastStrings {
   }
 
   /**
-   * Convert a float column to a string column.
+   * Convert a float or double column to a string column.
    *
    * @param cv the column data to process
    * @param jsonString true if non-finite values should include JSON quotes, e.g. {@code "NaN"}.

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -427,6 +427,17 @@ public class CastStringsTest {
     }
   }
 
+  @Test
+  void castFromFloatToJsonStringTest() {
+    try (ColumnVector input = ColumnVector.fromBoxedFloats(100.0f, -4.0f, Float.NaN,
+             Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, -0.0f, null);
+         ColumnVector result = CastStrings.fromFloat(input, true);
+         ColumnVector expected = ColumnVector.fromStrings("100.0", "-4.0", "\"NaN\"",
+             "\"Infinity\"", "\"-Infinity\"", "-0.0", null)) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
   private void convTestInternal(Table input, Table expected, int fromBase) {
     try(
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), fromBase, false,

--- a/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/CastStringsTest.java
@@ -438,6 +438,17 @@ public class CastStringsTest {
     }
   }
 
+  @Test
+  void castFromDoubleToJsonStringTest() {
+    try (ColumnVector input = ColumnVector.fromBoxedDoubles(100.0, -4.0, Double.NaN,
+             Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, -0.0, null);
+         ColumnVector result = CastStrings.fromFloat(input, true);
+         ColumnVector expected = ColumnVector.fromStrings("100.0", "-4.0", "\"NaN\"",
+             "\"Infinity\"", "\"-Infinity\"", "-0.0", null)) {
+      AssertUtils.assertColumnsAreEqual(expected, result);
+    }
+  }
+
   private void convTestInternal(Table input, Table expected, int fromBase) {
     try(
       ColumnVector intCol = CastStrings.toIntegersWithBase(input.getColumn(0), fromBase, false,


### PR DESCRIPTION
## Summary
- Add a JSON mode to the native float-to-string conversion path.
- Quote `NaN`, `Infinity`, and `-Infinity` when Spark JSON serialization casts float/double values.
- Keep the existing float-to-string cast behavior on the default path.

## Problem
Spark JSON serialization does not use the same textual representation as a regular float-to-string cast for non-finite floating point values.

For `to_json`, Spark emits non-finite float and double values as JSON strings, for example `"NaN"`, `"Infinity"`, and `"-Infinity"`. The existing JNI float-to-string path emits the regular cast strings without JSON quoting. When cudf-spark routes `to_json` through that path, GPU output can produce bare `NaN`/`Infinity` tokens instead of matching Spark's JSON output.

## Fix
This PR adds an explicit JSON mode to the native float-to-string conversion API. The default path remains unchanged for normal casts, while the JSON path quotes non-finite values so cudf-spark can use it from `to_json` without adding a per-row Spark-side workaround.

Contributes to NVIDIA/cudf-spark#15118.

