### PR TITLE
Fix JSON row delimiter selection for control-byte inputs

### DIFF
--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -36,6 +36,8 @@
 #include <thrust/transform.h>
 #include <thrust/uninitialized_fill.h>
 
+#include <cstdint>
+
 namespace spark_rapids_jni {
 
 namespace detail {
@@ -47,9 +49,9 @@ __host__ __device__ constexpr bool not_whitespace(cudf::char_utf8 ch)
   return ch != ' ' && ch != '\r' && ch != '\n' && ch != '\t';
 }
 
-__host__ __device__ constexpr bool can_be_delimiter(char c)
+__host__ __device__ constexpr bool can_be_delimiter(std::uint8_t c)
 {
-  // The character list below is from `json_reader_options.set_delimiter`.
+  // The character list below is from `json_reader_options::set_delimiter`.
   switch (c) {
     case '{':
     case '[':
@@ -66,6 +68,43 @@ __host__ __device__ constexpr bool can_be_delimiter(char c)
     case '\r': return false;
     default: return true;
   }
+}
+
+// Delimiter preference, in the order `delimiter_candidate` enumerates it:
+//   1. '\n'                         - the natural JSON-lines delimiter
+//   2. printable ASCII 0x21..0x7e   - safe, never confused with unquoted control chars
+//   3. DEL 0x7f
+//   4. C0 controls 0x01..0x1f       - last-resort fallback (see note in `delimiter_candidate`)
+// NUL (0x00) is never a candidate; the other excluded bytes are filtered by `can_be_delimiter`.
+constexpr std::uint8_t first_printable = 0x21;  // '!'
+constexpr std::uint8_t last_printable  = 0x7e;  // '~'
+constexpr std::uint8_t del_byte        = 0x7f;
+constexpr std::uint8_t last_c0         = 0x1f;  // highest C0 control byte used in the fallback
+
+constexpr int num_printable         = last_printable - first_printable + 1;
+constexpr int first_printable_index = 1;  // index 0 is '\n'
+constexpr int del_index             = first_printable_index + num_printable;
+constexpr int first_c0_index        = del_index + 1;
+
+// One index per distinct preference slot: '\n' + printables + DEL + C0 fallback (0x01..0x1f).
+constexpr int num_delimiter_candidates = first_c0_index + last_c0;
+
+__host__ __device__ constexpr std::uint8_t delimiter_candidate(int candidate_index)
+{
+  if (candidate_index == 0) { return '\n'; }
+  if (candidate_index < del_index) {
+    return static_cast<std::uint8_t>(first_printable + candidate_index - first_printable_index);
+  }
+  if (candidate_index == del_index) { return del_byte; }
+
+  // C0 bytes (0x01..0x1f) are a last-resort fallback, reached only if '\n', every eligible
+  // printable, and DEL are all already present in the input. A C0 delimiter can still be
+  // mishandled by the reader when `allow_unquoted_control` is set (the very interaction this
+  // ordering avoids), so this branch is intentionally the least preferred. NUL (0x00) is not
+  // reachable here; tab (0x09) and CR (0x0d) fall in this range but are rejected by
+  // `can_be_delimiter`, while LF (0x0a) is already covered at index 0 (its count is nonzero
+  // whenever this branch is reached, so the duplicate is harmless).
+  return static_cast<std::uint8_t>(candidate_index - del_index);
 }
 
 }  // namespace
@@ -138,59 +177,57 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
       output[idx] = cuda::std::make_tuple(not_eol, !not_eol);
     });
 
-  auto constexpr num_levels  = 256;
-  auto constexpr lower_level = std::numeric_limits<char>::min();
-  auto constexpr upper_level = std::numeric_limits<char>::max();
+  // CUB expects one more level than bins. Use byte samples and integer bounds so each bin maps
+  // exactly to one ASCII byte, including DEL (0x7f). High-bit bytes are intentionally ignored.
+  auto constexpr num_bins    = 128;
+  auto constexpr num_levels  = num_bins + 1;
+  auto constexpr lower_level = 0;
+  auto constexpr upper_level = 128;
   auto const num_chars       = input.chars_size(stream);
 
