### PR TITLE
Use larger copy buffer for vectored read fallback

### DIFF
--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFile.java
@@ -30,6 +30,8 @@ import java.util.OptionalLong;
  * The implementation of this interface should be thread-safe.
  */
 public interface RapidsInputFile {
+  int DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE = 8 * 1024 * 1024;
+
   /**
    * Get the path of this input file.
    * @return the file path string
@@ -72,22 +74,25 @@ public interface RapidsInputFile {
     if (copyRanges.isEmpty()) {
       return;
     }
-    long outputLength = output.getLength();
-    for (CopyRange copyRange : copyRanges) {
-      Objects.requireNonNull(copyRange, "copyRange can't be null");
-      long end = copyRange.getOutputOffset() + copyRange.getLength();
-      if (end < 0 || end > outputLength) {
-        throw new IllegalArgumentException(
-            "Output buffer length " + outputLength + " is smaller than requested end " + end);
-      }
-    }
+    RapidsInputFileUtils.readVectoredUsingCopyBuffer(
+        this, output, copyRanges, DEFAULT_READ_VECTORED_COPY_BUFFER_SIZE);
+  }
 
-    try (SeekableInputStream input = open()) {
-      for (CopyRange copyRange : copyRanges) {
-        input.seek(copyRange.getInputOffset());
-        output.copyFromStream(copyRange.getOutputOffset(), input, copyRange.getLength());
-      }
-    }
+  /**
+   * Reads data from {@code inputFile} into {@code output} using a caller-supplied copy buffer.
+   *
+   * @param inputFile the file to read from
+   * @param output the destination buffer
+   * @param copyRanges input ranges and output offsets
+   * @param copyBuffer reusable copy buffer
+   * @throws IOException if an I/O error occurs during reading
+   */
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<CopyRange> copyRanges,
+      byte[] copyBuffer) throws IOException {
+    RapidsInputFileUtils.readVectoredUsingCopyBuffer(inputFile, output, copyRanges, copyBuffer);
   }
 
   /**

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileUtils.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.jni.fileio;
+
+import ai.rapids.cudf.HostMemoryBuffer;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+final class RapidsInputFileUtils {
+  private RapidsInputFileUtils() {
+  }
+
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      int copyBufferSize) throws IOException {
+    validateReadVectoredArgs(inputFile, output, copyRanges, copyBufferSize);
+    if (copyRanges.isEmpty()) {
+      return;
+    }
+
+    byte[] copyBuffer = new byte[getCopyBufferAllocationSize(copyRanges, copyBufferSize)];
+    try (SeekableInputStream input = inputFile.open()) {
+      readVectored(input, output, copyRanges, copyBuffer);
+    }
+  }
+
+  static void readVectoredUsingCopyBuffer(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      byte[] copyBuffer) throws IOException {
+    validateReadVectoredArgs(inputFile, output, copyRanges, copyBuffer);
+    if (copyRanges.isEmpty()) {
+      return;
+    }
+
+    try (SeekableInputStream input = inputFile.open()) {
+      readVectored(input, output, copyRanges, copyBuffer);
+    }
+  }
+
+  private static void readVectored(
+      SeekableInputStream input,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      byte[] copyBuffer) throws IOException {
+    for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+      if (input.getPos() != copyRange.getInputOffset()) {
+        input.seek(copyRange.getInputOffset());
+      }
+      long outputOffset = copyRange.getOutputOffset();
+      long bytesLeft = copyRange.getLength();
+      while (bytesLeft > 0) {
+        int readLength = (int) Math.min(bytesLeft, copyBuffer.length);
+        readFully(input, copyBuffer, readLength);
+        output.setBytes(outputOffset, copyBuffer, 0, readLength);
+        outputOffset += readLength;
+        bytesLeft -= readLength;
+      }
+    }
+  }
+
+  private static void validateReadVectoredArgs(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      int copyBufferSize) {
+    Objects.requireNonNull(inputFile, "inputFile can't be null");
+    if (copyBufferSize <= 0) {
+      throw new IllegalArgumentException("copyBufferSize must be positive");
+    }
+    validateReadVectoredArgs(inputFile, output, copyRanges);
+  }
+
+  private static void validateReadVectoredArgs(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges,
+      byte[] copyBuffer) {
+    Objects.requireNonNull(inputFile, "inputFile can't be null");
+    Objects.requireNonNull(copyBuffer, "copyBuffer can't be null");
+    if (copyBuffer.length == 0) {
+      throw new IllegalArgumentException("copyBuffer must not be empty");
+    }
+    validateReadVectoredArgs(inputFile, output, copyRanges);
+  }
+
+  private static void validateReadVectoredArgs(
+      RapidsInputFile inputFile,
+      HostMemoryBuffer output,
+      List<RapidsInputFile.CopyRange> copyRanges) {
+    Objects.requireNonNull(inputFile, "inputFile can't be null");
+    Objects.requireNonNull(output, "output can't be null");
+    Objects.requireNonNull(copyRanges, "copyRanges can't be null");
+
+    long outputLength = output.getLength();
+    for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+      Objects.requireNonNull(copyRange, "copyRange can't be null");
+      long end = copyRange.getOutputOffset() + copyRange.getLength();
+      if (end < 0 || end > outputLength) {
+        throw new IllegalArgumentException(
+            "Output buffer length " + outputLength + " is smaller than requested end " + end);
+      }
+    }
+  }
+
+  private static int getCopyBufferAllocationSize(
+      List<RapidsInputFile.CopyRange> copyRanges,
+      int copyBufferSize) {
+    long maxRangeLength = 0;
+    for (RapidsInputFile.CopyRange copyRange : copyRanges) {
+      maxRangeLength = Math.max(maxRangeLength, copyRange.getLength());
+      if (maxRangeLength >= copyBufferSize) {
+        return copyBufferSize;
+      }
+    }
+    return (int) Math.min(copyBufferSize, maxRangeLength);
+  }
+
+  private static void readFully(SeekableInputStream input, byte[] copyBuffer, int readLength)
+      throws IOException {
+    int totalRead = 0;
+    while (totalRead < readLength) {
+      int amountRead = input.read(copyBuffer, totalRead, readLength - totalRead);
+      if (amountRead < 0) {
+        throw new EOFException(
+            "Unexpected end of stream, expected " + (readLength - totalRead) + " more bytes");
+      }
+      if (amountRead == 0) {
+        throw new IOException(
+            "No progress reading stream, expected " + (readLength - totalRead) + " more bytes");
+      }
+      totalRead += amountRead;
+    }
+  }
+}

--- a/src/main/java/com/nvidia/spark/rapids/jni/fileio/SeekableInputStream.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/fileio/SeekableInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,10 @@ import java.io.InputStream;
 
 /**
  * An {@code Inputstream} that offers random access interface.
+ *
+ * <p>Implementations of {@link #read(byte[], int, int)} must not return 0 when {@code len} is
+ * positive. They must either block until at least one byte is available, return -1 at end of
+ * stream, or throw an {@link IOException}.
  *
  */
 public abstract class SeekableInputStream extends InputStream {

--- a/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/fileio/RapidsInputFileTest.java
@@ -44,12 +44,35 @@ public class RapidsInputFileTest {
   }
 
   @Test
+  public void readVectoredUsingCallerSuppliedCopyBuffer() throws IOException {
+    TestRapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
+    byte[] copyBuffer = new byte[4];
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(12)) {
+      RapidsInputFile.readVectoredUsingCopyBuffer(inputFile, output, Arrays.asList(
+          new RapidsInputFile.CopyRange(0, 6, 0),
+          new RapidsInputFile.CopyRange(8, 6, 6)), copyBuffer);
+      assertArrayEquals("abcdefijklmn".getBytes(StandardCharsets.UTF_8), readBytes(output));
+    }
+    assertEquals(1, inputFile.getOpenCount());
+  }
+
+  @Test
   public void readVectoredThrowsOnShortRead() throws IOException {
     RapidsInputFile inputFile = new TestRapidsInputFile(FILE_DATA);
     try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
       assertThrows(EOFException.class,
           () -> inputFile.readVectored(output,
               Collections.singletonList(new RapidsInputFile.CopyRange(14, 3, 0))));
+    }
+  }
+
+  @Test
+  public void readVectoredThrowsIOExceptionOnZeroProgressRead() throws IOException {
+    RapidsInputFile inputFile = new ZeroProgressInputFile(FILE_DATA.length);
+    try (HostMemoryBuffer output = HostMemoryBuffer.allocate(3)) {
+      assertThrows(IOException.class,
+          () -> inputFile.readVectored(output,
+              Collections.singletonList(new RapidsInputFile.CopyRange(0, 3, 0))));
     }
   }
 
