### PR TITLE
Add JNI Variant extraction support

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -230,6 +230,7 @@ add_library(
   src/StringUtilsJni.cpp
   src/SubStringIndexJni.cpp
   src/TaskPriorityJni.cpp
+  src/VariantUtilsJni.cpp
   src/ZOrderJni.cpp
   src/iceberg/IcebergBucketJni.cpp
   src/iceberg/IcebergDateTimeUtilJni.cpp

--- a/src/main/cpp/src/VariantUtilsJni.cpp
+++ b/src/main/cpp/src/VariantUtilsJni.cpp
@@ -80,4 +80,10 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_extractVar
   JNI_CATCH(env, 0);
 }
 
+JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_isAvailableNative(JNIEnv*,
+                                                                                           jclass)
+{
+  return JNI_TRUE;
+}
+
 }  // extern "C"

--- a/src/main/cpp/src/VariantUtilsJni.cpp
+++ b/src/main/cpp/src/VariantUtilsJni.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf_jni_apis.hpp"
+#include "jni_utils.hpp"
+
+#include <cudf/io/experimental/variant.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_getVariantFieldValue(
+  JNIEnv* env, jclass, jlong variant_struct_handle, jstring j_path)
+{
+  JNI_NULL_CHECK(env, variant_struct_handle, "variant struct column is null", 0);
+  JNI_NULL_CHECK(env, j_path, "path is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const& variant_struct = *reinterpret_cast<cudf::column_view const*>(variant_struct_handle);
+    cudf::jni::native_jstring path(env, j_path);
+    return cudf::jni::release_as_jlong(
+      cudf::io::parquet::experimental::get_variant_field(variant_struct,
+                                                         path.get(),
+                                                         cudf::get_default_stream(),
+                                                         cudf::get_current_device_resource_ref()));
+  }
+  JNI_CATCH(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_castVariantValue(
+  JNIEnv* env, jclass, jlong value_bytes_handle, jint cudf_type_id)
+{
+  JNI_NULL_CHECK(env, value_bytes_handle, "value bytes column is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const& value_bytes = *reinterpret_cast<cudf::column_view const*>(value_bytes_handle);
+    return cudf::jni::release_as_jlong(cudf::io::parquet::experimental::cast_variant(
+      value_bytes,
+      cudf::data_type{static_cast<cudf::type_id>(cudf_type_id)},
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref()));
+  }
+  JNI_CATCH(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_extractVariantField(
+  JNIEnv* env, jclass, jlong variant_struct_handle, jstring j_path, jint cudf_type_id)
+{
+  JNI_NULL_CHECK(env, variant_struct_handle, "variant struct column is null", 0);
+  JNI_NULL_CHECK(env, j_path, "path is null", 0);
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const& variant_struct = *reinterpret_cast<cudf::column_view const*>(variant_struct_handle);
+    cudf::jni::native_jstring path(env, j_path);
+    return cudf::jni::release_as_jlong(cudf::io::parquet::experimental::extract_variant_field(
+      variant_struct,
+      path.get(),
+      cudf::data_type{static_cast<cudf::type_id>(cudf_type_id)},
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref()));
+  }
+  JNI_CATCH(env, 0);
+}
+
+JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_isAvailableNative(JNIEnv*,
+                                                                                           jclass)
+{
+  return JNI_TRUE;
+}
+
+}  // extern "C"

--- a/src/main/cpp/src/VariantUtilsJni.cpp
+++ b/src/main/cpp/src/VariantUtilsJni.cpp
@@ -80,10 +80,4 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_extractVar
   JNI_CATCH(env, 0);
 }
 
-JNIEXPORT jboolean JNICALL Java_com_nvidia_spark_rapids_jni_VariantUtils_isAvailableNative(JNIEnv*,
-                                                                                           jclass)
-{
-  return JNI_TRUE;
-}
-
 }  // extern "C"