-  rmm::device_uvector<uint32_t> histogram(num_levels, stream, default_mr);
+  rmm::device_uvector<uint32_t> histogram(num_bins, stream, default_mr);
   thrust::uninitialized_fill(
     rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), 0);
 
+  auto const byte_samples   = reinterpret_cast<std::uint8_t const*>(input.chars_begin(stream));
   size_t temp_storage_bytes = 0;
-  cub::DeviceHistogram::HistogramEven(nullptr,
-                                      temp_storage_bytes,
-                                      input.chars_begin(stream),
-                                      histogram.begin(),
-                                      num_levels,
-                                      lower_level,
-                                      upper_level,
-                                      num_chars,
-                                      stream.value());
+  CUDF_CUDA_TRY(cub::DeviceHistogram::HistogramEven(nullptr,
+                                                    temp_storage_bytes,
+                                                    byte_samples,
+                                                    histogram.begin(),
+                                                    num_levels,
+                                                    lower_level,
+                                                    upper_level,
+                                                    num_chars,
+                                                    stream.value()));
   rmm::device_buffer d_temp(temp_storage_bytes, stream);
-  cub::DeviceHistogram::HistogramEven(d_temp.data(),
-                                      temp_storage_bytes,
-                                      input.chars_begin(stream),
-                                      histogram.begin(),
-                                      num_levels,
-                                      lower_level,
-                                      upper_level,
-                                      num_chars,
-                                      stream.value());
+  CUDF_CUDA_TRY(cub::DeviceHistogram::HistogramEven(d_temp.data(),
+                                                    temp_storage_bytes,
+                                                    byte_samples,
+                                                    histogram.begin(),
+                                                    num_levels,
+                                                    lower_level,
+                                                    upper_level,
+                                                    num_chars,
+                                                    stream.value()));
 
