### PR TITLE
Use larger copy buffer for vectored read fallback

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -74,28 +74,8 @@ public interface RapidsInputFile {
     if (copyRanges.isEmpty()) {
       return;
     }
-    readVectoredUsingCopyBuffer(
-        this, output, copyRanges, DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE);
-  }
-
-  /**
-   * Reads data from {@code inputFile} into {@code output} using an allocated copy buffer.
-   * Callers that perform repeated reads should use the {@code byte[]} overload to reuse a buffer
-   * across calls.
-   *
-   * @param inputFile the file to read from
-   * @param output the destination buffer
-   * @param copyRanges input ranges and output offsets
-   * @param copyBufferSize size of the allocated copy buffer in bytes
-   * @throws IOException if an I/O error occurs during reading
-   */
-  static void readVectoredUsingCopyBuffer(
-      RapidsInputFile inputFile,
-      HostMemoryBuffer output,
-      List<CopyRange> copyRanges,
-      int copyBufferSize) throws IOException {
     RapidsInputFileUtils.readVectoredUsingCopyBuffer(
-        inputFile, output, copyRanges, copyBufferSize);
+        this, output, copyRanges, DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE);
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -30,6 +30,8 @@ import java.util.OptionalLong;
  * The implementation of this interface should be thread-safe.
  */
 public interface RapidsInputFile {
+  int DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE = 8 * 1024 * 1024;
+
   /**
    * Get the path of this input file.
    * @return the file path string
@@ -72,22 +74,26 @@ public interface RapidsInputFile {
     if (copyRanges.isEmpty()) {
       return;
     }
-    long outputLength = output.getLength();
-    for (CopyRange copyRange : copyRanges) {
-      Objects.requireNonNull(copyRange, "copyRange can't be null");
-      long end = copyRange.getOutputOffset() + copyRange.getLength();
-      if (end < 0 || end > outputLength) {
-        throw new IllegalArgumentException(
-            "Output buffer length " + outputLength + " is smaller than requested end " + end);
-      }
-    }
+    readVectoredUsingCopyBuffer(
+        this, output, copyRanges, DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE);
+  }
 
-    try (SeekableInputStream input = open()) {
-      for (CopyRange copyRange : copyRanges) {
-        input.seek(copyRange.getInputOffset());
-        output.copyFromStream(copyRange.getOutputOffset(), input, copyRange.getLength());
-      }
-    }
+  /**
+   * Reads data from {@code inputFile} into {@code output} using a reusable copy buffer.
+   *
+   * @param inputFile the file to read from
+   * @param output the destination buffer
+   * @param copyRanges input ranges and output offsets
+   * @param copyBufferSize size of the reusable copy buffer in bytes
+   * @throws IOException if an I/O error occurs during reading
+   */
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<CopyRange> copyRanges,
+      int copyBufferSize) throws IOException {
+    RapidsInputFileUtils.readVectoredUsingCopyBuffer(
+        inputFile, output, copyRanges, copyBufferSize);
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -79,12 +79,14 @@ public interface RapidsInputFile {
   }
 
   /**
-   * Reads data from {@code inputFile} into {@code output} using a reusable copy buffer.
+   * Reads data from {@code inputFile} into {@code output} using an allocated copy buffer.
+   * Callers that perform repeated reads should use the {@code byte[]} overload to reuse a buffer
+   * across calls.
    *
    * @param inputFile the file to read from
    * @param output the destination buffer
    * @param copyRanges input ranges and output offsets
-   * @param copyBufferSize size of the reusable copy buffer in bytes
+   * @param copyBufferSize size of the allocated copy buffer in bytes
    * @throws IOException if an I/O error occurs during reading
    */
   static void readVectoredUsingCopyBuffer(
@@ -94,6 +96,23 @@ public interface RapidsInputFile {
       int copyBufferSize) throws IOException {
     RapidsInputFileUtils.readVectoredUsingCopyBuffer(
         inputFile, output, copyRanges, copyBufferSize);
+  }
+
+  /**
+   * Reads data from {@code inputFile} into {@code output} using a caller-supplied copy buffer.
+   *
+   * @param inputFile the file to read from
+   * @param output the destination buffer
+   * @param copyRanges input ranges and output offsets
+   * @param copyBuffer reusable copy buffer
+   * @throws IOException if an I/O error occurs during reading
+   */
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<CopyRange> copyRanges,
+      byte[] copyBuffer) throws IOException {
+    RapidsInputFileUtils.readVectoredUsingCopyBuffer(inputFile, output, copyRanges, copyBuffer);
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
@@ -39,19 +39,42 @@ final class RapidsInputFileUtils {
 
     byte[] copyBuffer = new byte[getCopyBufferAllocationSize(copyRanges, copyBufferSize)];
     try (SeekableInputStream input = inputFile.open()) {
-      for (RapidsInputFile.CopyRange copyRange : copyRanges) {
-        if (input.getPos() != copyRange.getInputOffset()) {
-          input.seek(copyRange.getInputOffset());
-        }
-        long outputOffset = copyRange.getOutputOffset();
-        long bytesLeft = copyRange.getLength();
-        while (bytesLeft > 0) {
-          int readLength = (int) Math.min(bytesLeft, copyBuffer.length);
-          readFully(input, copyBuffer, readLength);
-          output.setBytes(outputOffset, copyBuffer, 0, readLength);
-          outputOffset += readLength;
-          bytesLeft -= readLength;
-        }
+      readVectored(input, output, copyRanges, copyBuffer);
+    }
+  }
+
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      byte[] copyBuffer) throws IOException {
+    validateReadVectoredArgs(inputFile, output, copyRanges, copyBuffer);
+    if (copyRanges.isEmpty()) {
+      return;
+    }
+
+    try (SeekableInputStream input = inputFile.open()) {
+      readVectored(input, output, copyRanges, copyBuffer);
+    }
+  }
+
+  private static void readVectored(
+      SeekableInputStream input,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      byte[] copyBuffer) throws IOException {
+    for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+      if (input.getPos() != copyRange.getInputOffset()) {
+        input.seek(copyRange.getInputOffset());
+      }
+      long outputOffset = copyRange.getOutputOffset();
+      long bytesLeft = copyRange.getLength();
+      while (bytesLeft > 0) {
+        int readLength = (int) Math.min(bytesLeft, copyBuffer.length);
+        readFully(input, copyBuffer, readLength);
+        output.setBytes(outputOffset, copyBuffer, 0, readLength);
+        outputOffset += readLength;
+        bytesLeft -= readLength;
       }
     }
   }
@@ -62,11 +85,32 @@ final class RapidsInputFileUtils {
       List<RapidsInputFile.CopyRange> copyRanges,
       int copyBufferSize) {
     Objects.requireNonNull(inputFile, "inputFile can't be null");
-    Objects.requireNonNull(output, "output can't be null");
-    Objects.requireNonNull(copyRanges, "copyRanges can't be null");
     if (copyBufferSize <= 0) {
       throw new IllegalArgumentException("copyBufferSize must be positive");
     }
+    validateReadVectoredArgs(inputFile, output, copyRanges);
+  }
+
+  private static void validateReadVectoredArgs(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      byte[] copyBuffer) {
+    Objects.requireNonNull(inputFile, "inputFile can't be null");
+    Objects.requireNonNull(copyBuffer, "copyBuffer can't be null");
+    if (copyBuffer.length == 0) {
+      throw new IllegalArgumentException("copyBuffer must not be empty");
+    }
+    validateReadVectoredArgs(inputFile, output, copyRanges);
+  }
+
+  private static void validateReadVectoredArgs(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges) {
+    Objects.requireNonNull(inputFile, "inputFile can't be null");
+    Objects.requireNonNull(output, "output can't be null");
+    Objects.requireNonNull(copyRanges, "copyRanges can't be null");
 
     long outputLength = output.getLength();
     for (RapidsInputFile.CopyRange copyRange : copyRanges) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni.fileio;
+
+import ai.rapids.cudf.HostMemoryBuffer;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+final class RapidsInputFileUtils {
+  private RapidsInputFileUtils() {
+  }
+
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      int copyBufferSize) throws IOException {
+    validateReadVectoredArgs(inputFile, output, copyRanges, copyBufferSize);
+    if (copyRanges.isEmpty()) {
+      return;
+    }
+
+    byte[] copyBuffer = new byte[getCopyBufferAllocationSize(copyRanges, copyBufferSize)];
+    try (SeekableInputStream input = inputFile.open()) {
+      for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+        if (input.getPos() != copyRange.getInputOffset()) {
+          input.seek(copyRange.getInputOffset());
+        }
+        long outputOffset = copyRange.getOutputOffset();
+        long bytesLeft = copyRange.getLength();
+        while (bytesLeft > 0) {
+          int readLength = (int) Math.min(bytesLeft, copyBuffer.length);
+          readFully(input, copyBuffer, readLength);
+          output.setBytes(outputOffset, copyBuffer, 0, readLength);
+          outputOffset += readLength;
+          bytesLeft -= readLength;
+        }
+      }
+    }
+  }
+
+  private static void validateReadVectoredArgs(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      int copyBufferSize) {
+    Objects.requireNonNull(inputFile, "inputFile can't be null");
+    Objects.requireNonNull(output, "output can't be null");
+    Objects.requireNonNull(copyRanges, "copyRanges can't be null");
+    if (copyBufferSize <= 0) {
+      throw new IllegalArgumentException("copyBufferSize must be positive");
+    }
+
+    long outputLength = output.getLength();
+    for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+      Objects.requireNonNull(copyRange, "copyRange can't be null");
+      long end = copyRange.getOutputOffset() + copyRange.getLength();
+      if (end < 0 || end > outputLength) {
+        throw new IllegalArgumentException(
+            "Output buffer length " + outputLength + " is smaller than requested end " + end);
+      }
+    }
+  }
+
+  private static int getCopyBufferAllocationSize(
+      List<RapidsInputFile.CopyRange> copyRanges,
+      int copyBufferSize) {
+    long maxRangeLength = 0;
+    for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+      maxRangeLength = Math.max(maxRangeLength, copyRange.getLength());
+    }
+    return (int) Math.min(copyBufferSize, maxRangeLength);
+  }
+
+  private static void readFully(SeekableInputStream input, byte[] copyBuffer, int readLength)
+      throws IOException {
+    int totalRead = 0;
+    while (totalRead < readLength) {
+      int amountRead = input.read(copyBuffer, totalRead, readLength - totalRead);
+      if (amountRead < 0) {
+        throw new EOFException(
+            "Unexpected end of stream, expected " + (readLength - totalRead) + " more bytes");
+      }
+      if (amountRead == 0) {
+        throw new IOException(
+            "No progress reading stream, expected " + (readLength - totalRead) + " more bytes");
+      }
+      totalRead += amountRead;
+    }
+  }
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
@@ -85,6 +85,9 @@ final class RapidsInputFileUtils {
     long maxRangeLength = 0;
     for (RapidsInputFile.CopyRange copyRange : copyRanges) {
       maxRangeLength = Math.max(maxRangeLength, copyRange.getLength());
+      if (maxRangeLength >= copyBufferSize) {
+        return copyBufferSize;
+      }
     }
     return (int) Math.min(copyBufferSize, maxRangeLength);
   }

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/SeekableInputStream.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/SeekableInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/SeekableInputStream.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/SeekableInputStream.java
@@ -22,6 +22,10 @@ import java.io.InputStream;
 /**
  * An {@code Inputstream} that offers random access interface.
  *
+ * <p>Implementations of {@link #read(byte[], int, int)} must not return 0 when {@code len} is
+ * positive. They must either block until at least one byte is available, return -1 at end of
+ * stream, or throw an {@link IOException}.
+ *
  */
 public abstract class SeekableInputStream extends InputStream {
   /**

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -69,10 +69,9 @@ public class RapidsInputFileTest {
   public void readVectoredThrowsIOExceptionOnZeroProgressRead() throws IOException {
     RapidsInputFile inputFile = new ZeroProgressInputFile(FILE_DATA.length);
     try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
-      IOException e = assertThrows(IOException.class,
+      assertThrows(IOException.class,
           () -> inputFile.readVectored(output,
               Collections.singletonList(new RapidsInputFile.CopyRange(0, 3, 0))));
-      assertEquals(IOException.class, e.getClass());
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -56,6 +56,19 @@ public class RapidsInputFileTest {
   }
 
   @Test
+  public void readVectoredUsingCallerSuppliedCopyBuffer() throws IOException {
+    TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    byte[] copyBuffer = new byte[4];
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(12)) {
+      RapidsInputFile.readVectoredUsingCopyBuffer(inputFile, output, Arrays.asList(
+          new RapidsInputFile.CopyRange(0, 6, 0),
+          new RapidsInputFile.CopyRange(8, 6, 6)), copyBuffer);
+      assertArrayEquals("abcdefijklmn".getBytes(StandardCharsets.UTF_8), readBytes(output));
+    }
+    assertEquals(1, inputFile.getOpenCount());
+  }
+
+  @Test
   public void readVectoredThrowsOnShortRead() throws IOException {
     RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
     try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -44,12 +44,35 @@ public class RapidsInputFileTest {
   }
 
   @Test
+  public void readVectoredUsingConfiguredCopyBuffer() throws IOException {
+    TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(12)) {
+      RapidsInputFile.readVectoredUsingCopyBuffer(inputFile, output, Arrays.asList(
+          new RapidsInputFile.CopyRange(0, 6, 0),
+          new RapidsInputFile.CopyRange(8, 6, 6)), 4);
+      assertArrayEquals("abcdefijklmn".getBytes(StandardCharsets.UTF_8), readBytes(output));
+    }
+    assertEquals(1, inputFile.getOpenCount());
+  }
+
+  @Test
   public void readVectoredThrowsOnShortRead() throws IOException {
     RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
     try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
       assertThrows(EOFException.class,
           () -> inputFile.readVectored(output,
               Collections.singletonList(new RapidsInputFile.CopyRange(14, 3, 0))));
+    }
+  }
+
+  @Test
+  public void readVectoredThrowsIOExceptionOnZeroProgressRead() throws IOException {
+    RapidsInputFile inputFile = new ZeroProgressInputFile(FILE_DATA.length);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
+      IOException e = assertThrows(IOException.class,
+          () -> inputFile.readVectored(output,
+              Collections.singletonList(new RapidsInputFile.CopyRange(0, 3, 0))));
+      assertEquals(IOException.class, e.getClass());
     }
   }
 
@@ -128,6 +151,24 @@ public class RapidsInputFileTest {
     }
   }
 
+  private static final class ZeroProgressInputFile implements RapidsInputFile {
+    private final long length;
+
+    private ZeroProgressInputFile(long length) {
+      this.length = length;
+    }
+
+    @Override
+    public long getLength() {
+      return length;
+    }
+
+    @Override
+    public SeekableInputStream open() {
+      return new ZeroProgressSeekableInputStream();
+    }
+  }
+
   private static final class ArraySeekableInputStream extends SeekableInputStream {
     private final byte[] data;
     private int position;
@@ -177,6 +218,27 @@ public class RapidsInputFileTest {
       System.arraycopy(data, position, b, off, amountToRead);
       position += amountToRead;
       return amountToRead;
+    }
+  }
+
+  private static final class ZeroProgressSeekableInputStream extends SeekableInputStream {
+    @Override
+    public long getPos() {
+      return 0;
+    }
+
+    @Override
+    public void seek(long newPos) {
+    }
+
+    @Override
+    public int read() {
+      return 0;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) {
+      return 0;
     }
   }
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -44,18 +44,6 @@ public class RapidsInputFileTest {
   }
 
   @Test
-  public void readVectoredUsingConfiguredCopyBuffer() throws IOException {
-    TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
-    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(12)) {
-      RapidsInputFile.readVectoredUsingCopyBuffer(inputFile, output, Arrays.asList(
-          new RapidsInputFile.CopyRange(0, 6, 0),
-          new RapidsInputFile.CopyRange(8, 6, 6)), 4);
-      assertArrayEquals("abcdefijklmn".getBytes(StandardCharsets.UTF_8), readBytes(output));
-    }
-    assertEquals(1, inputFile.getOpenCount());
-  }
-
-  @Test
   public void readVectoredUsingCallerSuppliedCopyBuffer() throws IOException {
     TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
     byte[] copyBuffer = new byte[4];


### PR DESCRIPTION
## Description

This updates the default `RapidsInputFile.readVectored` fallback to copy through an explicit byte-buffer loop and write into the destination `HostMemoryBuffer` with `setBytes`.

The default fallback does not cache a scratch buffer in the interface implementation. It allocates a bounded buffer for each `readVectored` call, using the smaller of the default 8 MiB limit and the largest requested range. Callers with a well-defined lifecycle can use `RapidsInputFile.readVectoredUsingCopyBuffer(..., byte[])` to provide a caller-managed scratch buffer.

This avoids routing default fallback vectored reads through `HostMemoryBuffer.copyFromStream`, whose internal copy chunk is 128 KiB. Internal validation and stream-copy helpers live in a package-private utility class so they do not expand the interface API surface beyond the caller-supplied helper.

Related issue: NVIDIA/cudf-spark#15163.

The dependent NVIDIA/cudf-spark#15164 uses the helper in `HadoopInputFile.readVectored`. It keeps the `GpuParquetScan` `readVectored` abstraction introduced by NVIDIA/cudf-spark#14674 while allowing Hadoop-backed fallback reads to honor `parquet.read.allocation.size`.

## Testing

The current PR head (`901ca4f570cb843c814121a7698ba8b3d5896fbf`) was tested with:

```text
mvn -B -Dmaven.antrun.skip=true -Dtest=RapidsInputFileTest \
  test-compile surefire:test@default-test
```

Result:

```text
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The JNI artifact was then installed locally and the dependent cudf-spark head (`ba4487c750ba73cf2f2281288ca319ad7f3752be`) was packaged on an x86 host with:

```text
mvn -B -pl sql-plugin -am -DskipTests \
  -Dspark-rapids-jni.version=26.06.1-SNAPSHOT package
```

Result: `BUILD SUCCESS`.

## Performance Validation

End-to-end performance validation was performed with the dependent NVIDIA/cudf-spark#15164. Five interleaved NDS runs did not reproduce a stable regression after the fix. See NVIDIA/cudf-spark#15164 for the complete results.