@@ -128,6 +151,24 @@ public class RapidsInputFileTest {
     }
   }
 
+  private static final class ZeroProgressInputFile implements RapidsInputFile {
+    private final long length;
+
+    private ZeroProgressInputFile(long length) {
+      this.length = length;
+    }
+
+    @Override
+    public long getLength() {
+      return length;
+    }
+
+    @Override
+    public SeekableInputStream open() {
+      return new ZeroProgressSeekableInputStream();
+    }
+  }
+
   private static final class ArraySeekableInputStream extends SeekableInputStream {
     private final byte[] data;
     private int position;
@@ -177,6 +218,27 @@ public class RapidsInputFileTest {
       System.arraycopy(data, position, b, off, amountToRead);
       position += amountToRead;
       return amountToRead;
+    }
+  }
+
+  private static final class ZeroProgressSeekableInputStream extends SeekableInputStream {
+    @Override
+    public long getPos() {
+      return 0;
+    }
+
+    @Override
+    public void seek(long newPos) {
+    }
+
+    @Override
+    public int read() {
+      return 0;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) {
+      return 0;
     }
   }
 }


### PR DESCRIPTION
## Description

This is the `main` forward-port of NVIDIA/cudf-spark-jni#4765, which targeted `release/26.06`.

It updates the default `RapidsInputFile.readVectored` fallback to copy through an explicit byte-buffer loop and write into the destination `HostMemoryBuffer` with `setBytes`:

- allocate a bounded per-call buffer using the smaller of 8 MiB and the largest requested range
- expose `RapidsInputFile.readVectoredUsingCopyBuffer(..., byte[])` for callers with a well-defined scratch-buffer lifecycle
- keep validation and stream-copy details in a package-private utility
- avoid retained shared buffers and `ThreadLocal` state

Related issue: NVIDIA/cudf-spark#15163.

The corresponding cudf-spark `main` forward-port, NVIDIA/cudf-spark#15242, uses the caller-supplied-buffer helper in `HadoopInputFile.readVectored`, allowing Hadoop-backed fallback reads to honor `parquet.read.allocation.size` while preserving the `inputFile.readVectored` abstraction.

## Testing

The current `main` forward-port commit (`daca8177f626c4c48676beea5f16d36a974620fe`) was tested on an x86 host with:

```text
mvn -B -Dmaven.antrun.skip=true -Dtest=RapidsInputFileTest \
  test-compile surefire:test@default-test
```

Result:

```text
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The JNI `26.08.0-SNAPSHOT` artifact was then installed locally and used to package the corresponding cudf-spark `main` forward-port:

```text
mvn -B -pl sql-plugin -am -DskipTests \
  -Dspark-rapids-jni.version=26.08.0-SNAPSHOT package
```

Result: `BUILD SUCCESS` for all four reactor modules.

## Performance Validation

End-to-end NDS validation of the same implementation is documented in NVIDIA/cudf-spark#15163. Five interleaved runs per side did not reproduce a stable regression with either PerfIO disabled or enabled.