-  auto const it             = thrust::make_counting_iterator(0);
-  auto const zero_level_idx = -lower_level;  // the bin storing count for character `\0`
-  auto const zero_level_it  = it + zero_level_idx;
-  auto const end            = it + num_levels;
-
-  auto const first_zero_count_pos =
+  auto const candidates_begin = thrust::make_counting_iterator(0);
+  auto const candidates_end   = candidates_begin + num_delimiter_candidates;
+  auto const first_available =
     thrust::find_if(rmm::exec_policy_nosync(stream),
-                    zero_level_it,  // ignore the negative characters
-                    end,
-                    [zero_level_idx, counts = histogram.begin()] __device__(auto idx) -> bool {
-                      auto const count = counts[idx];
-                      if (count > 0) { return false; }
-                      auto const first_non_existing_char = static_cast<char>(idx - zero_level_idx);
-                      return can_be_delimiter(first_non_existing_char);
+                    candidates_begin,
+                    candidates_end,
+                    [counts = histogram.begin()] __device__(auto candidate_index) -> bool {
+                      auto const candidate = delimiter_candidate(candidate_index);
+                      return can_be_delimiter(candidate) && counts[candidate] == 0;
                     });
 
-  // This should never happen since the input should never cover the entire char range.
-  if (first_zero_count_pos == end) {
+  if (first_available == candidates_end) {
     throw std::logic_error(
-      "Cannot find any character suitable as delimiter during joining json strings.");
+      "Cannot find an unused cuDF-supported ASCII delimiter while joining JSON strings.");
   }
   auto const delimiter =
-    static_cast<char>(cuda::std::distance(zero_level_it, first_zero_count_pos));
+    static_cast<char>(delimiter_candidate(cuda::std::distance(candidates_begin, first_available)));
 
   auto [null_mask, null_count] =
     cudf::bools_to_mask(cudf::device_span<bool const>(is_valid_input), stream, default_mr);

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -29,8 +29,11 @@
 
 #include <cub/device/device_histogram.cuh>
 #include <cuda/std/functional>
+#include <cuda/std/iterator>
 #include <cuda/std/tuple>
+#include <thrust/fill.h>
 #include <thrust/find.h>
+#include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
@@ -51,7 +54,8 @@ __host__ __device__ constexpr bool not_whitespace(cudf::char_utf8 ch)
 
 __host__ __device__ constexpr bool can_be_delimiter(std::uint8_t c)
 {
-  // The character list below is from `json_reader_options::set_delimiter`.
+  // Matches `json_reader_options::set_delimiter`, with NUL additionally excluded because
+  // embedded NUL bytes must not be treated as row boundaries.
   switch (c) {
     case '{':
     case '[':
@@ -79,15 +83,17 @@ __host__ __device__ constexpr bool can_be_delimiter(std::uint8_t c)
 constexpr std::uint8_t first_printable = 0x21;  // '!'
 constexpr std::uint8_t last_printable  = 0x7e;  // '~'
 constexpr std::uint8_t del_byte        = 0x7f;
-constexpr std::uint8_t last_c0         = 0x1f;  // highest C0 control byte used in the fallback
+constexpr std::uint8_t first_c0        = 0x01;
+constexpr std::uint8_t last_c0         = 0x1f;
 
 constexpr int num_printable         = last_printable - first_printable + 1;
+constexpr int num_c0                = last_c0 - first_c0 + 1;
 constexpr int first_printable_index = 1;  // index 0 is '\n'
 constexpr int del_index             = first_printable_index + num_printable;
 constexpr int first_c0_index        = del_index + 1;
 
-// One index per distinct preference slot: '\n' + printables + DEL + C0 fallback (0x01..0x1f).
-constexpr int num_delimiter_candidates = first_c0_index + last_c0;
+// One index per preference slot: '\n' + printables + DEL + C0 fallback (0x01..0x1f).
+constexpr int num_delimiter_candidates = first_c0_index + num_c0;
 
 __host__ __device__ constexpr std::uint8_t delimiter_candidate(int candidate_index)
 {
@@ -104,7 +110,7 @@ __host__ __device__ constexpr std::uint8_t delimiter_candidate(int candidate_ind
   // reachable here; tab (0x09) and CR (0x0d) fall in this range but are rejected by
   // `can_be_delimiter`, while LF (0x0a) is already covered at index 0 (its count is nonzero
   // whenever this branch is reached, so the duplicate is harmless).
-  return static_cast<std::uint8_t>(candidate_index - del_index);
+  return static_cast<std::uint8_t>(first_c0 + candidate_index - first_c0_index);
 }
 
 }  // namespace
@@ -200,27 +206,58 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
                                                     upper_level,
                                                     num_chars,
                                                     stream.value()));
-  rmm::device_buffer d_temp(temp_storage_bytes, stream);
-  CUDF_CUDA_TRY(cub::DeviceHistogram::HistogramEven(d_temp.data(),
-                                                    temp_storage_bytes,
-                                                    byte_samples,
-                                                    histogram.begin(),
-                                                    num_levels,
-                                                    lower_level,
-                                                    upper_level,
-                                                    num_chars,
-                                                    stream.value()));
+  {
+    rmm::device_buffer d_temp(temp_storage_bytes, stream);
+    CUDF_CUDA_TRY(cub::DeviceHistogram::HistogramEven(d_temp.data(),
+                                                      temp_storage_bytes,
+                                                      byte_samples,
+                                                      histogram.begin(),
+                                                      num_levels,
+                                                      lower_level,
+                                                      upper_level,
+                                                      num_chars,
+                                                      stream.value()));
+  }
 
   auto const candidates_begin = thrust::make_counting_iterator(0);
   auto const candidates_end   = candidates_begin + num_delimiter_candidates;
-  auto const first_available =
-    thrust::find_if(rmm::exec_policy_nosync(stream),
-                    candidates_begin,
-                    candidates_end,
-                    [counts = histogram.begin()] __device__(auto candidate_index) -> bool {
-                      auto const candidate = delimiter_candidate(candidate_index);
-                      return can_be_delimiter(candidate) && counts[candidate] == 0;
-                    });
+  auto const find_available_delimiter = [&] {
+    return thrust::find_if(
+      rmm::exec_policy_nosync(stream),
+      candidates_begin,
+      candidates_end,
+      [counts = histogram.begin()] __device__(auto candidate_index) -> bool {
+        auto const candidate = delimiter_candidate(candidate_index);
+        return can_be_delimiter(candidate) && counts[candidate] == 0;
+      });
+  };
+
+  auto first_available = find_available_delimiter();
+  if (first_available == candidates_end) {
+    // Invalid rows are replaced with "{}" before parsing, so their original bytes do not need
+    // to reserve a delimiter. Retry with a row-aware histogram only on this rare exhausted path.
+    thrust::fill(rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), 0);
+    thrust::for_each(
+      rmm::exec_policy_nosync(stream),
+      thrust::make_counting_iterator(0L),
+      thrust::make_counting_iterator(input.size() * static_cast<int64_t>(cudf::detail::warp_size)),
+      [input      = *d_input_ptr,
+       valid_rows = is_valid_input.data(),
+       counts     = histogram.data()] __device__(int64_t tidx) {
+        auto const lane = static_cast<int32_t>(tidx % cudf::detail::warp_size);
+        auto const row  = tidx / cudf::detail::warp_size;
+        if (!valid_rows[row]) { return; }
+
+        auto const d_str = input.element<cudf::string_view>(row);
+        auto const bytes = reinterpret_cast<std::uint8_t const*>(d_str.data());
+        for (auto byte_index = lane; byte_index < d_str.size_bytes();
+             byte_index += cudf::detail::warp_size) {
+          auto const byte = bytes[byte_index];
+          if (byte < num_bins) { atomicAdd(&counts[byte], 1U); }
+        }
+      });
+    first_available = find_available_delimiter();
+  }
 
   if (first_available == candidates_end) {
     throw std::logic_error(

--- a/src/main/cpp/src/json_utils.cu
+++ b/src/main/cpp/src/json_utils.cu
@@ -219,17 +219,16 @@ std::tuple<std::unique_ptr<rmm::device_buffer>, char, std::unique_ptr<cudf::colu
                                                       stream.value()));
   }
 
