### PR TITLE
Fix JNI CI blocking: Format C++ sources for updated cuDF style

### DIFF
--- a/src/main/cpp/faultinj/faultinj.cu
+++ b/src/main/cpp/faultinj/faultinj.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ namespace {
 typedef enum { FI_TRAP, FI_ASSERT, FI_RETURN_VALUE } FaultInjectionType;
 
 typedef struct {
-  volatile uint32_t initialized;
+  uint32_t volatile initialized;
   CUpti_SubscriberHandle subscriber;
 
   std::string configFilePath = std::string();
@@ -81,7 +81,7 @@ void CUPTIAPI faultInjectionCallbackHandler(void* userdata,
                                             CUpti_CallbackId cbid,
                                             void* cbInfo);
 
-const std::string configFilePathEnv = "FAULT_INJECTOR_CONFIG_PATH";
+std::string const configFilePathEnv = "FAULT_INJECTOR_CONFIG_PATH";
 CUptiResult cuptiInitialize(void);
 void readFaultInjectorConfig(void);
 void traceConfig(boost::property_tree::ptree const& pTree);
@@ -94,7 +94,7 @@ void globalControlInit(void)
   globalControl.subscriber      = 0;
   globalControl.terminateThread = 0;
   spdlog::trace("checking environment {}", configFilePathEnv);
-  const char* configFilePath = std::getenv(configFilePathEnv.c_str());
+  char const* configFilePath = std::getenv(configFilePathEnv.c_str());
   spdlog::debug("{} is {}", configFilePathEnv, configFilePath);
   if (configFilePath) {
     globalControl.configFilePath = std::string(configFilePath);
@@ -145,7 +145,7 @@ __global__ static void faultInjectorKernelTrap(void) { asm("trap;"); }
 
 boost::optional<boost::property_tree::ptree&> lookupConfig(
   boost::optional<boost::property_tree::ptree&> domainConfigs,
-  const char* key,
+  char const* key,
   CUpti_CallbackId cbid)
 {
   boost::optional<boost::property_tree::ptree&> faultConfig =
@@ -160,7 +160,7 @@ void CUPTIAPI faultInjectionCallbackHandler(void*,
                                             CUpti_CallbackId cbid,
                                             void* cbdata)
 {
-  const std::string faultInjectorKernelPrefix = std::string("faultInjectorKernel");
+  std::string const faultInjectorKernelPrefix = std::string("faultInjectorKernel");
 
   CUpti_CallbackData* cbInfo = static_cast<CUpti_CallbackData*>(cbdata);
 
@@ -243,22 +243,22 @@ void CUPTIAPI faultInjectionCallbackHandler(void*,
 
   // numeric value of FaultInjectionType: 0 (PTX trap), 1 (device assert), 2
   // (return code)
-  const std::string injectionTypeKey        = "injectionType";
-  const std::string substituteReturnCodeKey = "substituteReturnCode";
-  const std::string percentKey              = "percent";
-  const std::string interceptionCountKey    = "interceptionCount";
+  std::string const injectionTypeKey        = "injectionType";
+  std::string const substituteReturnCodeKey = "substituteReturnCode";
+  std::string const percentKey              = "percent";
+  std::string const interceptionCountKey    = "interceptionCount";
 
-  const int injectionType = (*matchedFaultConfig)
+  int const injectionType = (*matchedFaultConfig)
                               .get_optional<int>(injectionTypeKey)
                               .value_or(static_cast<int>(FI_RETURN_VALUE));
 
-  const int substituteReturnCode = (*matchedFaultConfig)
+  int const substituteReturnCode = (*matchedFaultConfig)
                                      .get_optional<int>(substituteReturnCodeKey)
                                      .value_or(static_cast<int>(CUDA_SUCCESS));
 
-  const int injectionProbability = (*matchedFaultConfig).get_optional<int>(percentKey).value_or(0);
+  int const injectionProbability = (*matchedFaultConfig).get_optional<int>(percentKey).value_or(0);
 
-  const int interceptionCount =
+  int const interceptionCount =
     (*matchedFaultConfig).get_optional<int>(interceptionCountKey).value_or(INT_MAX);
 
   spdlog::trace(
@@ -285,8 +285,8 @@ void CUPTIAPI faultInjectionCallbackHandler(void*,
 
   if (injectionProbability < 100) {
     if (injectionProbability <= 0) { return; }
-    const int rand10000     = std::rand() % 10000;
-    const int skipThreshold = injectionProbability * 10000 / 100;
+    int const rand10000     = std::rand() % 10000;
+    int const skipThreshold = injectionProbability * 10000 / 100;
     spdlog::trace("rand1000={} skipThreshold={}", rand10000, skipThreshold);
     if (rand10000 >= skipThreshold) { return; }
     spdlog::debug(
@@ -313,7 +313,7 @@ void CUPTIAPI faultInjectionCallbackHandler(void*,
     spdlog::debug("updating interception count {}: before locking", interceptionCount);
     // TODO the lock is too coarse-grained.
     PTHREAD_CALL(pthread_rwlock_wrlock(&globalControl.configLock));
-    const int interceptionCount = (*matchedFaultConfig).get<int>("interceptionCount");
+    int const interceptionCount = (*matchedFaultConfig).get<int>("interceptionCount");
     (*matchedFaultConfig).put("interceptionCount", interceptionCount - 1);
     PTHREAD_CALL(pthread_rwlock_unlock(&globalControl.configLock));
   }
@@ -361,41 +361,41 @@ void readFaultInjectorConfig(void)
 
   // to retrieve and the numeric value of spdlog:level::level_enum
   // https://github.com/gabime/spdlog/blob/d546201f127c306ec8a0082d57562a05a049af77/include/spdlog/common.h#L198-L204
-  const std::string logLevelKey = "logLevel";
+  std::string const logLevelKey = "logLevel";
 
   // A Boolean flag as to whether to watch for config file modifications
   // and apply changes after initial boot config.
   // Currently only file-based config is supported,
   // TODO add a socket for remote config
   //
-  const std::string dynamicConfigKey = "dynamic";
+  std::string const dynamicConfigKey = "dynamic";
 
   // An unsigned int to seed the random number generator to deterministically
   // recreate a fault sequence
   //
-  const std::string seedKey = "seed";
+  std::string const seedKey = "seed";
 
   // To retrieve a map of driver/runtime fault configs
   //   "functionName" -> fault config
   //   "CUPT callback id" -> fault config
   //   "*" -> fault config
-  const std::string driverFaultsKey  = "cudaDriverFaults";
-  const std::string runtimeFaultsKey = "cudaRuntimeFaults";
+  std::string const driverFaultsKey  = "cudaDriverFaults";
+  std::string const runtimeFaultsKey = "cudaRuntimeFaults";
 
   PTHREAD_CALL(pthread_rwlock_wrlock(&globalControl.configLock));
   try {
     boost::property_tree::read_json(jsonStream, globalControl.configRoot);
-    const int logLevel = globalControl.configRoot.get_optional<int>(logLevelKey).value_or(0);
+    int const logLevel = globalControl.configRoot.get_optional<int>(logLevelKey).value_or(0);
 
     globalControl.dynamic =
       globalControl.configRoot.get_optional<bool>(dynamicConfigKey).value_or(false);
 
-    const unsigned seed =
+    unsigned const seed =
       globalControl.configRoot.get_optional<unsigned>(seedKey).value_or(std::time(0));
     spdlog::info("Seeding std::srand with {}", seed);
     std::srand(seed);
 
-    const spdlog::level::level_enum logLevelEnum = static_cast<spdlog::level::level_enum>(logLevel);
+    spdlog::level::level_enum const logLevelEnum = static_cast<spdlog::level::level_enum>(logLevel);
     spdlog::info("changed log level to {}", logLevel);
     spdlog::set_level(logLevelEnum);
     traceConfig(globalControl.configRoot);
@@ -433,13 +433,13 @@ int eventCheck(int fd)
 void* dynamicReconfig(void*)
 {
   spdlog::debug("config watcher thread: inotify_init()");
-  const int inotifyFd = inotify_init();
+  int const inotifyFd = inotify_init();
   if (inotifyFd < 0) {
     spdlog::error("inotify_init() failed");
     return nullptr;
   }
   spdlog::debug("config watcher thread: inotify_add_watch {}", globalControl.configFilePath);
-  const int watchFd = inotify_add_watch(inotifyFd, globalControl.configFilePath.c_str(), IN_MODIFY);
+  int const watchFd = inotify_add_watch(inotifyFd, globalControl.configFilePath.c_str(), IN_MODIFY);
   if (watchFd < 0) {
     spdlog::error("config watcher thread: inotify_add_watch {} failed",
                   globalControl.configFilePath);
@@ -449,16 +449,16 @@ void* dynamicReconfig(void*)
   constexpr auto MAX_EVENTS = 1024;
   constexpr auto EVENT_SIZE = sizeof(struct inotify_event);
 
-  const auto configFilePathStr = std::string(globalControl.configFilePath);
-  const auto BUF_LEN           = MAX_EVENTS * (EVENT_SIZE + configFilePathStr.length());
+  auto const configFilePathStr = std::string(globalControl.configFilePath);
+  auto const BUF_LEN           = MAX_EVENTS * (EVENT_SIZE + configFilePathStr.length());
   char eventBuffer[BUF_LEN];
 
   while (!globalControl.terminateThread) {
     spdlog::trace("about to call eventCheck");
-    const int eventCheckRes = eventCheck(inotifyFd);
+    int const eventCheckRes = eventCheck(inotifyFd);
     spdlog::trace("eventCheck returned {}", eventCheckRes);
     if (eventCheckRes > 0) {
-      const int length = read(inotifyFd, eventBuffer, BUF_LEN);
+      int const length = read(inotifyFd, eventBuffer, BUF_LEN);
       spdlog::debug("config watcher thread: read {} bytes", length);
       if (length < EVENT_SIZE) { continue; }
       for (int i = 0; i < length;) {

--- a/src/main/cpp/profiler/NvtxwEvents.cpp
+++ b/src/main/cpp/profiler/NvtxwEvents.cpp
@@ -27,11 +27,11 @@ namespace NvidiaNvtxw {
   {(flags), (type), (name), nullptr, 0, 0, nullptr, nullptr}
 
 // The C string containing the event's name must be provided in a special way.
-static const nvtxPayloadSchemaEntry_t nameSchema[] = {PAYLOAD_ENTRY_SIMPLE(
+static nvtxPayloadSchemaEntry_t const nameSchema[] = {PAYLOAD_ENTRY_SIMPLE(
   NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE | NVTX_PAYLOAD_ENTRY_FLAG_ARRAY_ZERO_TERMINATED,
   NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
   "name")};
-static const nvtxPayloadSchemaAttr_t nameSchemaAttr{
+static nvtxPayloadSchemaAttr_t const nameSchemaAttr{
   /*.fieldMask = */
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_FLAGS |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
@@ -55,7 +55,7 @@ static const nvtxPayloadSchemaAttr_t nameSchemaAttr{
   /*.extension = */
   nullptr};
 
-static const nvtxPayloadSchemaEntry_t nvtxRangeSchema[] = {
+static nvtxPayloadSchemaEntry_t const nvtxRangeSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN | NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE,
                        NVTX_PAYLOAD_ENTRY_TYPE_UINT64,
                        "time_start"),
@@ -70,7 +70,7 @@ static const nvtxPayloadSchemaEntry_t nvtxRangeSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_COLOR_ARGB, "color"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "push_pop")};
 // TimeBase = Relative
-static const nvtxPayloadSchemaAttr_t nvtxRangePushPopSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const nvtxRangePushPopSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -84,7 +84,7 @@ static const nvtxPayloadSchemaAttr_t nvtxRangePushPopSchemaAttr = {
   NvidiaNvtxw::PayloadSchemaId::nvtxRangePushPopId,
   nullptr};
 // TimeBase = Relative
-static const nvtxPayloadSchemaAttr_t nvtxRangeStartEndSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const nvtxRangeStartEndSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -98,7 +98,7 @@ static const nvtxPayloadSchemaAttr_t nvtxRangeStartEndSchemaAttr = {
   NvidiaNvtxw::PayloadSchemaId::nvtxRangeStartEndId,
   nullptr};
 
-static const nvtxPayloadSchemaEntry_t cuptiApiSchema[] = {
+static nvtxPayloadSchemaEntry_t const cuptiApiSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN | NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE,
                        NVTX_PAYLOAD_ENTRY_TYPE_UINT64,
                        "time_start"),
@@ -111,7 +111,7 @@ static const nvtxPayloadSchemaEntry_t cuptiApiSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_TID_UINT32, "thread_id"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT32, "correlation_id"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT32, "return_value")};
-static const nvtxPayloadSchemaAttr_t cuptiApiSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const cuptiApiSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -124,7 +124,7 @@ static const nvtxPayloadSchemaAttr_t cuptiApiSchemaAttr = {
   0,
   NvidiaNvtxw::PayloadSchemaId::cuptiApiId,
   nullptr};
-static const nvtxPayloadSchemaEntry_t cuptiDeviceSchema[] = {
+static nvtxPayloadSchemaEntry_t const cuptiDeviceSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT64, "global_memory_bandwidth"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT64, "global_memory_size"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT32, "constant_memory_size"),
@@ -154,7 +154,7 @@ static const nvtxPayloadSchemaEntry_t cuptiDeviceSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE | NVTX_PAYLOAD_ENTRY_FLAG_POINTER,
                        NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
                        "name")};
-static const nvtxPayloadSchemaAttr_t cuptiDeviceSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const cuptiDeviceSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -167,7 +167,7 @@ static const nvtxPayloadSchemaAttr_t cuptiDeviceSchemaAttr = {
   0,
   NvidiaNvtxw::PayloadSchemaId::cuptiDeviceId,
   nullptr};
-static const nvtxPayloadSchemaEntry_t cuptiKernelSchema[] = {
+static nvtxPayloadSchemaEntry_t const cuptiKernelSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN | NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE,
                        NVTX_PAYLOAD_ENTRY_TYPE_UINT64,
                        "time_start"),
@@ -216,7 +216,7 @@ static const nvtxPayloadSchemaEntry_t cuptiKernelSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "shared_memory_carveout_requested"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "shmem_limit_config"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "channel_type")};
-static const nvtxPayloadSchemaAttr_t cuptiKernelSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const cuptiKernelSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -229,7 +229,7 @@ static const nvtxPayloadSchemaAttr_t cuptiKernelSchemaAttr = {
   0,
   NvidiaNvtxw::PayloadSchemaId::cuptiKernelId,
   nullptr};
-static const nvtxPayloadSchemaEntry_t cuptiMemcpySchema[] = {
+static nvtxPayloadSchemaEntry_t const cuptiMemcpySchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN | NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE,
                        NVTX_PAYLOAD_ENTRY_TYPE_UINT64,
                        "time_start"),
@@ -250,7 +250,7 @@ static const nvtxPayloadSchemaEntry_t cuptiMemcpySchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "copy_kind"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "src_kind"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "dst_kind")};
-static const nvtxPayloadSchemaAttr_t cuptiMemcpySchemaAttr = {
+static nvtxPayloadSchemaAttr_t const cuptiMemcpySchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -263,7 +263,7 @@ static const nvtxPayloadSchemaAttr_t cuptiMemcpySchemaAttr = {
   0,
   NvidiaNvtxw::PayloadSchemaId::cuptiMemcpyId,
   nullptr};
-static const nvtxPayloadSchemaEntry_t cuptiMemsetSchema[] = {
+static nvtxPayloadSchemaEntry_t const cuptiMemsetSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN | NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE,
                        NVTX_PAYLOAD_ENTRY_TYPE_UINT64,
                        "time_start"),
@@ -283,7 +283,7 @@ static const nvtxPayloadSchemaEntry_t cuptiMemsetSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "channel_type"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "mem_kind"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "flags")};
-static const nvtxPayloadSchemaAttr_t cuptiMemsetSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const cuptiMemsetSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -296,7 +296,7 @@ static const nvtxPayloadSchemaAttr_t cuptiMemsetSchemaAttr = {
   0,
   NvidiaNvtxw::PayloadSchemaId::cuptiMemsetId,
   nullptr};
-static const nvtxPayloadSchemaEntry_t cuptiOverheadSchema[] = {
+static nvtxPayloadSchemaEntry_t const cuptiOverheadSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(NVTX_PAYLOAD_ENTRY_FLAG_RANGE_BEGIN | NVTX_PAYLOAD_ENTRY_FLAG_EVENT_MESSAGE,
                        NVTX_PAYLOAD_ENTRY_TYPE_UINT64,
                        "time_start"),
@@ -307,7 +307,7 @@ static const nvtxPayloadSchemaEntry_t cuptiOverheadSchema[] = {
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_TID_UINT32, "thread_id"),
   PAYLOAD_ENTRY_SIMPLE(0, NVTX_PAYLOAD_ENTRY_TYPE_UINT8, "overhead_kind"),
 };
-static const nvtxPayloadSchemaAttr_t cuptiOverheadSchemaAttr = {
+static nvtxPayloadSchemaAttr_t const cuptiOverheadSchemaAttr = {
   NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
     NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_SCHEMA_ID,
@@ -323,18 +323,18 @@ static const nvtxPayloadSchemaAttr_t cuptiOverheadSchemaAttr = {
 #undef PAYLOAD_ENTRY_SIMPLE
 
 const nvtxPayloadSchemaAttr_t* GetNameSchemaAttr() { return &nameSchemaAttr; }
-const nvtxPayloadSchemaAttr_t* GetNvtxRangePushPopSchemaAttr()
+nvtxPayloadSchemaAttr_t const* GetNvtxRangePushPopSchemaAttr()
 {
   return &nvtxRangePushPopSchemaAttr;
 }
-const nvtxPayloadSchemaAttr_t* GetNvtxRangeStartEndSchemaAttr()
+nvtxPayloadSchemaAttr_t const* GetNvtxRangeStartEndSchemaAttr()
 {
   return &nvtxRangeStartEndSchemaAttr;
 }
-const nvtxPayloadSchemaAttr_t* GetCuptiApiSchemaAttr() { return &cuptiApiSchemaAttr; }
-const nvtxPayloadSchemaAttr_t* GetCuptiDeviceSchemaAttr() { return &cuptiDeviceSchemaAttr; }
-const nvtxPayloadSchemaAttr_t* GetCuptiKernelSchemaAttr() { return &cuptiKernelSchemaAttr; }
-const nvtxPayloadSchemaAttr_t* GetCuptiMemcpySchemaAttr() { return &cuptiMemcpySchemaAttr; }
-const nvtxPayloadSchemaAttr_t* GetCuptiMemsetSchemaAttr() { return &cuptiMemsetSchemaAttr; }
-const nvtxPayloadSchemaAttr_t* GetCuptiOverheadSchemaAttr() { return &cuptiOverheadSchemaAttr; }
+nvtxPayloadSchemaAttr_t const* GetCuptiApiSchemaAttr() { return &cuptiApiSchemaAttr; }
+nvtxPayloadSchemaAttr_t const* GetCuptiDeviceSchemaAttr() { return &cuptiDeviceSchemaAttr; }
+nvtxPayloadSchemaAttr_t const* GetCuptiKernelSchemaAttr() { return &cuptiKernelSchemaAttr; }
+nvtxPayloadSchemaAttr_t const* GetCuptiMemcpySchemaAttr() { return &cuptiMemcpySchemaAttr; }
+nvtxPayloadSchemaAttr_t const* GetCuptiMemsetSchemaAttr() { return &cuptiMemsetSchemaAttr; }
+nvtxPayloadSchemaAttr_t const* GetCuptiOverheadSchemaAttr() { return &cuptiOverheadSchemaAttr; }
 }  // namespace NvidiaNvtxw

--- a/src/main/cpp/profiler/NvtxwEvents.h
+++ b/src/main/cpp/profiler/NvtxwEvents.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  *
  * you may not use this file except in compliance with the License.
@@ -37,18 +37,18 @@ static constexpr uint64_t cuptiOverheadId     = 0xffffff07;
 static constexpr uint64_t nvtxRangeStartEndId = 0xffffff08;
 };  // namespace PayloadSchemaId
 
-const nvtxPayloadSchemaAttr_t* GetNameSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetNameSchemaAttr();
 
 struct nvtxRangeEvent {
   uint64_t time_start;
   uint64_t time_stop;
-  const char* name;
+  char const* name;
   uint32_t process_id;
   uint32_t thread_id;
   uint32_t color;
 };
-const nvtxPayloadSchemaAttr_t* GetNvtxRangePushPopSchemaAttr();
-const nvtxPayloadSchemaAttr_t* GetNvtxRangeStartEndSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetNvtxRangePushPopSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetNvtxRangeStartEndSchemaAttr();
 struct cuptiApiEvent {
   uint64_t time_start;
   uint64_t time_stop;
@@ -59,7 +59,7 @@ struct cuptiApiEvent {
   uint32_t correlation_id;
   uint32_t return_value;
 };
-const nvtxPayloadSchemaAttr_t* GetCuptiApiSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetCuptiApiSchemaAttr();
 struct cuptiDevice {
   uint64_t global_memory_bandwidth;
   uint64_t global_memory_size;
@@ -87,9 +87,9 @@ struct cuptiDevice {
   uint32_t compute_capability_minor;
   uint32_t id;
   uint32_t ecc_enabled;
-  const char* name;
+  char const* name;
 };
-const nvtxPayloadSchemaAttr_t* GetCuptiDeviceSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetCuptiDeviceSchemaAttr();
 struct cuptiKernelEvent {
   uint64_t time_start;
   uint64_t time_stop;
@@ -99,7 +99,7 @@ struct cuptiKernelEvent {
   uint64_t submitted;
   uint64_t graph_node_id;
   uint64_t local_memory_total_v2;
-  const char* name;
+  char const* name;
   uint32_t device_id;
   uint32_t context_id;
   uint32_t stream_id;
@@ -134,7 +134,7 @@ struct cuptiKernelEvent {
   uint8_t shmem_limit_config;
   uint8_t channel_type;
 };
-const nvtxPayloadSchemaAttr_t* GetCuptiKernelSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetCuptiKernelSchemaAttr();
 
 struct cuptiMemcpyEvent {
   uint64_t time_start;
@@ -154,7 +154,7 @@ struct cuptiMemcpyEvent {
   uint8_t src_kind;
   uint8_t dst_kind;
 };
-const nvtxPayloadSchemaAttr_t* GetCuptiMemcpySchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetCuptiMemcpySchemaAttr();
 
 struct cuptiMemsetEvent {
   uint64_t time_start;
@@ -173,7 +173,7 @@ struct cuptiMemsetEvent {
   uint8_t mem_kind;
   uint8_t flags;
 };
-const nvtxPayloadSchemaAttr_t* GetCuptiMemsetSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetCuptiMemsetSchemaAttr();
 struct cuptiOverheadEvent {
   uint64_t time_start;
   uint64_t time_stop;
@@ -181,6 +181,6 @@ struct cuptiOverheadEvent {
   uint32_t thread_id;
   uint8_t overhead_kind;
 };
-const nvtxPayloadSchemaAttr_t* GetCuptiOverheadSchemaAttr();
+nvtxPayloadSchemaAttr_t const* GetCuptiOverheadSchemaAttr();
 
 }  // namespace NvidiaNvtxw

--- a/src/main/cpp/profiler/ProfilerJni.cpp
+++ b/src/main/cpp/profiler/ProfilerJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -314,7 +314,7 @@ void domain_runtime_callback(CUpti_CallbackId callback_id, CUpti_CallbackData co
 void CUPTIAPI callback_handler(void*,
                                CUpti_CallbackDomain domain,
                                CUpti_CallbackId callback_id,
-                               const void* callback_data_ptr)
+                               void const* callback_data_ptr)
 {
   auto rc = cuptiGetLastError();
   if (rc != CUPTI_SUCCESS && !State->has_cupti_callback_errored) {

--- a/src/main/cpp/profiler/init_nvtxw.cpp
+++ b/src/main/cpp/profiler/init_nvtxw.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,10 @@
 
 namespace spark_rapids_jni::profiler {
 
-bool create_nvtxw_stream(const nvtxwInterfaceCore_t* nvtxwInterface,
-                         const nvtxwSessionHandle_t& session,
-                         const std::string& name,
-                         const std::string& domain,
+bool create_nvtxw_stream(nvtxwInterfaceCore_t const* nvtxwInterface,
+                         nvtxwSessionHandle_t const& session,
+                         std::string const& name,
+                         std::string const& domain,
                          nvtxwStreamHandle_t& stream)
 {
   nvtxwResultCode_t result           = NVTXW3_RESULT_SUCCESS;
@@ -64,12 +64,12 @@ bool create_nvtxw_stream(const nvtxwInterfaceCore_t* nvtxwInterface,
 
 /// outName: basename of output nsys-rep, without .nsys-rep extension
 int initialize_nvtxw(std::ifstream& in,
-                     const std::string& outPath,
+                     std::string const& outPath,
                      void*& nvtxwModuleHandle,
                      nvtxwInterfaceCore_t*& nvtxwInterface,
                      nvtxwSessionHandle_t& session,
                      nvtxwStreamHandle_t& stream,
-                     const std::optional<std::filesystem::path>& nvtxw_backend_path)
+                     std::optional<std::filesystem::path> const& nvtxw_backend_path)
 {
   nvtxwResultCode_t result = NVTXW3_RESULT_SUCCESS;
   int errorCode            = 0;
@@ -79,14 +79,14 @@ int initialize_nvtxw(std::ifstream& in,
   std::string sessionName = p.stem().string();
 
   // initialize
-  static const char soNameDefault[] = "libNvtxwBackend.so";
-  const char* soName                = soNameDefault;
+  static char const soNameDefault[] = "libNvtxwBackend.so";
+  char const* soName                = soNameDefault;
   // First check if a path was provided via command line option
   if (nvtxw_backend_path) {
     soName = nvtxw_backend_path->c_str();
   } else {
     // Otherwise, check the environment variable
-    const char* backend_env = getenv("NVTXW_BACKEND");
+    char const* backend_env = getenv("NVTXW_BACKEND");
     if (backend_env) { soName = backend_env; }
   }
   nvtxwGetInterface_t getInterfaceFunc = nullptr;
@@ -110,7 +110,7 @@ int initialize_nvtxw(std::ifstream& in,
     return 1;
   }
 
-  const void* interfaceVoid;
+  void const* interfaceVoid;
   result = getInterfaceFunc(NVTXW3_INTERFACE_ID_CORE_V1, &interfaceVoid);
   if (result != NVTXW3_RESULT_SUCCESS) {
     fprintf(stderr, "getInterfaceFunc failed with code %d\n", (int)result);

--- a/src/main/cpp/profiler/init_nvtxw.h
+++ b/src/main/cpp/profiler/init_nvtxw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,18 +28,18 @@
 
 namespace spark_rapids_jni::profiler {
 
-bool create_nvtxw_stream(const nvtxwInterfaceCore_t* nvtxwInterface,
-                         const nvtxwSessionHandle_t& session,
-                         const std::string& name,
-                         const std::string& domain,
+bool create_nvtxw_stream(nvtxwInterfaceCore_t const* nvtxwInterface,
+                         nvtxwSessionHandle_t const& session,
+                         std::string const& name,
+                         std::string const& domain,
                          nvtxwStreamHandle_t& stream);
 
 int initialize_nvtxw(std::ifstream& in,
-                     const std::string& outPath,
+                     std::string const& outPath,
                      void*& nvtxwModuleHandle,
                      nvtxwInterfaceCore_t*& nvtxwInterface,
                      nvtxwSessionHandle_t& session,
                      nvtxwStreamHandle_t& stream,
-                     const std::optional<std::filesystem::path>& nvtxw_backend_path = std::nullopt);
+                     std::optional<std::filesystem::path> const& nvtxw_backend_path = std::nullopt);
 
 }  // namespace spark_rapids_jni::profiler

--- a/src/main/cpp/profiler/nvtxw3.cpp
+++ b/src/main/cpp/profiler/nvtxw3.cpp
@@ -49,7 +49,7 @@
 /* Path string helpers -- implement here to avoid dependencies */
 
 #if defined(_WIN32)
-static const char pathSep = '\\';
+static char const pathSep = '\\';
 #if defined(NVTXW3_TEST_PATH_UTILITIES)
 static const char pathDelimiter = ';';
 #endif
@@ -59,7 +59,7 @@ static const size_t initialPathBufSize = MAX_PATH; /* Grows if not big enough */
 #define NVTXW3_DLLFUNC    GetProcAddress
 #define NVTXW3_DLLCLOSE   FreeLibrary
 #else
-static const char pathSep = '/';
+static char const pathSep = '/';
 #if defined(NVTXW3_TEST_PATH_UTILITIES)
 static const char pathDelimiter = ':';
 #endif
@@ -141,7 +141,7 @@ static void StripLeadingSlashes(char* path)
 /* Take pointers to string buffer begin/end.  End must equal begin + strlen(begin),
  *  or NULL, in which case it will be set to begin + strlen(begin).
  *  Returns pointer to heap-allocated copy of input, must be freed with free(). */
-static char* AssignHeapString(char* lhs, const char* rhs)
+static char* AssignHeapString(char* lhs, char const* rhs)
 {
   size_t lenWithNull;
 
@@ -153,7 +153,7 @@ static char* AssignHeapString(char* lhs, const char* rhs)
   return lhs;
 }
 
-static char* AssignHeapStringFromRange(char* lhs, const char* rhsBegin, const char* rhsEnd)
+static char* AssignHeapStringFromRange(char* lhs, char const* rhsBegin, char const* rhsEnd)
 {
   size_t lenWithoutNull;
 
@@ -169,9 +169,9 @@ static char* AssignHeapStringFromRange(char* lhs, const char* rhsBegin, const ch
 /* Take pointers to string buffer begin/end.  End must equal begin + strlen(begin),
  *  or NULL, in which case it will be set to begin + strlen(begin).
  *  Returns pointer to heap-allocated copy of input, must be freed with free(). */
-static char* MakeHeapString(const char* str) { return AssignHeapString(NULL, str); }
+static char* MakeHeapString(char const* str) { return AssignHeapString(NULL, str); }
 
-static char* MakeHeapStringFromRange(const char* strBegin, const char* strEnd)
+static char* MakeHeapStringFromRange(char const* strBegin, char const* strEnd)
 {
   return AssignHeapStringFromRange(NULL, strBegin, strEnd);
 }
@@ -188,7 +188,7 @@ static char* MakeHeapStringWithNativeSlashes(const char* str)
  *  reallocating the heap memory for lhs if necessary.  Returns pointer to result
  *  HeapString, which may or may not be the same pointer passed in as lhs.
  *  HeapString must be freed with free(). */
-static char* AppendToHeapString(char* lhs, const char* rhs)
+static char* AppendToHeapString(char* lhs, char const* rhs)
 {
   size_t lenLhs, lenRhs;
   lenLhs = strlen(lhs);
@@ -206,7 +206,7 @@ static char* AppendToHeapString(char* lhs, const char* rhs)
  *  lhs is null or empty and rhs is not, then the result is a path separator
  *  followed by rhs.  Returns pointer to result HeapString, which may or may not
  *  be the same pointer passed in as lhs.  HeapString must be freed with free(). */
-static char* AppendToHeapStringWithSep(char* lhs, const char* rhs)
+static char* AppendToHeapStringWithSep(char* lhs, char const* rhs)
 {
   size_t lenLhs, lenRhs;
   lenLhs = strlen(lhs);
@@ -223,15 +223,15 @@ static char* AppendToHeapStringWithSep(char* lhs, const char* rhs)
  *  relativePath must be a valid relative path (not empty, not just slashes).
  *  Returns pointer to result HeapString, which may or may not be the same
  *  pointer passed in as lhs.  HeapString must be freed with free(). */
-static char* AppendToPathHeapString(char* dir, const char* relativePath)
+static char* AppendToPathHeapString(char* dir, char const* relativePath)
 {
-  const char* relPathAfterLeadingSlashes;
+  char const* relPathAfterLeadingSlashes;
   relPathAfterLeadingSlashes = AfterLeadingSlashesConst(relativePath);
   StripTrailingSlashes(dir);
   return AppendToHeapStringWithSep(dir, relPathAfterLeadingSlashes);
 }
 
-static char* LoadFileIntoHeapString(const char* filename)
+static char* LoadFileIntoHeapString(char const* filename)
 {
   FILE* f;
   char* buf;
@@ -281,7 +281,7 @@ static int HasSlashes(const char* cur)
   return 0;
 }
 
-static int HasTrailingSlash(const char* str)
+static int HasTrailingSlash(char const* str)
 {
   size_t len = strlen(str);
   if (len == 0) return 0;
@@ -318,7 +318,7 @@ static char* GetCurrentWorkingDir()
 /* Take pointer to string buffer of possibly-relative path, and returns
  *  equivalent absolute path.  Input path must not be empty.
  *  Returns pointer to heap-allocated string, must be freed with free(). */
-static char* AbsolutePath(const char* path)
+static char* AbsolutePath(char const* path)
 {
 #if defined(_WIN32)
   size_t size;
@@ -390,7 +390,7 @@ static char* ToParentDir(char* path)
  *  NULL, empty string, or root directory, NULL is returned to indicate there
  *  is no parent directory, so return value must be NULL-checked.
  *  Returns pointer to heap-allocated string, must be freed with free(). */
-static char* ParentDir(const char* path)
+static char* ParentDir(char const* path)
 {
   char* buf;
 
@@ -407,7 +407,7 @@ static char* ParentDir(const char* path)
   }
 }
 
-static int PathExists(const char* path)
+static int PathExists(char const* path)
 {
 #if defined(_WIN32)
   DWORD result = GetFileAttributesA(path);
@@ -461,7 +461,7 @@ static char* GetCurrentProcessPath()
     size_t size = initialPathBufSize;
     ssize_t bytesReadSigned;
     size_t bytesRead;
-    const char* linkName = "/proc/self/exe";
+    char const* linkName = "/proc/self/exe";
     buf                  = NULL;
     while (1) {
       buf             = (char*)realloc(buf, size);
@@ -483,10 +483,10 @@ static char* GetCurrentProcessPath()
 static char* GetCurrentProcessDir() { return ToParentDir(GetCurrentProcessPath()); }
 
 static int KVPConsumerForSimplify(void* state,
-                                  const char* readKeyBegin,
-                                  const char* readKeyEnd,
-                                  const char* readValBegin,
-                                  const char* readValEnd)
+                                  char const* readKeyBegin,
+                                  char const* readKeyEnd,
+                                  char const* readValBegin,
+                                  char const* readValEnd)
 {
   char* curWrite = *(char**)state;
   size_t size;
@@ -535,16 +535,16 @@ typedef struct GetInitModeState_t {
 } GetInitModeState_t;
 
 static int KVPConsumerForGetInitMode(void* statePtr,
-                                     const char* keyBegin,
-                                     const char* keyEnd,
-                                     const char* valBegin,
-                                     const char* valEnd)
+                                     char const* keyBegin,
+                                     char const* keyEnd,
+                                     char const* valBegin,
+                                     char const* valEnd)
 {
   GetInitModeState_t* state       = (GetInitModeState_t*)statePtr;
-  const char* const keyMode       = "InitMode";
-  const char* const keyModeString = "InitModeString";
-  const size_t keyModeLen         = strlen(keyMode);
-  const size_t keyModeStringLen   = strlen(keyModeString);
+  char const* const keyMode       = "InitMode";
+  char const* const keyModeString = "InitModeString";
+  size_t const keyModeLen         = strlen(keyMode);
+  size_t const keyModeStringLen   = strlen(keyModeString);
   size_t keyLen;
 
   keyLen = keyEnd - keyBegin;
@@ -574,7 +574,7 @@ static int KVPConsumerForGetInitMode(void* statePtr,
 /* Returns zero for success, and writes out params mode and modeString (the latter
  *  is a HeapString).  If mode is not detected, or if the mode requires a modeString
  *  and modeString is not detected, return non-zero error code. */
-static int GetInitModeFromConfig(const char* config, int* mode, char** modeString)
+static int GetInitModeFromConfig(char const* config, int* mode, char** modeString)
 {
   GetInitModeState_t state = {0};
 
@@ -602,8 +602,8 @@ static int GetInitModeFromConfig(const char* config, int* mode, char** modeStrin
 /* Backend loader helpers */
 
 static nvtxwResultCode_t InitLibraryFilename(
-  const char* filename,                  /* required */
-  const char* configString,              /* optional */
+  char const* filename,                  /* required */
+  char const* configString,              /* optional */
   nvtxwGetInterface_t* getInterfaceFunc, /* already null-checked */
   void** moduleHandle)                   /* optional */
 {
@@ -649,7 +649,7 @@ static nvtxwResultCode_t InitLibraryFilename(
 }
 
 static nvtxwResultCode_t InitSearchDefault(
-  const char* configString,              /* optional */
+  char const* configString,              /* optional */
   nvtxwGetInterface_t* getInterfaceFunc, /* already null-checked */
   void** moduleHandle)                   /* optional */
 {
@@ -677,8 +677,8 @@ static nvtxwResultCode_t InitSearchDefault(
 }
 
 static nvtxwResultCode_t InitLibraryDirectory(
-  const char* directory,                 /* required */
-  const char* configString,              /* optional */
+  char const* directory,                 /* required */
+  char const* configString,              /* optional */
   nvtxwGetInterface_t* getInterfaceFunc, /* already null-checked */
   void** moduleHandle)                   /* optional */
 {
@@ -695,7 +695,7 @@ static nvtxwResultCode_t InitLibraryDirectory(
   return result;
 }
 
-static nvtxwResultCode_t InitConfigString(const char* config,
+static nvtxwResultCode_t InitConfigString(char const* config,
                                           nvtxwGetInterface_t* getInterfaceFunc,
                                           void** moduleHandle)
 {
@@ -729,11 +729,11 @@ static nvtxwResultCode_t InitConfigString(const char* config,
   return result;
 }
 
-static nvtxwResultCode_t InitConfigEnvVar(const char* configEnvVarName,
+static nvtxwResultCode_t InitConfigEnvVar(char const* configEnvVarName,
                                           nvtxwGetInterface_t* getInterfaceFunc,
                                           void** moduleHandle)
 {
-  const char* config;
+  char const* config;
 
   if (!configEnvVarName) return NVTXW3_RESULT_INVALID_ARGUMENT;
 
@@ -743,7 +743,7 @@ static nvtxwResultCode_t InitConfigEnvVar(const char* configEnvVarName,
   return InitConfigString(config, getInterfaceFunc, moduleHandle);
 }
 
-static nvtxwResultCode_t InitConfigFilename(const char* configFilename,
+static nvtxwResultCode_t InitConfigFilename(char const* configFilename,
                                             nvtxwGetInterface_t* getInterfaceFunc,
                                             void** moduleHandle)
 {
@@ -760,7 +760,7 @@ static nvtxwResultCode_t InitConfigFilename(const char* configFilename,
   return result;
 }
 
-static nvtxwResultCode_t InitConfigDirectory(const char* configDirectory,
+static nvtxwResultCode_t InitConfigDirectory(char const* configDirectory,
                                              nvtxwGetInterface_t* getInterfaceFunc,
                                              void** moduleHandle)
 {

--- a/src/main/cpp/profiler/nvtxw3.h
+++ b/src/main/cpp/profiler/nvtxw3.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023, NVIDIA CORPORATION.
+ *  Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@ typedef int32_t nvtxwInitMode_t;
  *  In C++, you can construct a string using std::string(keyBegin, keyEnd).
  *  Return zero to continue consuming key/value pairs, or non-zero to stop. */
 typedef int (*nvtxwKeyValuePairConsumer_t)(
-  void* state, const char* keyBegin, const char* keyEnd, const char* valBegin, const char* valEnd);
+  void* state, char const* keyBegin, char const* keyEnd, char const* valBegin, char const* valEnd);
 
 /* Parse config and call the consumer callback (see typedef above) on each
  *  valid key/value pair found in the config.  Inline implementation provided
@@ -171,22 +171,22 @@ typedef int (*nvtxwKeyValuePairConsumer_t)(
  *  having to include nvtxw3.c in their build.  Users of the NVTXW API may
  *  also find it useful to parse/modify a config before passing it to NVTXW. */
 NVTX_LINKONCE_DEFINE_FUNCTION
-void nvtxwConsumeConfigString(const char* config, nvtxwKeyValuePairConsumer_t consumer, void* state)
+void nvtxwConsumeConfigString(char const* config, nvtxwKeyValuePairConsumer_t consumer, void* state)
 {
-  const char* curRead          = config;
-  const char* const lineBreak  = "|\n\r";
-  const char* const whitespace = " \t\v"; /* Not including lineBreak characters */
+  char const* curRead          = config;
+  char const* const lineBreak  = "|\n\r";
+  char const* const whitespace = " \t\v"; /* Not including lineBreak characters */
   int consumerStopRequested    = 0;
 
   if (!config || !consumer) return;
 
   while (*curRead && !consumerStopRequested) {
-    const char* lineBegin;
-    const char* lineEnd;
-    const char* keyBegin;
-    const char* keyEnd;
-    const char* valBegin;
-    const char* valEnd;
+    char const* lineBegin;
+    char const* lineEnd;
+    char const* keyBegin;
+    char const* keyEnd;
+    char const* valBegin;
+    char const* valEnd;
 
     /* Read a line, trimming leading whitespace - get pointers to begin/end */
     lineBegin = curRead + strspn(curRead, whitespace);
@@ -238,7 +238,7 @@ void nvtxwConsumeConfigString(const char* config, nvtxwKeyValuePairConsumer_t co
 typedef int32_t nvtxwInterfaceId_t;
 
 typedef nvtxwResultCode_t (*nvtxwGetInterface_t)(nvtxwInterfaceId_t interfaceId,
-                                                 const void** iface);
+                                                 void const** iface);
 
 /* Initialize the NVTXW library by providing information on how to
  *  load the backend library that implements the NVTXW API.  `mode` must
@@ -258,7 +258,7 @@ typedef nvtxwResultCode_t (*nvtxwGetInterface_t)(nvtxwInterfaceId_t interfaceId,
  *  library when NVTXW3_RESULT_SUCCESS is returned.  This can be passed
  *  to nvtxwUnload to unload the backend library. */
 NVTXW3_DECLSPEC nvtxwResultCode_t nvtxwInitialize(nvtxwInitMode_t mode,
-                                                  const char* modeString,
+                                                  char const* modeString,
                                                   nvtxwGetInterface_t* getInterfaceFunc,
                                                   void** moduleHandle);
 
@@ -273,7 +273,7 @@ NVTXW3_DECLSPEC void nvtxwUnload(void* moduleHandle);
 
 /*----- Typedefs for function pointers backend implements -----*/
 
-typedef nvtxwResultCode_t (*nvtxwLoadImplementation_t)(const char* configString,
+typedef nvtxwResultCode_t (*nvtxwLoadImplementation_t)(char const* configString,
                                                        nvtxwGetInterface_t* getInterfaceFunc);
 
 typedef void (*nvtxwUnloadImplementation_t)();
@@ -300,7 +300,7 @@ typedef struct nvtxwSessionAttributes_v1 {
   /* Provide a name for the session.
    *  Tools may display this name, or use it to name a file or directory
    *  representing the session. */
-  const char* name;
+  char const* name;
 
   /* String containing configuration options for the session.
    *  Format is key=value, one per line, delimited by \n (line feed).
@@ -310,7 +310,7 @@ typedef struct nvtxwSessionAttributes_v1 {
    *  options not provided, and ignore any keys they do not support.
    *  See above for explanation of how config strings are provided.
    *  See tool-specific documentation for lists of supported keys. */
-  const char* configString;
+  char const* configString;
 } nvtxwSessionAttributes_t;
 
 /* Define whether event ordering in a stream is based on event scope */
@@ -383,7 +383,7 @@ typedef struct nvtxwStreamAttributes_v1 {
   /* Name of a stream, used for identification from other streams.
    *  Tools typically will not display stream names.  No two streams
    *  in the same session may have the same name. */
-  const char* name;
+  char const* name;
 
   /* Name of NVTX domain to use implicitly for all events written into
    *  this stream.  Since registered IDs are required to be unique within
@@ -399,7 +399,7 @@ typedef struct nvtxwStreamAttributes_v1 {
    *  occurs on a different thread.  Tools are expected to combine data
    *  from any domains registered with the same name, even between NVTXW
    *  and NVTX, when merging data acquired from both APIs. */
-  const char* nvtxDomainName;
+  char const* nvtxDomainName;
 
   /* The default scope for all events in the stream that don't specify
    *  any scope.  See comments below for nvtxwEventScopeAttributes_t.
@@ -409,7 +409,7 @@ typedef struct nvtxwStreamAttributes_v1 {
    *  "nvtxwStream[name]" referencing a different stream by its name
    *  (see above) to use its default scope is supported, as long as that
    *  stream was successfully opened (and may be already closed). */
-  const char* eventScopePath;
+  char const* eventScopePath;
 
   /* Information about event ordering inside the stream.  See comments
    *  for #defines above. */
@@ -441,7 +441,7 @@ typedef struct nvtxwEventScopeAttributes_v1 {
    *  child node of the scope, since multiple domains can assign
    *  events to the same scope, and tools should isolate events
    *  from separate domains. */
-  const char* path;
+  char const* path;
 
   /* Static event scope ID must be provided, unique within the domain,
      >= NVTX_EVENT_SCOPE_ID_STATIC_START, and
@@ -464,7 +464,7 @@ typedef struct nvtxwInterfaceCore_v1 {
    *  from one or more streams.  Takes a growable struct of session
    *  attributes (see nvtxwSessionAttributes_t). */
   nvtxwResultCode_t (*SessionBegin)(nvtxwSessionHandle_t* session,
-                                    const nvtxwSessionAttributes_t* attr);
+                                    nvtxwSessionAttributes_t const* attr);
 
   /* Notify the implementation that all trace data for the session
    *  has been provided, and the session may be destroyed.  Depending
@@ -483,7 +483,7 @@ typedef struct nvtxwInterfaceCore_v1 {
    *  stream are ordered. */
   nvtxwResultCode_t (*StreamOpen)(nvtxwStreamHandle_t* stream,
                                   nvtxwSessionHandle_t session,
-                                  const nvtxwStreamAttributes_t* attr);
+                                  nvtxwStreamAttributes_t const* attr);
 
   /* Destroy the stream object.  This is not expected to trigger a
    *  reaction in the implementation that no more events are coming;
@@ -496,7 +496,7 @@ typedef struct nvtxwInterfaceCore_v1 {
    *  >= NVTX_EVENT_SCOPE_ID_STATIC_START, and
    *  <  NVTX_EVENT_SCOPE_ID_DYNAMIC_START */
   nvtxwResultCode_t (*EventScopeRegister)(nvtxwStreamHandle_t stream,
-                                          const nvtxwEventScopeAttributes_t* attr);
+                                          nvtxwEventScopeAttributes_t const* attr);
 
   /* Register a schema ID to represent a schema, which describes the
    *  binary layout of a payload.
@@ -504,21 +504,21 @@ typedef struct nvtxwInterfaceCore_v1 {
    *  >= NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START, and
    *  <  NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_DYNAMIC_START */
   nvtxwResultCode_t (*SchemaRegister)(nvtxwStreamHandle_t stream,
-                                      const nvtxPayloadSchemaAttr_t* attr);
+                                      nvtxPayloadSchemaAttr_t const* attr);
 
   /* Register a schema ID to represent an enum type, including the
   *  mapping between its values and their name strings.
   *  Static schema ID must be provided, unique within the domain,
      >= NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START, and
      <  NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_DYNAMIC_START */
-  nvtxwResultCode_t (*EnumRegister)(nvtxwStreamHandle_t stream, const nvtxPayloadEnumAttr_t* attr);
+  nvtxwResultCode_t (*EnumRegister)(nvtxwStreamHandle_t stream, nvtxPayloadEnumAttr_t const* attr);
 
   /* Write a batch of payloads into the stream representing one or more
    *  events.  A logical event with multiple payloads cannot be broken up
    *  across multiple calls to EventWrite.  The schema definitions for
    *  the payloads dictate how they are interpreted as events. */
   nvtxwResultCode_t (*EventWrite)(nvtxwStreamHandle_t stream,
-                                  const nvtxPayloadData_t* payloads,
+                                  nvtxPayloadData_t const* payloads,
                                   size_t payloadCount);
 
 } nvtxwInterfaceCore_t;

--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -557,7 +557,7 @@ std::string memcpy_to_string(spark_rapids_jni::profiler::MemcpyActivity const* m
   return oss.str();
 }
 
-const char* memcpy_to_color(spark_rapids_jni::profiler::MemcpyActivity const* m)
+char const* memcpy_to_color(spark_rapids_jni::profiler::MemcpyActivity const* m)
 {
   switch (m->copy_kind()) {
     case spark_rapids_jni::profiler::MemcpyKind_HtoD:

--- a/src/main/cpp/src/CastStringJni.cpp
+++ b/src/main/cpp/src/CastStringJni.cpp
@@ -210,7 +210,7 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_CastStrings_toIntegersW
     auto const valid_rows     = strings::matches_re(input_view, *validity_regex);
     auto const int_col        = [&] {
       auto const prepped_table = strings::extract(input_view, *validity_regex);
-      const strings_column_view prepped_view{prepped_table->get_column(0)};
+      strings_column_view const prepped_view{prepped_table->get_column(0)};
       switch (base) {
         case 10: {
           return strings::to_integers(prepped_view, res_data_type);

--- a/src/main/cpp/src/JSONUtilsJni.cpp
+++ b/src/main/cpp/src/JSONUtilsJni.cpp
@@ -69,7 +69,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObject(JNIEnv* env,
 
     for (int i = 0; i < size; i++) {
       path_instruction_type instruction_type = static_cast<path_instruction_type>(type_nums[i]);
-      const char* name_str                   = names[i].get();
+      char const* name_str                   = names[i].get();
       jlong index                            = indexes[i];
       instructions.emplace_back(instruction_type, name_str, index);
     }
@@ -125,7 +125,7 @@ Java_com_nvidia_spark_rapids_jni_JSONUtils_getJsonObjectMultiplePaths(JNIEnv* en
       path.reserve(path_size);
       for (int j = path_offsets[i]; j < path_offsets[i + 1]; ++j) {
         path_instruction_type instruction_type = static_cast<path_instruction_type>(type_nums[j]);
-        const char* name_str                   = names[j].get();
+        char const* name_str                   = names[j].get();
         jlong index                            = indexes[j];
         path.emplace_back(instruction_type, name_str, index);
       }

--- a/src/main/cpp/src/KudoGpuSerializerJni.cpp
+++ b/src/main/cpp/src/KudoGpuSerializerJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_splitAndSerializeToDevic
     cudf::jni::auto_set_device(env);
 
     auto table = reinterpret_cast<cudf::table_view const*>(j_table_view);
-    const cudf::jni::native_jintArray n_splits(env, j_splits);
+    cudf::jni::native_jintArray const n_splits(env, j_splits);
     std::vector<cudf::size_type> splits = n_splits.to_vector<int>();
 
     auto [split_result, split_meta] = spark_rapids_jni::shuffle_split(

--- a/src/main/cpp/src/NativeParquetJni.cpp
+++ b/src/main/cpp/src/NativeParquetJni.cpp
@@ -45,7 +45,7 @@ namespace jni {
 std::string unicode_to_lower(std::string const& input)
 {
   std::mbstate_t to_wc_state = std::mbstate_t();
-  const char* mbstr          = input.data();
+  char const* mbstr          = input.data();
   // get the size of the wide character result
   std::size_t wide_size   = std::mbsrtowcs(nullptr, &mbstr, 0, &to_wc_state);
   auto const invalid_size = std::numeric_limits<std::size_t>::max();
@@ -63,7 +63,7 @@ std::string unicode_to_lower(std::string const& input)
   }
   // Get the multi-byte result size
   std::mbstate_t from_wc_state = std::mbstate_t();
-  const wchar_t* wcstr         = wide.data();
+  wchar_t const* wcstr         = wide.data();
   std::size_t mb_size          = std::wcsrtombs(nullptr, &wcstr, 0, &from_wc_state);
   if (mb_size == invalid_size) {
     throw std::invalid_argument("unsupported wide character sequence");
@@ -173,7 +173,7 @@ class column_pruner {
 
  private:
   std::string get_name(parquet::format::SchemaElement& elem,
-                       const bool normalize_case = false) const
+                       bool const normalize_case = false) const
   {
     return normalize_case ? unicode_to_lower(elem.name) : elem.name;
   }

--- a/src/main/cpp/src/SparkResourceAdaptorJni.cpp
+++ b/src/main/cpp/src/SparkResourceAdaptorJni.cpp
@@ -106,7 +106,7 @@ enum class thread_state {
 /**
  * Convert a state to a string representation for logging.
  */
-const char* as_str(thread_state state)
+char const* as_str(thread_state state)
 {
   switch (state) {
     case thread_state::THREAD_RUNNING: return "THREAD_RUNNING";
@@ -365,7 +365,7 @@ class thread_priority {
 
   long get_thread_id() const { return thread_id; }
 
-  bool operator<(const thread_priority& other) const
+  bool operator<(thread_priority const& other) const
   {
     long task_priority       = this->task_priority;
     long other_task_priority = other.task_priority;
@@ -377,7 +377,7 @@ class thread_priority {
     return false;
   }
 
-  bool operator>(const thread_priority& other) const
+  bool operator>(thread_priority const& other) const
   {
     long task_priority       = this->task_priority;
     long other_task_priority = other.task_priority;
@@ -1417,7 +1417,7 @@ class spark_resource_adaptor_impl {
    * and if there are no blocked threads, then we wake up all BUFN threads.
    * Hopefully the frees have already woken up all the blocked threads anyways.
    */
-  void wake_up_threads_after_task_finishes(const std::unique_lock<std::mutex>& lock)
+  void wake_up_threads_after_task_finishes(std::unique_lock<std::mutex> const& lock)
   {
     bool are_any_tasks_just_blocked = false;
     for (auto& [thread_id, t_state] : threads) {
@@ -1456,7 +1456,7 @@ class spark_resource_adaptor_impl {
    */
   bool remove_thread_association(long thread_id,
                                  long remove_task_id,
-                                 const std::unique_lock<std::mutex>& lock)
+                                 std::unique_lock<std::mutex> const& lock)
   {
     bool thread_should_be_removed = false;
     bool ret                      = false;
@@ -1910,7 +1910,7 @@ class spark_resource_adaptor_impl {
    * This split in invocation is done to make the critical sections faster, and leave
    * deadlock busting to the deadlock thread.
    */
-  void check_and_update_for_bufn_state_machine_only(const std::unique_lock<std::mutex>& lock)
+  void check_and_update_for_bufn_state_machine_only(std::unique_lock<std::mutex> const& lock)
   {
     // we pass nullopt because we are calling this method from a place in the code that has
     // no java knowledge of blocked threads.
@@ -1926,7 +1926,7 @@ class spark_resource_adaptor_impl {
    * along a set of java native thread ids that are blocked in the java state (Thread.getState).
    */
   void check_and_update_for_bufn(
-    const std::unique_lock<std::mutex>& lock,
+    std::unique_lock<std::mutex> const& lock,
     std::optional<std::unordered_set<long>> const& java_blocked_thread_ids)
   {
     std::map<long, long> pool_bufn_task_thread_count;

--- a/src/main/cpp/src/cast_string.cu
+++ b/src/main/cpp/src/cast_string.cu
@@ -165,7 +165,7 @@ process_value(bool first_value, T current_val, T const new_digit, bool adding)
 template <typename T>
 CUDF_KERNEL void string_to_integer_kernel(T* out,
                                           bitmask_type* validity,
-                                          const char* const chars,
+                                          char const* const chars,
                                           size_type const* offsets,
                                           bitmask_type const* incoming_null_mask,
                                           size_type num_rows,
@@ -253,7 +253,7 @@ CUDF_KERNEL void string_to_integer_kernel(T* out,
 
 template <typename T>
 __device__ cuda::std::optional<cuda::std::tuple<bool, int, int>> validate_and_exponent(
-  const char* chars, const int len, bool strip)
+  char const* chars, int const len, bool strip)
 {
   T exponent_val         = 0;
   int i                  = 0;
@@ -276,7 +276,7 @@ __device__ cuda::std::optional<cuda::std::tuple<bool, int, int>> validate_and_ex
   };
 
   auto validate_char = [&decimal_location, &exponent_positive, &strip](
-                         processing_state const state, const char chr, int chr_idx) {
+                         processing_state const state, char const chr, int chr_idx) {
     switch (state) {
       case ST_TRAILING_WHITESPACE:
         if (!is_whitespace(chr)) { return ST_INVALID; }
@@ -396,7 +396,7 @@ __device__ cuda::std::optional<cuda::std::tuple<bool, int, int>> validate_and_ex
 template <typename T>
 CUDF_KERNEL void string_to_decimal_kernel(T* out,
                                           bitmask_type* validity,
-                                          const char* const chars,
+                                          char const* const chars,
                                           size_type const* offsets,
                                           bitmask_type const* incoming_null_mask,
                                           size_type num_rows,
@@ -422,7 +422,7 @@ CUDF_KERNEL void string_to_decimal_kernel(T* out,
   // If it is the index of a digit, that digit is after the decimal point.
 
   // turn into std::count_if
-  auto count_significant_digits = [](const char* str, int len, int num_digits) {
+  auto count_significant_digits = [](char const* str, int len, int num_digits) {
     int count        = 0;
     int digits_found = 0;
     for (int i = 0; i < len && digits_found < num_digits; ++i) {

--- a/src/main/cpp/src/cast_string_to_datetime.cu
+++ b/src/main/cpp/src/cast_string_to_datetime.cu
@@ -491,7 +491,7 @@ __device__ int64_t to_epoch_seconds(int year, int month, int day, int hour, int 
 __device__ bool is_valid_digits(int segment, int digits)
 {
   // A Long is able to represent a timestamp within [+-]200 thousand years
-  const int maxDigitsYear = 6;
+  int const maxDigitsYear = 6;
 
   // Check the validity of the digits based on the segment
   return (segment == 6) || (segment == 0 && digits >= 4 && digits <= maxDigitsYear) ||

--- a/src/main/cpp/src/cast_string_to_float.cu
+++ b/src/main/cpp/src/cast_string_to_float.cu
@@ -295,7 +295,7 @@ class string_to_float {
                              bitmask_type* validity,
                              int32_t* ansi_except,
                              size_type* valid_count,
-                             const char* const chars,
+                             char const* const chars,
                              size_type const* offsets,
                              uint64_t const* const ipow,
                              bitmask_type const* incoming_null_mask,
@@ -805,7 +805,7 @@ class string_to_float {
   bitmask_type* _validity;
   int32_t* _ansi_except;
   size_type* _valid_count;
-  const char* const _chars;
+  char const* const _chars;
   size_type const _warp_id;
   size_type const _row;
   size_type const _warp_lane;
@@ -829,7 +829,7 @@ CUDF_KERNEL void string_to_float_kernel(T* out,
                                         bitmask_type* validity,
                                         int32_t* ansi_except,
                                         size_type* valid_count,
-                                        const char* const chars,
+                                        char const* const chars,
                                         size_type const* offsets,
                                         bitmask_type const* incoming_null_mask,
                                         size_type const num_rows)

--- a/src/main/cpp/src/decimal_utils.cu
+++ b/src/main/cpp/src/decimal_utils.cu
@@ -887,7 +887,7 @@ struct dec128_remainder {
     // The output scale of remainder is technically the scale of the divisor (b_scale)
     // But since we want an output scale of rem_scale, we have to do the following:
     // First, we have to shift the divisor to the desired rem_scale
-    const int d_shift_exp = rem_scale - b_scale;
+    int const d_shift_exp = rem_scale - b_scale;
     // Then, we have to shift the dividend to compute integer divide
     // We use the formula from dec128_divider
     // Start with: quot_scale - (a_scale - b_scale)

--- a/src/main/cpp/src/from_json_to_raw_map.cu
+++ b/src/main/cpp/src/from_json_to_raw_map.cu
@@ -428,7 +428,7 @@ struct node_ranges_fn {
   cudf::device_span<int8_t const> key_or_value;
 
   // Whether the extracted string values from json map will have the quote character.
-  static const bool include_quote_char{false};
+  static bool const include_quote_char{false};
 
   __device__ cuda::std::pair<SymbolOffsetT, SymbolOffsetT> operator()(cudf::size_type node_id) const
   {

--- a/src/main/cpp/src/histogram.cu
+++ b/src/main/cpp/src/histogram.cu
@@ -92,9 +92,9 @@ struct fill_percentile_fn {
 
     // Using `volatile` qualifier to prevent the compiler from combining `lower_part` and
     // `upper_part` which may lead to output with different round-off error.
-    volatile double const lower_part =
+    double const volatile lower_part =
       (static_cast<double>(higher) - position) * static_cast<double>(lower_element);
-    volatile double const higher_part =
+    double const volatile higher_part =
       (position - static_cast<double>(lower)) * static_cast<double>(higher_element);
     output[idx] = lower_part + higher_part;
   }

--- a/src/main/cpp/src/parse_uri.cu
+++ b/src/main/cpp/src/parse_uri.cu
@@ -542,7 +542,7 @@ __device__ cuda::std::pair<string_view, bool> find_query_part(string_view haysta
   return {{}, false};
 }
 
-uri_parts __device__ validate_uri(const char* str,
+uri_parts __device__ validate_uri(char const* str,
                                   int len,
                                   cuda::std::optional<column_device_view const> query_match,
                                   size_type row_idx)
@@ -555,7 +555,7 @@ uri_parts __device__ validate_uri(const char* str,
   int slash    = -1;
   int hash     = -1;
   int question = -1;
-  for (const char* c = str;
+  for (char const* c = str;
        c - str < len && (col == -1 || slash == -1 || hash == -1 || question == -1);
        ++c) {
     switch (*c) {
@@ -679,7 +679,7 @@ uri_parts __device__ validate_uri(const char* str,
         ret.valid |= (1 << static_cast<int>(URI_chunks::AUTHORITY));
 
         // Inspect the authority for userinfo, host, and port
-        const char* auth   = ret.authority.data();
+        char const* auth   = ret.authority.data();
         auto auth_size     = ret.authority.size_bytes();
         int amp            = -1;
         int closingbracket = -1;

--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -319,14 +319,14 @@ struct fixed_width_row_offset_functor {
  * @param output_nm array of pointers to the output null masks
  * @param input_data pointing to the incoming row data
  */
-CUDF_KERNEL void copy_from_rows_fixed_width_optimized(const size_type num_rows,
-                                                      const size_type num_columns,
-                                                      const size_type row_size,
-                                                      const size_type* input_offset_in_row,
-                                                      const size_type* num_bytes,
+CUDF_KERNEL void copy_from_rows_fixed_width_optimized(size_type const num_rows,
+                                                      size_type const num_columns,
+                                                      size_type const row_size,
+                                                      size_type const* input_offset_in_row,
+                                                      size_type const* num_bytes,
                                                       int8_t** output_data,
                                                       bitmask_type** output_nm,
-                                                      const int8_t* input_data)
+                                                      int8_t const* input_data)
 {
   // We are going to copy the data in two passes.
   // The first pass copies a chunk of data into shared memory.
@@ -402,17 +402,17 @@ CUDF_KERNEL void copy_from_rows_fixed_width_optimized(const size_type num_rows,
           }
           case 2: {
             int16_t* short_col_output   = reinterpret_cast<int16_t*>(col_output);
-            short_col_output[row_index] = *reinterpret_cast<const int16_t*>(col_tmp);
+            short_col_output[row_index] = *reinterpret_cast<int16_t const*>(col_tmp);
             break;
           }
           case 4: {
             int32_t* int_col_output   = reinterpret_cast<int32_t*>(col_output);
-            int_col_output[row_index] = *reinterpret_cast<const int32_t*>(col_tmp);
+            int_col_output[row_index] = *reinterpret_cast<int32_t const*>(col_tmp);
             break;
           }
           case 8: {
             int64_t* long_col_output   = reinterpret_cast<int64_t*>(col_output);
-            long_col_output[row_index] = *reinterpret_cast<const int64_t*>(col_tmp);
+            long_col_output[row_index] = *reinterpret_cast<int64_t const*>(col_tmp);
             break;
           }
           default: {
@@ -438,14 +438,14 @@ CUDF_KERNEL void copy_from_rows_fixed_width_optimized(const size_type num_rows,
   }
 }
 
-CUDF_KERNEL void copy_to_rows_fixed_width_optimized(const size_type start_row,
-                                                    const size_type num_rows,
-                                                    const size_type num_columns,
-                                                    const size_type row_size,
-                                                    const size_type* output_offset_in_row,
-                                                    const size_type* num_bytes,
-                                                    const int8_t** input_data,
-                                                    const bitmask_type** input_nm,
+CUDF_KERNEL void copy_to_rows_fixed_width_optimized(size_type const start_row,
+                                                    size_type const num_rows,
+                                                    size_type const num_columns,
+                                                    size_type const row_size,
+                                                    size_type const* output_offset_in_row,
+                                                    size_type const* num_bytes,
+                                                    int8_t const** input_data,
+                                                    bitmask_type const** input_nm,
                                                     int8_t* output_data)
 {
   // We are going to copy the data in two passes.
@@ -492,24 +492,24 @@ CUDF_KERNEL void copy_to_rows_fixed_width_optimized(const size_type start_row,
            col_index += col_index_stride) {
         size_type col_size      = num_bytes[col_index];
         int8_t* col_tmp         = &(row_tmp[output_offset_in_row[col_index]]);
-        const int8_t* col_input = input_data[col_index];
+        int8_t const* col_input = input_data[col_index];
         switch (col_size) {
           case 1: {
             *col_tmp = col_input[row_index];
             break;
           }
           case 2: {
-            const int16_t* short_col_input       = reinterpret_cast<const int16_t*>(col_input);
+            int16_t const* short_col_input       = reinterpret_cast<int16_t const*>(col_input);
             *reinterpret_cast<int16_t*>(col_tmp) = short_col_input[row_index];
             break;
           }
           case 4: {
-            const int32_t* int_col_input         = reinterpret_cast<const int32_t*>(col_input);
+            int32_t const* int_col_input         = reinterpret_cast<int32_t const*>(col_input);
             *reinterpret_cast<int32_t*>(col_tmp) = int_col_input[row_index];
             break;
           }
           case 8: {
-            const int64_t* long_col_input        = reinterpret_cast<const int64_t*>(col_input);
+            int64_t const* long_col_input        = reinterpret_cast<int64_t const*>(col_input);
             *reinterpret_cast<int64_t*>(col_tmp) = long_col_input[row_index];
             break;
           }
@@ -588,13 +588,13 @@ CUDF_KERNEL void copy_to_rows_fixed_width_optimized(const size_type start_row,
  *
  */
 template <int block_size, typename RowOffsetFunctor>
-__launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_rows,
-                                                            const size_type num_columns,
-                                                            const size_type shmem_used_per_tile,
-                                                            device_span<const tile_info> tile_infos,
-                                                            const int8_t** input_data,
-                                                            const size_type* col_sizes,
-                                                            const size_type* col_offsets,
+__launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(size_type const num_rows,
+                                                            size_type const num_columns,
+                                                            size_type const shmem_used_per_tile,
+                                                            device_span<tile_info const> tile_infos,
+                                                            int8_t const** input_data,
+                                                            size_type const* col_sizes,
+                                                            size_type const* col_offsets,
                                                             RowOffsetFunctor row_offsets,
                                                             size_type const* batch_row_boundaries,
                                                             int8_t** output_data)
@@ -659,17 +659,17 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_
       // copy the element from global memory
       switch (col_size) {
         case 2: {
-          const int16_t* short_col_input = reinterpret_cast<const int16_t*>(input_src);
+          int16_t const* short_col_input = reinterpret_cast<int16_t const*>(input_src);
           *reinterpret_cast<int16_t*>(&shared_data[shared_offset]) = *short_col_input;
           break;
         }
         case 4: {
-          const int32_t* int_col_input = reinterpret_cast<const int32_t*>(input_src);
+          int32_t const* int_col_input = reinterpret_cast<int32_t const*>(input_src);
           *reinterpret_cast<int32_t*>(&shared_data[shared_offset]) = *int_col_input;
           break;
         }
         case 8: {
-          const int64_t* long_col_input = reinterpret_cast<const int64_t*>(input_src);
+          int64_t const* long_col_input = reinterpret_cast<int64_t const*>(input_src);
           *reinterpret_cast<int64_t*>(&shared_data[shared_offset]) = *long_col_input;
           break;
         }
@@ -724,15 +724,15 @@ __launch_bounds__(block_size) CUDF_KERNEL void copy_to_rows(const size_type num_
  */
 template <int block_size, typename RowOffsetFunctor>
 __launch_bounds__(block_size) CUDF_KERNEL
-  void copy_validity_to_rows(const size_type num_rows,
-                             const size_type num_columns,
-                             const size_type shmem_used_per_tile,
+  void copy_validity_to_rows(size_type const num_rows,
+                             size_type const num_columns,
+                             size_type const shmem_used_per_tile,
                              RowOffsetFunctor row_offsets,
                              size_type const* batch_row_boundaries,
                              int8_t** output_data,
-                             const size_type validity_offset,
-                             device_span<const tile_info> tile_infos,
-                             const bitmask_type** input_nm)
+                             size_type const validity_offset,
+                             device_span<tile_info const> tile_infos,
+                             bitmask_type const** input_nm)
 {
   extern __shared__ int8_t shared_data[];
 
@@ -909,16 +909,16 @@ __launch_bounds__(block_size) CUDF_KERNEL
  */
 template <int block_size, typename RowOffsetFunctor>
 __launch_bounds__(block_size) CUDF_KERNEL
-  void copy_from_rows(const size_type num_rows,
-                      const size_type num_columns,
-                      const size_type shmem_used_per_tile,
+  void copy_from_rows(size_type const num_rows,
+                      size_type const num_columns,
+                      size_type const shmem_used_per_tile,
                       RowOffsetFunctor row_offsets,
                       size_type const* batch_row_boundaries,
                       int8_t** output_data,
-                      const size_type* col_sizes,
-                      const size_type* col_offsets,
-                      device_span<const tile_info> tile_infos,
-                      const int8_t* input_data)
+                      size_type const* col_sizes,
+                      size_type const* col_offsets,
+                      device_span<tile_info const> tile_infos,
+                      int8_t const* input_data)
 {
   // We are going to copy the data in two passes.
   // The first pass copies a chunk of data into shared memory.
@@ -1019,15 +1019,15 @@ __launch_bounds__(block_size) CUDF_KERNEL
  */
 template <int block_size, typename RowOffsetFunctor>
 __launch_bounds__(block_size) CUDF_KERNEL
-  void copy_validity_from_rows(const size_type num_rows,
-                               const size_type num_columns,
-                               const size_type shmem_used_per_tile,
+  void copy_validity_from_rows(size_type const num_rows,
+                               size_type const num_columns,
+                               size_type const shmem_used_per_tile,
                                RowOffsetFunctor row_offsets,
                                size_type const* batch_row_boundaries,
                                bitmask_type** output_nm,
-                               const size_type validity_offset,
-                               device_span<const tile_info> tile_infos,
-                               const int8_t* input_data)
+                               size_type const validity_offset,
+                               device_span<tile_info const> tile_infos,
+                               int8_t const* input_data)
 {
   extern __shared__ int8_t shared[];
 
@@ -1199,9 +1199,9 @@ __launch_bounds__(block_size) CUDF_KERNEL
  * @param [out] threads the size of the threads for the kernel
  * @return the size in bytes of shared memory needed for each block.
  */
-static int calc_fixed_width_kernel_dims(const size_type num_columns,
-                                        const size_type num_rows,
-                                        const size_type size_per_row,
+static int calc_fixed_width_kernel_dims(size_type const num_columns,
+                                        size_type const num_rows,
+                                        size_type const size_per_row,
                                         dim3& blocks,
                                         dim3& threads)
 {
@@ -1253,16 +1253,16 @@ static int calc_fixed_width_kernel_dims(const size_type num_columns,
  * into this function are common between runs and should be calculated once.
  */
 static std::unique_ptr<column> fixed_width_convert_to_rows(
-  const size_type start_row,
-  const size_type num_rows,
-  const size_type num_columns,
-  const size_type size_per_row,
+  size_type const start_row,
+  size_type const num_rows,
+  size_type const num_columns,
+  size_type const size_per_row,
   rmm::device_uvector<size_type>& column_start,
   rmm::device_uvector<size_type>& column_size,
-  rmm::device_uvector<const int8_t*>& input_data,
-  rmm::device_uvector<const bitmask_type*>& input_nm,
-  const scalar& zero,
-  const scalar& scalar_size_per_row,
+  rmm::device_uvector<int8_t const*>& input_data,
+  rmm::device_uvector<bitmask_type const*>& input_nm,
+  scalar const& zero,
+  scalar const& scalar_size_per_row,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
@@ -2187,7 +2187,7 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
   auto const num_rows = tbl.num_rows();
 
   // Get the pointers to the input columnar data ready
-  std::vector<const int8_t*> input_data;
+  std::vector<int8_t const*> input_data;
   std::vector<bitmask_type const*> input_nm;
   for (size_type column_number = 0; column_number < num_columns; column_number++) {
     column_view cv = tbl.column(column_number);

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -953,7 +953,7 @@ std::pair<shuffle_assemble_result, rmm::device_uvector<assemble_batch>> assemble
   std::transform(buffer_slices.begin(),
                  buffer_slices.end(),
                  h_dst_buffers.begin(),
-                 [](const buffer_slice& slice) { return slice.data; });
+                 [](buffer_slice const& slice) { return slice.data; });
   auto dst_buffers = cudf::detail::make_device_uvector_async(h_dst_buffers, stream, temp_mr);
 
   // compute:

--- a/src/main/cpp/src/zorder.cu
+++ b/src/main/cpp/src/zorder.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ std::unique_ptr<cudf::column> interleave_bits(cudf::table_view const& tbl,
   // Because the input is a table we know that they all have the same length.
   auto num_rows = tbl.num_rows();
 
-  const cudf::size_type max_bytes_allowed = std::numeric_limits<cudf::size_type>::max();
+  cudf::size_type const max_bytes_allowed = std::numeric_limits<cudf::size_type>::max();
 
   int64_t total_output_size = static_cast<int64_t>(num_rows) * data_type_size * num_columns;
   CUDF_EXPECTS(total_output_size <= max_bytes_allowed, "Input is too large to process");

--- a/src/main/cpp/tests/exception_with_row_index.cpp
+++ b/src/main/cpp/tests/exception_with_row_index.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ TEST_F(ErrorAtRowTests, unary)
   try {
     spark_rapids_jni::throw_row_error_if_any(input, result, cudf::get_default_stream());
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 1);
   }
 
@@ -49,7 +49,7 @@ TEST_F(ErrorAtRowTests, binary)
   try {
     spark_rapids_jni::throw_row_error_if_any(input1, input2, result, cudf::get_default_stream());
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 1);
   }
 
@@ -68,7 +68,7 @@ TEST_F(ErrorAtRowTests, ternary)
     spark_rapids_jni::throw_row_error_if_any(
       input1, input2, input3, result, cudf::get_default_stream());
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 1);
   }
 

--- a/src/main/cpp/tests/multiply.cpp
+++ b/src/main/cpp/tests/multiply.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ TEST_F(MultiplyTests, int8)
   try {
     spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 1);
   }
 }
@@ -57,7 +57,7 @@ TEST_F(MultiplyTests, int16)
   try {
     spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 2);
   }
 }
@@ -81,7 +81,7 @@ TEST_F(MultiplyTests, int32)
   try {
     spark_rapids_jni::multiply(input, input2, /*ansi*/ true, /*try*/ false);
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 3);
   }
 }
@@ -107,7 +107,7 @@ TEST_F(MultiplyTests, int64)
   std::vector<int64_t> right_longs;
   std::vector<int64_t> expected_longs;
   std::vector<bool> is_valid;
-  for (const auto& [left, right, is_valid_result, expected] : cases) {
+  for (auto const& [left, right, is_valid_result, expected] : cases) {
     left_longs.push_back(left);
     right_longs.push_back(right);
     expected_longs.push_back(expected);
@@ -124,7 +124,7 @@ TEST_F(MultiplyTests, int64)
   try {
     spark_rapids_jni::multiply(input1, input2, /*ansi*/ true, /*try*/ false);
     FAIL() << "Expected error_at_row exception to be thrown";
-  } catch (const spark_rapids_jni::exception_with_row_index& e) {
+  } catch (spark_rapids_jni::exception_with_row_index const& e) {
     EXPECT_EQ(e.get_row_index(), 2);
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/NVIDIA/cudf-spark-jni/pull/4777.

### Description

PR #4777 updated the cuDF submodule to a commit from https://github.com/rapidsai/cudf/pull/22834 that added `QualifierAlignment: Right` to cuDF's `.clang-format` configuration. spark-rapids-jni's pre-commit hook uses that configuration, so `pre-commit run --all-files` began rewriting existing C++ and CUDA sources and pre-commit.ci could fail on otherwise unrelated pull requests.

PR #4779 was not the source of the formatting change. It updated the cuDF submodule again, but both its old and new cuDF revisions already contained `QualifierAlignment: Right`.

This PR applies the generated formatting changes to the 26 affected files and updates their copyright years. It contains no functional code changes.

Validation:

```text
pre-commit run --all-files --show-diff-on-failure
Check clang-format version matches cudf..................................Passed
clang-format.............................................................Passed
```

### Checklists

Documentation
- [ ] Updated for new or modified user-facing features or behaviors
- [x] No user-facing change

Testing
- [ ] Added or modified tests to cover new code paths
- [ ] Covered by existing tests
- [x] Not required

Performance
- [ ] Tests ran and results are added in the PR description
- [ ] Issue filed with a link in the PR description
- [x] Not required
