### PR TITLE
Prevent NUL from being selected as the JSON row delimiter

### DIFF
--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -58,7 +58,7 @@ __host__ __device__ constexpr bool can_be_delimiter(char c)
     case ',':
     case ':':
     case '"':
-    case '\0':	    
+    case '\0':
     case '\'':
     case '\\':
     case ' ':

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -58,6 +58,7 @@ __host__ __device__ constexpr bool can_be_delimiter(char c)
     case ',':
     case ':':
     case '"':
+    case '\0':	    
     case '\'':
     case '\\':
     case ' ':

--- a/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
@@ -26,6 +26,7 @@ import ai.rapids.cudf.JSONOptions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
@@ -203,6 +204,25 @@ public class FromJsonToRawMapTest {
          ColumnVector result = JSONUtils.extractRawMapFromJsonString(input, getOptions(),
              JSONUtils.MapValueType.ARRAY_OF_STRING);
          ColumnVector expected = ColumnVector.fromLists(LIST_TYPE, row0)) {
+      assertColumnsAreEqual(expected, result);
+      assertKeyAndStructNonNullable(result);
+    }
+  }
+
+  // Empty keys, lists, and strings are valid values and must remain distinct from JSON null.
+  @Test
+  void testExtractRawMapArrayEmptyBoundaries() {
+    List<HostColumnVector.StructData> row0 =
+        Arrays.asList(pair("", Collections.emptyList()));
+    List<HostColumnVector.StructData> row1 =
+        Arrays.asList(pair("k", Collections.emptyList()));
+    List<HostColumnVector.StructData> row2 =
+        Arrays.asList(pair("k", Arrays.asList("", "null", null)));
+    try (ColumnVector input = ColumnVector.fromStrings(
+             "{\"\":[]}", "{\"k\":[]}", "{\"k\":[\"\",\"null\",null]}");
+         ColumnVector result = JSONUtils.extractRawMapFromJsonString(input, getOptions(),
+             JSONUtils.MapValueType.ARRAY_OF_STRING);
+         ColumnVector expected = ColumnVector.fromLists(LIST_TYPE, row0, row1, row2)) {
       assertColumnsAreEqual(expected, result);
       assertKeyAndStructNonNullable(result);
     }

--- a/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToRawMapTest.java
@@ -192,6 +192,22 @@ public class FromJsonToRawMapTest {
     }
   }
 
+  // The delimiter used to concatenate rows must not split an embedded NUL in an array element.
+  @Test
+  void testExtractRawMapArrayEmbeddedNul() {
+    String valueWithNul = "a\u0000b";
+    List<HostColumnVector.StructData> row0 =
+        Arrays.asList(pair("k", Arrays.asList(valueWithNul)));
+    try (ColumnVector input =
+             ColumnVector.fromStrings("{\"k\":[\"" + valueWithNul + "\"]}");
+         ColumnVector result = JSONUtils.extractRawMapFromJsonString(input, getOptions(),
+             JSONUtils.MapValueType.ARRAY_OF_STRING);
+         ColumnVector expected = ColumnVector.fromLists(LIST_TYPE, row0)) {
+      assertColumnsAreEqual(expected, result);
+      assertKeyAndStructNonNullable(result);
+    }
+  }
+
   // ARRAY_OF_STRING nested validity through the public HostColumnVector path:
   //  - {"k":null}       -> row kept, the value inner list is null (mask #1);
   //  - {"k":[null,"x"]} -> inner list present with a null first element (mask #2).

--- a/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToStructsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToStructsTest.java
@@ -19,11 +19,13 @@ package com.nvidia.spark.rapids.jni;
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.ColumnView;
 import ai.rapids.cudf.DType;
+import ai.rapids.cudf.HostColumnVector;
 import ai.rapids.cudf.JSONOptions;
 import ai.rapids.cudf.Schema;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FromJsonToStructsTest {
   private static JSONOptions getOptions() {
@@ -53,6 +55,10 @@ public class FromJsonToStructsTest {
              input, schema, getOptions(), true);
          ColumnView outputAniviaData = output.getChildColumnView(0);
          ColumnView outputAsset = outputAniviaData.getChildColumnView(0)) {
+      try (ColumnView outputAssetId = outputAsset.getChildColumnView(0);
+           HostColumnVector hostAssetId = outputAssetId.copyToHost()) {
+        assertTrue(hostAssetId.isNull(0), "malformed record should nullify assetId");
+      }
       assertEquals(input.getRowCount(), output.getRowCount());
       assertEquals(input.getRowCount(), outputAniviaData.getRowCount());
       assertEquals(input.getRowCount(), outputAsset.getRowCount());

--- a/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToStructsTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/FromJsonToStructsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.ColumnView;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.JSONOptions;
+import ai.rapids.cudf.Schema;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FromJsonToStructsTest {
+  private static JSONOptions getOptions() {
+    return JSONOptions.builder()
+        .withNormalizeSingleQuotes(true)
+        .withLeadingZeros(true)
+        .withNonNumericNumbers(true)
+        .withUnquotedControlChars(false)
+        .build();
+  }
+
+  @Test
+  void testEmbeddedNulIsNotUsedAsRowDelimiter() {
+    String malformedBanner =
+        "\uFFFD\uFFFD[\u0000\"\u0000\uFFFD\u0000\"\u0000]\u0000";
+    String json = "{\"aniviaData\":{\"asset\":{\"assetId\":\"va\"}," +
+        "\"bannerDetails\":" + malformedBanner + "}}";
+
+    Schema.Builder root = Schema.builder();
+    Schema.Builder aniviaData = root.addColumn(DType.STRUCT, "aniviaData");
+    Schema.Builder asset = aniviaData.addColumn(DType.STRUCT, "asset");
+    asset.addColumn(DType.STRING, "assetId");
+    Schema schema = root.build();
+
+    try (ColumnVector input = ColumnVector.fromStrings(json);
+         ColumnVector output = JSONUtils.fromJSONToStructs(
+             input, schema, getOptions(), true);
+         ColumnView outputAniviaData = output.getChildColumnView(0);
+         ColumnView outputAsset = outputAniviaData.getChildColumnView(0)) {
+      assertEquals(input.getRowCount(), output.getRowCount());
+      assertEquals(input.getRowCount(), outputAniviaData.getRowCount());
+      assertEquals(input.getRowCount(), outputAsset.getRowCount());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR contributes to https://github.com/NVIDIA/cudf-spark/issues/15212

`concat_json` can select NUL (`\0`) as the delimiter used to concatenate JSON rows.
When an input string contains embedded NUL characters, the cuDF JSON reader can interpret
them as additional row boundaries and return more rows than were present in the input.

This can cause downstream expressions such as `CASE WHEN` to fail with:

```
Boolean mask column must be the same size as lhs column
```

This change excludes NUL from the possible JSON delimiters.

## Test plan

- Added FromJsonToStructsTest.testEmbeddedNulIsNotUsedAsRowDelimiter.
- Added `FromJsonToRawMapTest.testExtractRawMapArrayEmbeddedNul` to cover the
  `MAP<STRING, ARRAY<STRING>>` raw-extraction path.
- Verified that the output struct and its children retain the input row count.
- Ran the focused JNI test successfully.


A separate cudf-spark PR will add Spark integration coverage for the
from_json and CASE WHEN reproduction.