-  auto const candidates_begin = thrust::make_counting_iterator(0);
-  auto const candidates_end   = candidates_begin + num_delimiter_candidates;
+  auto const candidates_begin         = thrust::make_counting_iterator(0);
+  auto const candidates_end           = candidates_begin + num_delimiter_candidates;
   auto const find_available_delimiter = [&] {
-    return thrust::find_if(
-      rmm::exec_policy_nosync(stream),
-      candidates_begin,
-      candidates_end,
-      [counts = histogram.begin()] __device__(auto candidate_index) -> bool {
-        auto const candidate = delimiter_candidate(candidate_index);
-        return can_be_delimiter(candidate) && counts[candidate] == 0;
-      });
+    return thrust::find_if(rmm::exec_policy_nosync(stream),
+                           candidates_begin,
+                           candidates_end,
+                           [counts = histogram.begin()] __device__(auto candidate_index) -> bool {
+                             auto const candidate = delimiter_candidate(candidate_index);
+                             return can_be_delimiter(candidate) && counts[candidate] == 0;
+                           });
   };
 
   auto first_available = find_available_delimiter();

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -104,6 +104,14 @@ std::unique_ptr<cudf::column> make_expected_raw_map(std::vector<std::vector<kv>>
 // Convenience: every row valid.
 std::vector<bool> all_valid(std::size_t n) { return std::vector<bool>(n, true); }
 
+// Returns the delimiter `concat_json` picks for `input`; used to pin delimiter selection.
+char selected_delimiter(std::string const& input)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{input};
+  auto const result    = spark_rapids_jni::concat_json(cudf::strings_column_view{input_col});
+  return std::get<1>(result);
+}
+
 // Default leniency options shared by all calls and the single source of truth for the defaults.
 // Individual tests override only the field a case exercises (designated initializers below).
 constexpr spark_rapids_jni::json_parse_options default_options{
@@ -126,6 +134,71 @@ std::unique_ptr<cudf::column> raw_map_array(cudf::strings_column_view const& inp
 }
 
 }  // namespace
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_PrefersLineFeedWithEmbeddedNul)
+{
+  auto input = std::string{R"({"v":"a)"};
+  input.push_back('\0');
+  input.append(R"(b"})");
+
+  EXPECT_EQ(selected_delimiter(input), '\n');
+}
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_SkipsPresentPrintable)
+{
+  auto const input = std::string{"{\n!}"};
+
+  EXPECT_EQ(selected_delimiter(input), '#');
+}
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_CountsDelAndSkipsNulFallback)
+{
+  auto input = std::string{"{\n"};
+  for (int byte = 0x20; byte <= 0x7f; ++byte) {
+    input.push_back(static_cast<char>(byte));
+  }
+
+  EXPECT_EQ(selected_delimiter(input), '\x01');
+}
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_PrefersDelBeforeC0Fallback)
+{
+  // '\n' plus every printable 0x20..0x7e are present, but DEL (0x7f) is absent. DEL is preferred
+  // over the C0 control-byte fallback, so it must be selected instead of dropping to 0x01.
+  auto input = std::string{"{\n"};
+  for (int byte = 0x20; byte <= 0x7e; ++byte) {
+    input.push_back(static_cast<char>(byte));
+  }
+
+  EXPECT_EQ(selected_delimiter(input), '\x7f');
+}
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_ThrowsWhenAsciiExhausted)
+{
+  auto input = std::string{"{"};
+  for (int byte = 0; byte <= 0x7f; ++byte) {
+    input.push_back(static_cast<char>(byte));
+  }
+
+  EXPECT_THROW(selected_delimiter(input), std::logic_error);
+}
+
+TEST_F(FromJsonTest, RawMapOpt_UnquotedControlCharactersStrict)
+{
+  std::vector<std::string> rows{R"({"str":"value"})",
+                                "{\"str\":\t\"value\"}",
+                                "{\"str\":\"val\001ue\"}",
+                                "{\"str\":\"val\002ue\"}",
+                                "{\"str\":\"v\003alue\"}",
+                                "{\"str\":\"value\",\"other\":\"in\001fo\"}"};
+  auto const input_col = cudf::test::strings_column_wrapper{rows.begin(), rows.end()};
+  auto const input     = cudf::strings_column_view{input_col};
+
+  auto const expected =
+    make_expected_raw_map({{{"str", "value"}}, {{"str", "value"}}, {}, {}, {}, {}},
+                          {true, true, false, false, false, false});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*raw_map(input), *expected);
+}
 
 // ===========================================================================
 // RawMapOpt_* : pin the exact LIST<STRUCT<STRING,STRING>> output of `from_json_to_raw_map`.
