### PR TITLE
[FEA] Update pre-merge CI CUDA 13 to version 13.3.0

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -31,7 +31,7 @@ import ipp.blossom.*
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
 def IMAGE_PREMERGE_CU12 = "${common.ARTIFACTORY_NAME}/sw-spark-docker/plugin-jni:rockylinux8-cuda12.9.1-blossom"
-def IMAGE_PREMERGE_CU13 = "${common.ARTIFACTORY_NAME}/sw-spark-docker/plugin-jni:rockylinux8-cuda13.2.1-blossom"
+def IMAGE_PREMERGE_CU13 = "${common.ARTIFACTORY_NAME}/sw-spark-docker/plugin-jni:rockylinux8-cuda13.3.0-blossom"
 def cpuImage = pod.getCPUYAML(IMAGE_PREMERGE_CU12)
 def PREMERGE_DOCKERFILE = 'ci/Dockerfile'
 def PREMERGE_TAG_CU12
@@ -161,7 +161,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE_CU12 .")
                             uploadDocker(IMAGE_PREMERGE_CU12)
                             docker.build(IMAGE_PREMERGE_CU13,
-                                "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE_CU13 --build-arg CUDA_VERSION=13.2.1 .")
+                                "--network=host -f ${PREMERGE_DOCKERFILE} -t $IMAGE_PREMERGE_CU13 --build-arg CUDA_VERSION=13.3.0 .")
                             uploadDocker(IMAGE_PREMERGE_CU13)
                         }
                     }


### PR DESCRIPTION
## Summary

- Update the prebuilt CUDA 13 CI image from 13.2.1 to 13.3.0.
- Update the temporary CUDA 13 image build argument to `CUDA_VERSION=13.3.0`.
- Keep the CUDA 12 pre-merge configuration unchanged.
- Retain driver 590.44.01, which supports CUDA 13.x through minor-version compatibility.

## Validation

- `git diff --check`
- Verified both the prebuilt-image and temporary-image paths use CUDA 13.3.0.
- Verified no CUDA 13.2.1 references remain in `ci/Jenkinsfile.premerge`.

Full CUDA 13 build and fuzz-test validation will run in pre-merge CI.

Closes #4771

Reference: https://github.com/NVIDIA/cudf-spark-jni/pull/4503