### PR TITLE
Synchronize stream to drain H2D uploads before host staging vectors are destroyed

### DIFF
--- a/src/main/cpp/src/row_conversion.cu
+++ b/src/main/cpp/src/row_conversion.cu
@@ -1998,6 +1998,10 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
           batch_row_offset,
           reinterpret_cast<int8_t*>(output_data[i]));
     }
+
+    // Drain the async H2D uploads above before variable_width_input_data goes out of scope:
+    // CUDA 13+ may read the host source only when the stream executes the copy.
+    stream.synchronize();
   }
 
   // split up the output buffer into multiple buffers based on row batch sizes and create list of
@@ -2028,6 +2032,11 @@ std::vector<std::unique_ptr<column>> convert_to_rows(
                                             0,
                                             rmm::device_buffer{0, cudf::get_default_stream(), mr});
                  });
+
+  // Drain the async H2D uploads above before input_data, input_nm, output_data and
+  // validity_tile_infos go out of scope: CUDA 13+ may read the host source only when the stream
+  // executes the copy.
+  stream.synchronize();
 
   return ret;
 }
@@ -2223,6 +2232,10 @@ std::vector<std::unique_ptr<column>> convert_to_rows_fixed_width_optimized(
                                                          stream,
                                                          mr));
   }
+
+  // Drain the async H2D uploads above before column_start, column_size, input_data and input_nm
+  // go out of scope: CUDA 13+ may read the host source only when the stream executes the copy.
+  stream.synchronize();
 
   return ret;
 }
@@ -2540,12 +2553,21 @@ std::unique_ptr<table> convert_from_rows(lists_column_view const& input,
         string_idx++;
       }
     }
+
+    // Drain the async H2D uploads above before string_col_offset_ptrs and string_data_col_ptrs
+    // go out of scope: CUDA 13+ may read the host source only when the stream executes the copy.
+    stream.synchronize();
   }
 
   // Set null counts, because output_columns are modified via mutable-view,
   // in the kernel above.
   // TODO(future): Consider setting null count in the kernel itself.
   fixup_null_counts(output_columns, stream);
+
+  // Explicitly drain async H2D uploads before the host staging vectors go out of scope
+  // (CUDA 13+ may read the host source only at stream-execution time). Not left to the
+  // incidental sync in fixup_null_counts, which vanishes if null counts move into the kernel.
+  stream.synchronize();
 
   return std::make_unique<table>(std::move(output_columns));
 }
@@ -2619,6 +2641,11 @@ std::unique_ptr<table> convert_from_rows_fixed_width_optimized(lists_column_view
   // in the kernel above.
   // TODO(future): Consider setting null count in the kernel itself.
   fixup_null_counts(output_columns, stream);
+
+  // Explicitly drain async H2D uploads before the host staging vectors go out of scope
+  // (CUDA 13+ may read the host source only at stream-execution time). Not left to the
+  // incidental sync in fixup_null_counts, which vanishes if null counts move into the kernel.
+  stream.synchronize();
 
   return std::make_unique<table>(std::move(output_columns));
 }

--- a/src/main/cpp/src/shuffle_assemble.cu
+++ b/src/main/cpp/src/shuffle_assemble.cu
@@ -184,7 +184,9 @@ rmm::device_uvector<offset_column_info> compute_offset_column_info(
   while (col_index < static_cast<int>(metadata.col_info.size())) {
     col_index = compute_offset_column_info_traverse(metadata.col_info, col_index, -1, offset_info);
   }
-  return cudf::detail::make_device_uvector_async(offset_info, stream, mr);
+  // Sync variant required: offset_info dies at return, but an async upload may read the host
+  // source only when the stream executes the copy (CUDA 13+ deferred source read).
+  return cudf::detail::make_device_uvector(offset_info, stream, mr);
 }
 
 /**
@@ -1330,6 +1332,11 @@ std::pair<shuffle_assemble_result, rmm::device_uvector<assemble_batch>> assemble
       }),
     stream,
     mr);
+
+  // Drain the async H2D uploads above before h_dst_buffers and validity_spans_to_zero (uploaded
+  // by batched_memset) go out of scope: CUDA 13+ may read the host source only when the stream
+  // executes the copy.
+  stream.synchronize();
 
   // Return shuffle assemble result with slices and copy batches (column_views will be populated
   // later)


### PR DESCRIPTION
This fixes the bug that the host staging vectors are destroyed before their data was completely uploaded to device memory through async memcpy. 

From CUDA 13, `memcpy_batch_async` routes a non-default-stream copy through `cudaMemcpyBatchAsync` with `cudaMemcpySrcAccessOrderStream`, so the host source is read when the stream executes the copy, not at enqueue. As such, the bug already stay hidden for a long time but didn't show up until being tested with CUDA 13 build.