### PR TITLE
Update pre-merge CI cuda13 to version 13.3.0

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -31,7 +31,7 @@ import ipp.blossom.*
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
 def IMAGE_PREMERGE_CU12 = "${common.ARTIFACTORY_NAME}/sw-spark-docker/plugin-jni:rockylinux8-cuda12.9.1-blossom"
-def IMAGE_PREMERGE_CU13 = "${common.ARTIFACTORY_NAME}/sw-spark-docker/plugin-jni:rockylinux8-cuda13.2.1-blossom"
+def IMAGE_PREMERGE_CU13 = "${common.ARTIFACTORY_NAME}/sw-spark-docker/plugin-jni:rockylinux8-cuda13.3.0-blossom"
 def cpuImage = pod.getCPUYAML(IMAGE_PREMERGE_CU12)
 def PREMERGE_DOCKERFILE = 'ci/Dockerfile'
 def PREMERGE_TAG_CU12
@@ -161,7 +161,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE_CU12 .")
                             uploadDocker(IMAGE_PREMERGE_CU12)
                             docker.build(IMAGE_PREMERGE_CU13,
-                                "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE_CU13 --build-arg CUDA_VERSION=13.2.1 .")
+                                "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE_CU13 --build-arg CUDA_VERSION=13.3.0 .")
                             uploadDocker(IMAGE_PREMERGE_CU13)
                         }
                     }


### PR DESCRIPTION
Fixes #4771

For 26.08:
- Updates the pre-merge CUDA 13 Jenkins image from CUDA 13.2.1 to CUDA 13.3.0.
- Updates the temporary pre-merge Docker build argument to build CUDA 13.3.0 images when `ci/Dockerfile` changes.
- Leaves the CUDA 12 pre-merge configuration unchanged.

This follows the CUDA 13.2.1 update in #4503.