### PR TITLE
Fix misuse of pointer type in `KudoGpuSerializer.java#assembleFromDeviceRaw`

### DIFF
--- a/src/main/cpp/src/KudoGpuSerializerJni.cpp
+++ b/src/main/cpp/src/KudoGpuSerializerJni.cpp
@@ -112,10 +112,15 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_assembleFromDeviceRawNat
                                             cudf::get_default_stream(),
                                             cudf::get_current_device_resource_ref());
 
-    // Create buffer metadata
-    jlong buffer_size   = static_cast<jlong>(assemble_result.shared_buffer.size());
-    jlong buffer_handle = cudf::jni::release_as_jlong(
-      std::make_unique<rmm::device_buffer>(std::move(assemble_result.shared_buffer)));
+    // Create buffer metadata. The device DATA address must be captured and returned separately
+    // from the rmm::device_buffer* owner handle: Java wraps this allocation via
+    // DeviceMemoryBuffer.fromRmm(address, length, rmmBufferAddress), and any consumer of that
+    // buffer's address (e.g. spill) performs device memory operations on it.
+    auto shared_buffer =
+      std::make_unique<rmm::device_buffer>(std::move(assemble_result.shared_buffer));
+    jlong buffer_size    = static_cast<jlong>(shared_buffer->size());
+    jlong buffer_address = cudf::jni::ptr_as_jlong(shared_buffer->data());
+    jlong buffer_handle  = cudf::jni::release_as_jlong(std::move(shared_buffer));
 
     // Create column handles array
     cudf::jni::native_jlongArray column_handles(env, assemble_result.column_views.size());
@@ -126,10 +131,14 @@ Java_com_nvidia_spark_rapids_jni_kudo_KudoGpuSerializer_assembleFromDeviceRawNat
     // Create and return Java AssembleResult object
     jclass result_class =
       env->FindClass("com/nvidia/spark/rapids/jni/kudo/KudoGpuSerializer$AssembleResult");
-    jmethodID constructor = env->GetMethodID(result_class, "<init>", "(JJ[J)V");
+    jmethodID constructor = env->GetMethodID(result_class, "<init>", "(JJJ[J)V");
 
-    return env->NewObject(
-      result_class, constructor, buffer_handle, buffer_size, column_handles.get_jArray());
+    return env->NewObject(result_class,
+                          constructor,
+                          buffer_address,
+                          buffer_size,
+                          buffer_handle,
+                          column_handles.get_jArray());
   }
   JNI_CATCH(env, NULL);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoGpuSerializer.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/kudo/KudoGpuSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,16 +28,22 @@ public class KudoGpuSerializer {
    * Result class for assembleFromDeviceRaw operation containing buffer metadata and column handles
    */
   public static class AssembleResult {
-    private final long bufferHandle;
+    private final long bufferAddress;
     private final long bufferSize;
+    private final long bufferHandle;
     private final long[] columnHandles;
 
-    public AssembleResult(long bufferHandle, long bufferSize, long[] columnHandles) {
-      this.bufferHandle = bufferHandle;
+    public AssembleResult(long bufferAddress, long bufferSize, long bufferHandle,
+                          long[] columnHandles) {
+      this.bufferAddress = bufferAddress;
       this.bufferSize = bufferSize;
+      this.bufferHandle = bufferHandle;
       this.columnHandles = columnHandles;
     }
 
+    /** Device address of the shared buffer's data (what device memory operations must use). */
+    public long getBufferAddress() { return bufferAddress; }
+    /** Native {@code rmm::device_buffer*} owner handle (what frees the allocation). */
     public long getBufferHandle() { return bufferHandle; }
     public long getBufferSize() { return bufferSize; }
     public long[] getColumnHandles() { return columnHandles; }
@@ -79,7 +85,7 @@ public class KudoGpuSerializer {
         schema.getFlattenedTypeScales());
 
     DeviceMemoryBuffer singleBuffer = DeviceMemoryBuffer.fromRmm(
-        result.getBufferHandle(), result.getBufferSize(), result.getBufferHandle());
+        result.getBufferAddress(), result.getBufferSize(), result.getBufferHandle());
 
     // Create ColumnVector array using fromViewWithContiguousAllocation
     ColumnVector[] columnVectors = new ColumnVector[result.getNumColumns()];


### PR DESCRIPTION
`KudoGpuSerializer.java#AssembleResult` only stores the buffer handle (i.e., pointer of type `rmm::device_buffer*`). When calling `DeviceMemoryBuffer.fromRmm(gpuAddress, size, handle)`, it passes handle `rmm::device_buffer*` twice for both `gpuAddress` and `handle`. This is incorrect, and such call will result in crash or data corruption.

This fix properly stores both the GPU address of the buffer as well as buffer handle and pass to `fromRmm` by the proper way.