--- a/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
@@ -56,6 +56,7 @@ public class VariantUtils {
    * @return LIST&lt;UINT8&gt; column of raw encoded Variant values
    */
   public static ColumnVector getVariantFieldValue(ColumnView variantStruct, String path) {
+    Objects.requireNonNull(variantStruct, "variantStruct");
     Objects.requireNonNull(path, "path");
     return new ColumnVector(getVariantFieldValue(variantStruct.getNativeView(), path));
   }
@@ -79,6 +80,7 @@ public class VariantUtils {
    */
   public static ColumnVector extractVariantField(
       ColumnView variantStruct, String path, DType targetType) {
+    Objects.requireNonNull(variantStruct, "variantStruct");
     Objects.requireNonNull(path, "path");
     validateTargetType(targetType);
     return new ColumnVector(extractVariantField(

--- a/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
@@ -85,6 +85,17 @@ public class VariantUtils {
         variantStruct.getNativeView(), path, targetType.getTypeId().getNativeId()));
   }
 
+  /**
+   * Returns true when the loaded JNI library exposes the Variant extraction entry points.
+   */
+  public static boolean isAvailable() {
+    try {
+      return isAvailableNative();
+    } catch (UnsatisfiedLinkError e) {
+      return false;
+    }
+  }
+
   private static native long getVariantFieldValue(long variantStructHandle, String path);
 
   private static native long castVariantValue(long valueBytesHandle, int cudfTypeId);
@@ -92,4 +103,5 @@ public class VariantUtils {
   private static native long extractVariantField(
       long variantStructHandle, String path, int cudfTypeId);
 
+  private static native boolean isAvailableNative();
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.ColumnView;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.NativeDepsLoader;
+
+import java.util.Objects;
+
+/**
+ * JNI bridge to cuDF's experimental Parquet Variant field extraction APIs.
+ */
+public class VariantUtils {
+  static {
+    NativeDepsLoader.loadNativeDeps();
+  }
+
+  private VariantUtils() {}
+
+  private static void validateTargetType(DType targetType) {
+    Objects.requireNonNull(targetType, "targetType");
+    if (targetType != DType.STRING && targetType != DType.INT8 && targetType != DType.INT16 &&
+        targetType != DType.INT32 && targetType != DType.INT64) {
+      throw new IllegalArgumentException("unsupported Variant target type: " + targetType +
+          "; supported types are STRING, INT8, INT16, INT32, and INT64");
+    }
+  }
+
+  /**
+   * Extract raw Variant-encoded value bytes at {@code path} from a Variant struct column.
+   *
+   * @param variantStruct Variant materialization: STRUCT(metadata LIST&lt;UINT8&gt;,
+   *                      value LIST&lt;UINT8&gt;, optional shredded children...)
+   * @param path JSONPath-like path accepted by cuDF's Variant extractor. Paths are expected to
+   *             be ASCII object-field paths like {@code x}, {@code $.x}, or {@code $.x.y}.
+   * @return LIST&lt;UINT8&gt; column of raw encoded Variant values
+   */
+  public static ColumnVector getVariantFieldValue(ColumnView variantStruct, String path) {
+    return new ColumnVector(getVariantFieldValue(variantStruct.getNativeView(), path));
+  }
+
+  /**
+   * Decode raw Variant-encoded value bytes into {@code targetType}. Supported target types are
+   * {@link DType#STRING}, {@link DType#INT8}, {@link DType#INT16}, {@link DType#INT32}, and
+   * {@link DType#INT64}.
+   */
+  public static ColumnVector castVariantValue(ColumnView valueBytes, DType targetType) {
+    validateTargetType(targetType);
+    return new ColumnVector(castVariantValue(
+        valueBytes.getNativeView(), targetType.getTypeId().getNativeId()));
+  }
+
+  /**
+   * Extract a Variant field and decode it into {@code targetType} in one native call.
+   * Supported target types are {@link DType#STRING}, {@link DType#INT8}, {@link DType#INT16},
+   * {@link DType#INT32}, and {@link DType#INT64}.
+   */
+  public static ColumnVector extractVariantField(
+      ColumnView variantStruct, String path, DType targetType) {
+    validateTargetType(targetType);
+    return new ColumnVector(extractVariantField(
+        variantStruct.getNativeView(), path, targetType.getTypeId().getNativeId()));
+  }
+
+  /**
+   * Returns true when this JNI library was built against cuDF with Variant extraction APIs.
+   */
+  public static boolean isAvailable() {
+    try {
+      return isAvailableNative();
+    } catch (UnsatisfiedLinkError e) {
+      return false;
+    }
+  }
+
+  private static native long getVariantFieldValue(long variantStructHandle, String path);
+
+  private static native long castVariantValue(long valueBytesHandle, int cudfTypeId);
+
+  private static native long extractVariantField(
+      long variantStructHandle, String path, int cudfTypeId);
+
+  private static native boolean isAvailableNative();
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
@@ -35,8 +35,9 @@ public class VariantUtils {
 
   private static void validateTargetType(DType targetType) {
     Objects.requireNonNull(targetType, "targetType");
-    if (targetType != DType.STRING && targetType != DType.INT8 && targetType != DType.INT16 &&
-        targetType != DType.INT32 && targetType != DType.INT64) {
+    if (!targetType.equals(DType.STRING) && !targetType.equals(DType.INT8) &&
+        !targetType.equals(DType.INT16) && !targetType.equals(DType.INT32) &&
+        !targetType.equals(DType.INT64)) {
       throw new IllegalArgumentException("unsupported Variant target type: " + targetType +
           "; supported types are STRING, INT8, INT16, INT32, and INT64");
     }
@@ -52,6 +53,7 @@ public class VariantUtils {
    * @return LIST&lt;UINT8&gt; column of raw encoded Variant values
    */
   public static ColumnVector getVariantFieldValue(ColumnView variantStruct, String path) {
+    Objects.requireNonNull(path, "path");
     return new ColumnVector(getVariantFieldValue(variantStruct.getNativeView(), path));
   }
 
@@ -73,6 +75,7 @@ public class VariantUtils {
    */
   public static ColumnVector extractVariantField(
       ColumnView variantStruct, String path, DType targetType) {
+    Objects.requireNonNull(path, "path");
     validateTargetType(targetType);
     return new ColumnVector(extractVariantField(
         variantStruct.getNativeView(), path, targetType.getTypeId().getNativeId()));

--- a/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/VariantUtils.java
@@ -21,6 +21,8 @@ import ai.rapids.cudf.ColumnView;
 import ai.rapids.cudf.DType;
 import ai.rapids.cudf.NativeDepsLoader;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -31,15 +33,16 @@ public class VariantUtils {
     NativeDepsLoader.loadNativeDeps();
   }
 
+  private static final List<DType> SUPPORTED_TYPES = Arrays.asList(
+      DType.STRING, DType.INT8, DType.INT16, DType.INT32, DType.INT64);
+
   private VariantUtils() {}
 
   private static void validateTargetType(DType targetType) {
     Objects.requireNonNull(targetType, "targetType");
-    if (!targetType.equals(DType.STRING) && !targetType.equals(DType.INT8) &&
-        !targetType.equals(DType.INT16) && !targetType.equals(DType.INT32) &&
-        !targetType.equals(DType.INT64)) {
+    if (!SUPPORTED_TYPES.contains(targetType)) {
       throw new IllegalArgumentException("unsupported Variant target type: " + targetType +
-          "; supported types are STRING, INT8, INT16, INT32, and INT64");
+          "; supported types are " + SUPPORTED_TYPES);
     }
   }
 
@@ -63,6 +66,7 @@ public class VariantUtils {
    * {@link DType#INT64}.
    */
   public static ColumnVector castVariantValue(ColumnView valueBytes, DType targetType) {
+    Objects.requireNonNull(valueBytes, "valueBytes");
     validateTargetType(targetType);
     return new ColumnVector(castVariantValue(
         valueBytes.getNativeView(), targetType.getTypeId().getNativeId()));
@@ -81,17 +85,6 @@ public class VariantUtils {
         variantStruct.getNativeView(), path, targetType.getTypeId().getNativeId()));
   }
 
-  /**
-   * Returns true when this JNI library was built against cuDF with Variant extraction APIs.
-   */
-  public static boolean isAvailable() {
-    try {
-      return isAvailableNative();
-    } catch (UnsatisfiedLinkError e) {
-      return false;
-    }
-  }
-
   private static native long getVariantFieldValue(long variantStructHandle, String path);
 
   private static native long castVariantValue(long valueBytesHandle, int cudfTypeId);
@@ -99,5 +92,4 @@ public class VariantUtils {
   private static native long extractVariantField(
       long variantStructHandle, String path, int cudfTypeId);
 
-  private static native boolean isAvailableNative();
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
@@ -205,6 +205,11 @@ public class VariantUtilsTest {
   }
 
   @Test
+  void nullTargetTypeThrows() {
+    assertThrows(NullPointerException.class, () -> VariantUtils.castVariantValue(null, null));
+  }
+
+  @Test
   void parentStructNullIsPreserved() {
     List<Byte> metadata = bytes(0x01, 0x01, 0x00, 0x01, 'x');
     List<Byte> value = bytes(0x02, 0x01, 0x00, 0x00, 0x05, 0x14, 0x07, 0x00, 0x00, 0x00);

--- a/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VariantUtilsTest {
   private static final ListType BINARY_TYPE =
@@ -93,9 +92,13 @@ public class VariantUtilsTest {
         variant(m3, v3));
   }
 
-  @Test
-  void isAvailable() {
-    assertTrue(VariantUtils.isAvailable());
+  private static ColumnVector makeExactWidthIntVariantColumn() {
+    List<Byte> metadata = bytes(0x01, 0x02, 0x00, 0x01, 0x02, 'b', 'l');
+    List<Byte> value = bytes(
+        0x02, 0x02, 0x00, 0x01, 0x00, 0x02, 0x0b,
+        0x0c, 0x2a,
+        0x18, 0x15, 0x81, 0xe9, 0x7d, 0xf4, 0x10, 0x22, 0x11);
+    return ColumnVector.fromStructs(VARIANT_TYPE, variant(metadata, value));
   }
 
   @Test
@@ -141,6 +144,24 @@ public class VariantUtilsTest {
          ColumnVector result = VariantUtils.extractVariantField(
              variant, "$.species.population", DType.INT16);
          ColumnVector expected = ColumnVector.fromBoxedShorts((short) 6789)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void extractInt8Field() {
+    try (ColumnVector variant = makeExactWidthIntVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(variant, "b", DType.INT8);
+         ColumnVector expected = ColumnVector.fromBoxedBytes((byte) 42)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void extractInt64Field() {
+    try (ColumnVector variant = makeExactWidthIntVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(variant, "l", DType.INT64);
+         ColumnVector expected = ColumnVector.fromBoxedLongs(1234567890123456789L)) {
       assertColumnsAreEqual(expected, result);
     }
   }
@@ -205,8 +226,12 @@ public class VariantUtilsTest {
   }
 
   @Test
-  void nullTargetTypeThrows() {
+  void nullCastArgumentsThrow() {
     assertThrows(NullPointerException.class, () -> VariantUtils.castVariantValue(null, null));
+    assertThrows(NullPointerException.class,
+        () -> VariantUtils.castVariantValue(null, DType.INT32));
+    assertThrows(NullPointerException.class,
+        () -> VariantUtils.castVariantValue(null, DType.FLOAT64));
   }
 
   @Test

--- a/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VariantUtilsTest {
   private static final ListType BINARY_TYPE =
@@ -90,6 +91,11 @@ public class VariantUtilsTest {
         variant(m1, v1),
         variant(m2, v2),
         variant(m3, v3));
+  }
+
+  @Test
+  void isAvailable() {
+    assertTrue(VariantUtils.isAvailable());
   }
 
   private static ColumnVector makeExactWidthIntVariantColumn() {

--- a/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
@@ -221,6 +221,14 @@ public class VariantUtilsTest {
   }
 
   @Test
+  void nullVariantStructThrows() {
+    assertThrows(NullPointerException.class,
+        () -> VariantUtils.getVariantFieldValue(null, "x"));
+    assertThrows(NullPointerException.class,
+        () -> VariantUtils.extractVariantField(null, "x", DType.INT32));
+  }
+
+  @Test
   void unsupportedTargetTypeThrows() {
     try (ColumnVector variant = makeXyzVariantColumn();
          ColumnVector valueBytes = VariantUtils.getVariantFieldValue(variant, "x")) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/VariantUtilsTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.CudfException;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.HostColumnVector.BasicType;
+import ai.rapids.cudf.HostColumnVector.ListType;
+import ai.rapids.cudf.HostColumnVector.StructData;
+import ai.rapids.cudf.HostColumnVector.StructType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VariantUtilsTest {
+  private static final ListType BINARY_TYPE =
+      new ListType(true, new BasicType(false, DType.UINT8));
+  private static final StructType VARIANT_TYPE =
+      new StructType(true, Arrays.asList(BINARY_TYPE, BINARY_TYPE));
+
+  private static List<Byte> bytes(int... values) {
+    List<Byte> list = new ArrayList<>(values.length);
+    for (int value : values) {
+      list.add((byte) value);
+    }
+    return list;
+  }
+
+  private static StructData variant(List<Byte> metadata, List<Byte> value) {
+    return new StructData(metadata, value);
+  }
+
+  private static ColumnVector makeApacheObjectNestedVariantColumn() {
+    List<Byte> metadata = bytes(
+        0x01, 0x0a, 0x00, 0x02, 0x09, 0x0d, 0x17, 0x22, 0x26, 0x2e, 0x33, 0x3e,
+        0x46, 'i', 'd', 's', 'p', 'e', 'c', 'i', 'e', 's', 'n', 'a', 'm', 'e',
+        'p', 'o', 'p', 'u', 'l', 'a', 't', 'i', 'o', 'n', 'o', 'b', 's', 'e',
+        'r', 'v', 'a', 't', 'i', 'o', 'n', 't', 'i', 'm', 'e', 'l', 'o', 'c',
+        'a', 't', 'i', 'o', 'n', 'v', 'a', 'l', 'u', 'e', 't', 'e', 'm', 'p',
+        'e', 'r', 'a', 't', 'u', 'r', 'e', 'h', 'u', 'm', 'i', 'd', 'i', 't',
+        'y');
+    List<Byte> value = bytes(
+        0x02, 0x03, 0x00, 0x04, 0x01, 0x00, 0x19, 0x02, 0x46, 0x0c, 0x01,
+        0x02, 0x02, 0x02, 0x03, 0x00, 0x0d, 0x10, 0x31, 'l', 'a', 'v', 'a',
+        ' ', 'm', 'o', 'n', 's', 't', 'e', 'r', 0x10, 0x85, 0x1a, 0x02, 0x03,
+        0x06, 0x05, 0x07, 0x09, 0x00, 0x18, 0x24, 0x21, '1', '2', ':', '3',
+        '4', ':', '5', '6', 0x39, 'I', 'n', ' ', 't', 'h', 'e', ' ', 'V',
+        'o', 'l', 'c', 'a', 'n', 'o', 0x02, 0x02, 0x09, 0x08, 0x02, 0x00,
+        0x05, 0x0c, 0x7b, 0x10, 0xc8, 0x01);
+    return ColumnVector.fromStructs(VARIANT_TYPE, variant(metadata, value));
+  }
+
+  private static ColumnVector makeXyzVariantColumn() {
+    List<Byte> m1 = bytes(0x01, 0x02, 0x00, 0x01, 0x02, 'x', 'y');
+    List<Byte> v1 = bytes(
+        0x02, 0x02, 0x00, 0x01, 0x00, 0x05, 0x08,
+        0x14, 0x07, 0x00, 0x00, 0x00,
+        0x09, 'h', 'i');
+    List<Byte> m2 = bytes(0x01, 0x02, 0x00, 0x01, 0x02, 'x', 'z');
+    List<Byte> v2 = bytes(
+        0x02, 0x02, 0x00, 0x01, 0x00, 0x05, 0x0a,
+        0x14, 0x2a, 0x00, 0x00, 0x00,
+        0x14, 0x63, 0x00, 0x00, 0x00);
+    List<Byte> m3 = bytes(0x01, 0x01, 0x00, 0x01, 'y');
+    List<Byte> v3 = bytes(0x02, 0x01, 0x00, 0x00, 0x04, 0x0d, 'z', 'z', 'z');
+
+    return ColumnVector.fromStructs(
+        VARIANT_TYPE,
+        variant(m1, v1),
+        variant(m2, v2),
+        variant(m3, v3));
+  }
+
+  @Test
+  void isAvailable() {
+    assertTrue(VariantUtils.isAvailable());
+  }
+
+  @Test
+  void extractStringField() {
+    try (ColumnVector variant = makeXyzVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(variant, "y", DType.STRING);
+         ColumnVector expected = ColumnVector.fromStrings("hi", null, "zzz")) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void extractIntField() {
+    try (ColumnVector variant = makeXyzVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(variant, "x", DType.INT32);
+         ColumnVector expected = ColumnVector.fromBoxedInts(7, 42, null)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void extractDollarPrefixedPath() {
+    try (ColumnVector variant = makeXyzVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(variant, "$.x", DType.INT32);
+         ColumnVector expected = ColumnVector.fromBoxedInts(7, 42, null)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void extractNestedStringField() {
+    try (ColumnVector variant = makeApacheObjectNestedVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(
+             variant, "$.species.name", DType.STRING);
+         ColumnVector expected = ColumnVector.fromStrings("lava monster")) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void extractNestedInt16Field() {
+    try (ColumnVector variant = makeApacheObjectNestedVariantColumn();
+         ColumnVector result = VariantUtils.extractVariantField(
+             variant, "$.species.population", DType.INT16);
+         ColumnVector expected = ColumnVector.fromBoxedShorts((short) 6789)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void getThenCastFieldValue() {
+    try (ColumnVector variant = makeXyzVariantColumn();
+         ColumnVector valueBytes = VariantUtils.getVariantFieldValue(variant, "z");
+         ColumnVector result = VariantUtils.castVariantValue(valueBytes, DType.INT32);
+         ColumnVector expected = ColumnVector.fromBoxedInts(null, 99, null)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void emptyInputProducesEmptyOutput() {
+    try (ColumnVector variant = ColumnVector.fromStructs(VARIANT_TYPE);
+         ColumnVector result = VariantUtils.extractVariantField(variant, "x", DType.INT32);
+         ColumnVector expected = ColumnVector.fromBoxedInts()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void emptyPathThrows() {
+    try (ColumnVector variant = makeXyzVariantColumn()) {
+      assertThrows(CudfException.class, () -> VariantUtils.getVariantFieldValue(variant, ""));
+      assertThrows(CudfException.class,
+          () -> VariantUtils.extractVariantField(variant, "", DType.INT32));
+    }
+  }
+
+  @Test
+  void malformedPathThrows() {
+    try (ColumnVector variant = makeXyzVariantColumn()) {
+      assertThrows(CudfException.class,
+          () -> VariantUtils.getVariantFieldValue(variant, "$.x[0]"));
+      assertThrows(CudfException.class,
+          () -> VariantUtils.extractVariantField(variant, "$.x[0]", DType.INT32));
+    }
+  }
+
+  @Test
+  void nullPathThrows() {
+    try (ColumnVector variant = makeXyzVariantColumn()) {
+      assertThrows(NullPointerException.class,
+          () -> VariantUtils.getVariantFieldValue(variant, null));
+      assertThrows(NullPointerException.class,
+          () -> VariantUtils.extractVariantField(variant, null, DType.INT32));
+    }
+  }
+
+  @Test
+  void unsupportedTargetTypeThrows() {
+    try (ColumnVector variant = makeXyzVariantColumn();
+         ColumnVector valueBytes = VariantUtils.getVariantFieldValue(variant, "x")) {
+      assertThrows(IllegalArgumentException.class,
+          () -> VariantUtils.castVariantValue(valueBytes, DType.FLOAT64));
+      assertThrows(IllegalArgumentException.class,
+          () -> VariantUtils.extractVariantField(variant, "x", DType.FLOAT64));
+    }
+  }
+
+  @Test
+  void parentStructNullIsPreserved() {
+    List<Byte> metadata = bytes(0x01, 0x01, 0x00, 0x01, 'x');
+    List<Byte> value = bytes(0x02, 0x01, 0x00, 0x00, 0x05, 0x14, 0x07, 0x00, 0x00, 0x00);
+    try (ColumnVector variant = ColumnVector.fromStructs(
+             VARIANT_TYPE,
+             variant(metadata, value),
+             null);
+         ColumnVector result = VariantUtils.extractVariantField(variant, "x", DType.INT32);
+         ColumnVector expected = ColumnVector.fromBoxedInts(7, null)) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds `VariantUtils` Java/JNI bindings for cuDF's experimental Parquet Variant extraction APIs:

- `get_variant_field` → extract raw Variant `LIST<UINT8>` value bytes for a path
- `cast_variant` → decode raw Variant value bytes to a supported cuDF type
- `extract_variant_field` → extract and decode in one native call

The Spark RAPIDS integration will be added in cudf-spark in a follow-up PR after this JNI API lands.

The wrapper currently supports the cuDF path grammar for object fields, e.g. `x`, `$.x`, and `$.a.b`. Target types `STRING`, `INT8`, `INT16`, `INT32`, and `INT64`.

- Input is expected to be cuDF's Variant materialization: `STRUCT(metadata LIST<UINT8>, value LIST<UINT8>, ...)`.
- Java validates null arguments and unsupported target types before crossing JNI where applicable.
- `VariantUtils.isAvailable()` lets Spark RAPIDS check whether the loaded JNI library includes the Variant extraction symbols.


## Validation

Added  a new test suite `VariantUtilsTest` for:

- string and integer extraction
- nested paths and `$`-prefixed paths
- two-step `getVariantFieldValue` + `castVariantValue`
- empty inputs
- null parent rows
- null, empty, and malformed paths
- unsupported target types

Tests run: Success:17, Failures: 0, Errors: 0, Skipped: 0