@@ -422,21 +495,34 @@ TEST_F(FromJsonTest, RawMapOpt_EmptyInput)
   EXPECT_EQ(scv.child(1).type().id(), cudf::type_id::STRING);  // value.
 }
 
-// allow_unquoted_control=true: a literal control char (tab) inside a quoted value is accepted and
-// copied verbatim into the value bytes.
+// allow_unquoted_control=true: literal C0 bytes inside quoted values are accepted and copied
+// verbatim. Keeping several distinct bytes present also guards delimiter selection.
 TEST_F(FromJsonTest, RawMapOpt_UnquotedControl)
 {
-  auto const input_col = cudf::test::strings_column_wrapper{"{\"k\":\"a\tb\"}"};
+  std::vector<std::string> rows{R"({"str":"value"})",
+                                "{\"str\":\t\"value\"}",
+                                "{\"str\":\"val\001ue\"}",
+                                "{\"str\":\"val\002ue\"}",
+                                "{\"str\":\"v\003alue\"}",
+                                "{\"str\":\"value\",\"other\":\"in\001fo\"}"};
+  auto const input_col = cudf::test::strings_column_wrapper{rows.begin(), rows.end()};
   auto const input     = cudf::strings_column_view{input_col};
 
   auto const result = spark_rapids_jni::from_json_to_raw_map(
     input,
-    spark_rapids_jni::json_parse_options{default_options.normalize_single_quotes,
-                                         default_options.allow_leading_zeros,
-                                         default_options.allow_nonnumeric_numbers,
-                                         /*allow_unquoted_control=*/true});
+    spark_rapids_jni::json_parse_options{
+      .normalize_single_quotes  = default_options.normalize_single_quotes,
+      .allow_leading_zeros      = default_options.allow_leading_zeros,
+      .allow_nonnumeric_numbers = default_options.allow_nonnumeric_numbers,
+      .allow_unquoted_control   = true});
 
