### PR TITLE
Mount libcudf kernel cache in Docker builds

### DIFF
--- a/build/run-in-docker
+++ b/build/run-in-docker
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,9 +47,10 @@ fi
 DOCKER_RUN_EXTRA_ARGS=${DOCKER_RUN_EXTRA_ARGS:-""}
 LOCAL_CCACHE_DIR=${LOCAL_CCACHE_DIR:-"$HOME/.ccache"}
 LOCAL_MAVEN_REPO=${LOCAL_MAVEN_REPO:-"$HOME/.m2/repository"}
+LOCAL_LIBCUDF_KERNEL_CACHE_DIR=${LOCAL_LIBCUDF_KERNEL_CACHE_DIR:-${LIBCUDF_KERNEL_CACHE_PATH:-"$HOME/.libcudf"}}
 
 # ensure directories exist
-mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO"
+mkdir -p "$LOCAL_CCACHE_DIR" "$LOCAL_MAVEN_REPO" "$LOCAL_LIBCUDF_KERNEL_CACHE_DIR"
 
 echo "Building docker image for CICD environment..."
 JNI_DOCKER_CICD_IMAGE="spark-rapids-jni-build:${CUDA_VERSION}-rockylinux${OS_RELEASE}"
@@ -107,6 +108,7 @@ RW_SRC=(
   "$WORKDIR"
   "$LOCAL_CCACHE_DIR"
   "$LOCAL_MAVEN_REPO"
+  "$LOCAL_LIBCUDF_KERNEL_CACHE_DIR"
 )
 for (( i=0; i<${#RW_SRC[@]}; i++)); do
   MNT_ARGS+=(--mount "type=bind,src=${RW_SRC[$i]},dst=${RW_SRC[$i]}")
@@ -122,6 +124,7 @@ $DOCKER_CMD run $DOCKER_GPU_OPTS $DOCKER_RUN_EXTRA_ARGS -u $(id -u):$(id -g) --r
   -e CMAKE_CXX_LINKER_LAUNCHER="ccache" \
   -e CMAKE_GENERATOR \
   -e CUDA_VISIBLE_DEVICES \
+  -e LIBCUDF_KERNEL_CACHE_PATH="$LOCAL_LIBCUDF_KERNEL_CACHE_DIR" \
   -e PARALLEL_LEVEL \
   -e VERBOSE \
   -e TZ=${TZ} \


### PR DESCRIPTION
## Summary
- Mount a host-side libcudf kernel cache directory in the Docker build wrapper.
- Pass `LIBCUDF_KERNEL_CACHE_PATH` into the container so LIBRTCX can create `rtcx_cache` in a writable location.
- Allow the cache directory to be overridden through `LOCAL_LIBCUDF_KERNEL_CACHE_DIR` or `LIBCUDF_KERNEL_CACHE_PATH`.

## Problem
The standard local Docker build/test workflow can currently fail Java tests after the cuDF submodule picked up the LIBRTCX cache path.

The container runs as the host UID/GID and sees the host home path through the mounted passwd/group files, but `build/run-in-docker` did not mount a writable libcudf kernel cache directory. When Java tests exercise compiled expressions, LIBRTCX can try to create `$HOME/.libcudf/rtcx_cache` inside the container filesystem and fail with permission denied.

Example failure:

```text
CudfException: filesystem error: cannot create directories: Permission denied [/home/user/.libcudf/rtcx_cache]
```

## Fix
The wrapper now creates and mounts a host-side libcudf kernel cache directory, then passes that path to the container through `LIBCUDF_KERNEL_CACHE_PATH`. This keeps the default local Docker build/test path working without requiring each developer to manually export a cache path before running Java tests.

Fixes #4735.

## Tests
- Not run (Docker wrapper change only)
