### PR TITLE
Disable C++ module scanning in the JNI build

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -48,6 +48,11 @@ project(
   LANGUAGES CXX CUDA
 )
 
+# We use no C++20 modules; disable module scanning so CMake emits no ninja dyndep phase. Otherwise
+# its dyndep refresh trips ninja's RefreshDyndepDependents assertion on incremental rebuilds after
+# a structural source change. Mirrors libcudf (rapidsai/cudf#19192).
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 # ##################################################################################################
 # * build options ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
The JNI native build is C++20 and requires CMake >= 4.0, which has policy
[CMP0155](https://cmake.org/cmake/help/latest/policy/CMP0155.html) defaults
`CMAKE_CXX_SCAN_FOR_MODULES` to `ON`. We use **no** C++20 modules, so this scan does nothing useful
— but it adds a ninja **dyndep** phase ("Generating CXX dyndep file") that is fragile on incremental
builds: a structural source change (splitting a TU, adding a function/header) causes cached build fails with

```
ninja: .../src/build.cc:435: ... RefreshDyndepDependents(...): Assertion `edge && !edge->outputs_ready()' failed.
```

forcing a full clean rebuild. This is annoying for developer. This PR fixes it.

Note that libcudf already disables module scanning across all its C++ trees (rapidsai/cudf#19192).