-  auto const expected = make_expected_raw_map({{{"k", "a\tb"}}}, all_valid(1));
+  auto const expected = make_expected_raw_map({{{"str", "value"}},
+                                               {{"str", "value"}},
+                                               {{"str", "val\001ue"}},
+                                               {{"str", "val\002ue"}},
+                                               {{"str", "v\003alue"}},
+                                               {{"str", "value"}, {"other", "in\001fo"}}},
+                                              all_valid(rows.size()));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
 }
 

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -36,7 +36,9 @@
 #include <format>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -112,6 +114,14 @@ char selected_delimiter(std::string const& input)
   return std::get<1>(result);
 }
 
+char selected_delimiter(std::vector<std::string> const& input, bool nullify_invalid_rows)
+{
+  auto const input_col = cudf::test::strings_column_wrapper{input.begin(), input.end()};
+  auto const result    = spark_rapids_jni::concat_json(
+    cudf::strings_column_view{input_col}, nullify_invalid_rows);
+  return std::get<1>(result);
+}
+
 // Default leniency options shared by all calls and the single source of truth for the defaults.
 // Individual tests override only the field a case exercises (designated initializers below).
 constexpr spark_rapids_jni::json_parse_options default_options{
@@ -171,6 +181,30 @@ TEST_F(FromJsonTest, ConcatJsonDelimiter_PrefersDelBeforeC0Fallback)
   }
 
   EXPECT_EQ(selected_delimiter(input), '\x7f');
+}
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_UsesLastC0Fallback)
+{
+  auto input = std::string{"{"};
+  for (int byte = 0x01; byte <= 0x1e; ++byte) {
+    input.push_back(static_cast<char>(byte));
+  }
+  for (int byte = 0x21; byte <= 0x7f; ++byte) {
+    input.push_back(static_cast<char>(byte));
+  }
+
+  EXPECT_EQ(selected_delimiter(input), '\x1f');
+}
+
+TEST_F(FromJsonTest, ConcatJsonDelimiter_IgnoresInvalidRowsWhenExhausted)
+{
+  auto invalid_row = std::string{"not-json"};
+  for (int byte = 0; byte <= 0x7f; ++byte) {
+    invalid_row.push_back(static_cast<char>(byte));
+  }
+
+  std::vector<std::string> rows{R"({"k":"v"})", std::move(invalid_row)};
+  EXPECT_EQ(selected_delimiter(rows, /*nullify_invalid_rows=*/true), '\n');
 }
 
 TEST_F(FromJsonTest, ConcatJsonDelimiter_ThrowsWhenAsciiExhausted)

--- a/src/main/cpp/tests/from_json.cpp
+++ b/src/main/cpp/tests/from_json.cpp
@@ -117,8 +117,8 @@ char selected_delimiter(std::string const& input)
 char selected_delimiter(std::vector<std::string> const& input, bool nullify_invalid_rows)
 {
   auto const input_col = cudf::test::strings_column_wrapper{input.begin(), input.end()};
-  auto const result    = spark_rapids_jni::concat_json(
-    cudf::strings_column_view{input_col}, nullify_invalid_rows);
+  auto const result =
+    spark_rapids_jni::concat_json(cudf::strings_column_view{input_col}, nullify_invalid_rows);
   return std::get<1>(result);
 }
 


### PR DESCRIPTION
This PR addresses NVIDIA/cudf-spark#15231.

#4794 prevented NUL from being selected as the delimiter used to join JSON rows. That change exposed another problem in the existing delimiter-selection code that is - the histogram used to find an unused character could fail, and the
failure was not checked.

As a result, the code could select a control character that was already present in the JSON input. cuDF would then treat that character as a row separator which could turn one input row into multiple rows and cause downstream row-count mismatch errors.

This PR fixes the histogram calculation, checks for CUDA errors and makes sure the selected delimiter is not present in the input. 

It also adds tests for embedded NUL characters, control characters, printable characters, DEL and the case where no delimiter is available.

## Testing

- JNI build passed
- All 23 native C++ tests passed
- 11 focused JNI JSON tests passed
- The three failing tests from NVIDIA/cudf-spark#15231 passed
- The full JSON matrix passed with 946 tests and no failures