### PR TITLE
Fix ORC base-offset borrow

### DIFF
--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023-2025, NVIDIA CORPORATION.
+/*
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +16,8 @@
 
 #include "cudf_jni_apis.hpp"
 #include "timezones.hpp"
+
+#include <cstdint>
 
 extern "C" {
 
@@ -97,14 +100,15 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTimestampColumnToUTCWithTz
   JNI_CATCH(env, 0);
 }
 
-JNIEXPORT jlong JNICALL
-Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOrcTimezones(JNIEnv* env,
-                                                                   jclass,
-                                                                   jlong input_handle,
-                                                                   jlong writer_tz_info_table,
-                                                                   jint writer_tz_raw_offset,
-                                                                   jlong reader_tz_info_table,
-                                                                   jint reader_tz_raw_offset)
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOrcTimezones(
+  JNIEnv* env,
+  jclass,
+  jlong input_handle,
+  jlong writer_tz_info_table,
+  jint writer_tz_raw_offset,
+  jlong writer_2015_year_base_offset_us,
+  jlong reader_tz_info_table,
+  jint reader_tz_raw_offset)
 {
   JNI_NULL_CHECK(env, input_handle, "input column is null", 0);
 
@@ -114,10 +118,14 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOrcTimezones(JNIEnv* env,
     auto const input              = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const writer_tz_info_tab = reinterpret_cast<cudf::table_view const*>(writer_tz_info_table);
     auto const reader_tz_info_tab = reinterpret_cast<cudf::table_view const*>(reader_tz_info_table);
-    return cudf::jni::ptr_as_jlong(
-      spark_rapids_jni::convert_orc_writer_reader_timezones(
-        *input, writer_tz_info_tab, writer_tz_raw_offset, reader_tz_info_tab, reader_tz_raw_offset)
-        .release());
+    return cudf::jni::ptr_as_jlong(spark_rapids_jni::convert_orc_writer_reader_timezones(
+                                     *input,
+                                     writer_tz_info_tab,
+                                     writer_tz_raw_offset,
+                                     static_cast<int64_t>(writer_2015_year_base_offset_us),
+                                     reader_tz_info_tab,
+                                     reader_tz_raw_offset)
+                                     .release());
   }
   JNI_CATCH(env, 0);
 }

--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -118,14 +118,13 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOr
     auto const input              = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const writer_tz_info_tab = reinterpret_cast<cudf::table_view const*>(writer_tz_info_table);
     auto const reader_tz_info_tab = reinterpret_cast<cudf::table_view const*>(reader_tz_info_table);
-    return cudf::jni::ptr_as_jlong(spark_rapids_jni::convert_orc_writer_reader_timezones(
-                                     *input,
-                                     writer_tz_info_tab,
-                                     writer_tz_raw_offset,
-                                     static_cast<int64_t>(writer_2015_year_base_offset_us),
-                                     reader_tz_info_tab,
-                                     reader_tz_raw_offset)
-                                     .release());
+    return cudf::jni::release_as_jlong(spark_rapids_jni::convert_orc_writer_reader_timezones(
+      *input,
+      writer_tz_info_tab,
+      writer_tz_raw_offset,
+      static_cast<int64_t>(writer_2015_year_base_offset_us),
+      reader_tz_info_tab,
+      reader_tz_raw_offset));
   }
   JNI_CATCH(env, 0);
 }

--- a/src/main/cpp/src/integer_utils.cuh
+++ b/src/main/cpp/src/integer_utils.cuh
@@ -38,6 +38,17 @@ __device__ Type floor_div(Type x, Type y)
   return quotient - mixed_sign * nonzero_remainder;
 }
 
+/**
+ * @brief floor modulo for positive divisors.
+ */
+template <typename Type>
+__device__ Type floor_mod(Type x, Type y)
+  requires(cuda::std::is_integral_v<Type> and cuda::std::is_signed_v<Type>)
+{
+  auto const remainder = x % y;
+  return remainder < 0 ? remainder + y : remainder;
+}
+
 }  // namespace integer_utils
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -672,6 +672,7 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
                            cudf::bitmask_type const* __restrict__ null_mask,
                            cudf::timestamp_us* __restrict__ output,
                            cudf::size_type num_rows,
+                           cudf::size_type input_offset,
                            orc_base_offset_info writer_2015_year_base_offset,
                            orc_tz_side_kernel_args writer_args,
                            orc_tz_side_kernel_args reader_args)
@@ -700,7 +701,7 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
 
   cudf::size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_rows) {
-    if (null_mask && !cudf::bit_is_set(null_mask, idx)) { return; }
+    if (null_mask && !cudf::bit_is_set(null_mask, idx + input_offset)) { return; }
     tz_side_info const writer{wt_begin,
                               wt_end,
                               wo_begin,
@@ -789,6 +790,7 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
                input.null_mask(),
                results->mutable_view().begin<cudf::timestamp_us>(),
                input.size(),
+               input.offset(),
                writer_2015_year_base_offset,
                writer_args,
                reader_args);

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -37,6 +37,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/launch>
+#include <cuda/std/chrono>
 #include <cuda/std/functional>
 #include <thrust/binary_search.h>
 
@@ -49,6 +50,9 @@ using struct_view              = cudf::struct_view;
 using table_view               = cudf::table_view;
 
 namespace {
+
+constexpr int64_t MICROS_PER_MILLI  = 1'000;
+constexpr int64_t MICROS_PER_SECOND = 1'000'000;
 
 /**
  * Functor to convert timestamps between UTC and a specific timezone.
@@ -107,7 +111,7 @@ auto convert_timestamp_tz(column_view const& input,
                                              mr);
 
   thrust::transform(
-    rmm::exec_policy(stream),
+    rmm::exec_policy_nosync(stream),
     input.begin<timestamp_type>(),
     input.end<timestamp_type>(),
     results->mutable_view().begin<timestamp_type>(),
@@ -462,6 +466,25 @@ struct tz_side_info {
   spark_rapids_jni::dst_rule dst;
 };
 
+struct orc_base_offset_info {
+  int64_t us;
+  bool is_second_aligned;
+};
+
+[[nodiscard]] orc_base_offset_info make_orc_base_offset_info(int64_t us)
+{
+  return orc_base_offset_info{us, (us % MICROS_PER_SECOND) == 0};
+}
+
+struct orc_tz_side_kernel_args {
+  int64_t const* __restrict__ trans;
+  int32_t const* __restrict__ offsets;
+  int32_t trans_count;
+  int32_t initial_offset;
+  int32_t raw_offset;
+  spark_rapids_jni::dst_rule dst;
+};
+
 __device__ static int32_t get_transition_index(int64_t time_ms, tz_side_info const& side)
 {
   if (side.trans_begin == side.trans_end) {
@@ -497,25 +520,80 @@ __device__ static bool is_fixed_offset_tz(tz_side_info const& side)
 }
 
 /**
+ * @brief Apply the ORC 2015 writer base offset while preserving Apache's negative timestamp borrow.
+ *
+ * ORC stores a timestamp as seconds relative to 2015-01-01 in the writer timezone plus a
+ * non-negative nanos field. For a pre-epoch timestamp with a fractional part, the Apache writer
+ * truncates the seconds toward zero. On read, Apache reconstructs the writer-specific 2015 epoch,
+ * then borrows one second when the resulting seconds are negative and the encoded nanos contribute
+ * at least one millisecond.
+ *
+ * With `ignoreTimezoneInStripeFooter=true`, cuDF instead uses the UTC 2015 epoch when deciding
+ * whether to borrow. The later writer 2015 base-offset adjustment can move the timestamp across
+ * the Unix epoch, making cuDF's earlier borrow decision incorrect. This function first reconstructs
+ * the value before cuDF's borrow, applies the writer-specific 2015 base offset, and then makes the
+ * borrow decision in the same frame as Apache. It can therefore both add a missing borrow and undo
+ * one that cuDF applied before the sign changed.
+ *
+ * For example, the Asia/Shanghai reproducer from rapidsai/cudf#21993 has:
+ *
+ * @code{.pseudo}
+ *   decoded_us     =  21'087'883'873  // cuDF used the UTC 2015 epoch; no borrow
+ *   writer_2015_year_base_offset_us =  28'800'000'000  // Shanghai is UTC+08:00 at the ORC epoch
+ *   unborrowed_us  =  -7'712'116'127  // negative after using the writer-specific epoch
+ *   result_us      =  -7'713'116'127  // Apache-compatible one-second borrow
+ * @endcode
+ *
+ * The one-millisecond threshold matches cuDF's ORC decoder and the Apache writer's nanos encoding.
+ */
+__device__ static int64_t apply_orc_base_offset(int64_t decoded_us,
+                                                orc_base_offset_info base_offset)
+{
+  if (base_offset.us == 0) { return decoded_us; }
+
+  // ORC timezone base offsets are second-aligned. For an arbitrary microsecond offset, the
+  // original nanos field cannot be reconstructed reliably, so retain the plain offset behavior.
+  if (!base_offset.is_second_aligned) { return decoded_us - base_offset.us; }
+
+  auto const plain_adjusted_us = decoded_us - base_offset.us;
+  if (decoded_us >= 0 && plain_adjusted_us >= 0) { return plain_adjusted_us; }
+  if (decoded_us < 0 && plain_adjusted_us < -MICROS_PER_SECOND) { return plain_adjusted_us; }
+
+  auto const fractional_us =
+    spark_rapids_jni::integer_utils::floor_mod(decoded_us, MICROS_PER_SECOND);
+
+  bool const has_borrowable_fraction = fractional_us >= MICROS_PER_MILLI;
+  bool const cudf_applied_borrow     = decoded_us < 0 && has_borrowable_fraction;
+
+  auto const unborrowed_us = decoded_us + (cudf_applied_borrow ? MICROS_PER_SECOND : int64_t{0});
+  auto const adjusted_unborrowed_us = unborrowed_us - base_offset.us;
+  bool const apache_applies_borrow  = adjusted_unborrowed_us < 0 && has_borrowable_fraction;
+
+  return adjusted_unborrowed_us - (apache_applies_borrow ? MICROS_PER_SECOND : int64_t{0});
+}
+
+/**
  * @brief Convert a timestamp between ORC writer and reader timezones.
  *
- * Implements org.apache.orc.impl.SerializationUtils.convertBetweenTimezones.
+ * Matches Apache ORC's read order: first reconstruct the timestamp using the writer timezone's
+ * 2015 base instant and apply Apache's negative nanos borrow, then run the equivalent of
+ * org.apache.orc.impl.SerializationUtils.convertBetweenTimezones. The first step is required for
+ * fixed, transition-table, and DST writers because ORC's 2015 base offset can include historical
+ * or DST-specific offset state.
  *
  * Optimized for common cases:
  * - Fixed-offset reader (e.g. UTC): skip all reader lookups, use constant offset.
  * - Fixed-offset writer: skip writer lookups.
  */
-__device__ static cudf::timestamp_us convert_timestamp_between_timezones(cudf::timestamp_us ts,
-                                                                         int64_t base_offset_us,
-                                                                         tz_side_info const& writer,
-                                                                         tz_side_info const& reader)
+__device__ static cudf::timestamp_us convert_timestamp_between_timezones(
+  cudf::timestamp_us ts,
+  orc_base_offset_info writer_2015_year_base_offset,
+  tz_side_info const& writer,
+  tz_side_info const& reader)
 {
-  constexpr int64_t MICROS_PER_MILLI = 1000L;
-
-  int64_t const adjusted_us =
-    static_cast<int64_t>(
-      cuda::std::chrono::duration_cast<cudf::duration_us>(ts.time_since_epoch()).count()) -
-    base_offset_us;
+  int64_t const decoded_us = static_cast<int64_t>(
+    cuda::std::chrono::duration_cast<cudf::duration_us>(ts.time_since_epoch()).count());
+  int64_t const adjusted_us = apply_orc_base_offset(decoded_us, writer_2015_year_base_offset);
 
   // Floor-divide to get epoch millis (handles negative timestamps correctly)
   int64_t const epoch_millis =
@@ -594,19 +672,9 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
                            cudf::bitmask_type const* __restrict__ null_mask,
                            cudf::timestamp_us* __restrict__ output,
                            cudf::size_type num_rows,
-                           int64_t base_offset_us,
-                           int64_t const* __restrict__ g_writer_trans,
-                           int32_t const* __restrict__ g_writer_offsets,
-                           int32_t writer_trans_count,
-                           int32_t writer_initial_offset,
-                           int32_t writer_raw_offset,
-                           spark_rapids_jni::dst_rule writer_dst,
-                           int64_t const* __restrict__ g_reader_trans,
-                           int32_t const* __restrict__ g_reader_offsets,
-                           int32_t reader_trans_count,
-                           int32_t reader_initial_offset,
-                           int32_t reader_raw_offset,
-                           spark_rapids_jni::dst_rule reader_dst)
+                           orc_base_offset_info writer_2015_year_base_offset,
+                           orc_tz_side_kernel_args writer_args,
+                           orc_tz_side_kernel_args reader_args)
 {
   // Shared memory layout: writer transitions, writer offsets, reader transitions, reader offsets
   extern __shared__ char smem[];
@@ -614,25 +682,44 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
   char* ptr = smem;
   int64_t const *wt_begin, *wt_end, *rt_begin, *rt_end;
   int32_t const *wo_begin, *ro_begin;
-  stage_side_transitions(
-    g_writer_trans, g_writer_offsets, writer_trans_count, ptr, wt_begin, wt_end, wo_begin);
-  stage_side_transitions(
-    g_reader_trans, g_reader_offsets, reader_trans_count, ptr, rt_begin, rt_end, ro_begin);
+  stage_side_transitions(writer_args.trans,
+                         writer_args.offsets,
+                         writer_args.trans_count,
+                         ptr,
+                         wt_begin,
+                         wt_end,
+                         wo_begin);
+  stage_side_transitions(reader_args.trans,
+                         reader_args.offsets,
+                         reader_args.trans_count,
+                         ptr,
+                         rt_begin,
+                         rt_end,
+                         ro_begin);
   __syncthreads();
 
   cudf::size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_rows) {
     if (null_mask && !cudf::bit_is_set(null_mask, idx)) { return; }
-    tz_side_info const writer{
-      wt_begin, wt_end, wo_begin, writer_initial_offset, writer_raw_offset, writer_dst};
-    tz_side_info const reader{
-      rt_begin, rt_end, ro_begin, reader_initial_offset, reader_raw_offset, reader_dst};
-    output[idx] = convert_timestamp_between_timezones(input[idx], base_offset_us, writer, reader);
+    tz_side_info const writer{wt_begin,
+                              wt_end,
+                              wo_begin,
+                              writer_args.initial_offset,
+                              writer_args.raw_offset,
+                              writer_args.dst};
+    tz_side_info const reader{rt_begin,
+                              rt_end,
+                              ro_begin,
+                              reader_args.initial_offset,
+                              reader_args.raw_offset,
+                              reader_args.dst};
+    output[idx] =
+      convert_timestamp_between_timezones(input[idx], writer_2015_year_base_offset, writer, reader);
   }
 }
 
 std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
-                                          int64_t base_offset_us,
+                                          int64_t writer_2015_year_base_offset_us,
                                           spark_rapids_jni::orc_tz_side writer,
                                           spark_rapids_jni::orc_tz_side reader,
                                           rmm::cuda_stream_view stream,
@@ -677,6 +764,20 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
   }
 
   int32_t num_blocks = cudf::util::div_rounding_up_safe(input.size(), CONVERT_TZ_BLOCK_SIZE);
+  auto const writer_2015_year_base_offset =
+    make_orc_base_offset_info(writer_2015_year_base_offset_us);
+  auto const writer_args = orc_tz_side_kernel_args{writer_trans_ptr,
+                                                   writer_offsets_ptr,
+                                                   writer_trans_count,
+                                                   writer.initial_offset,
+                                                   writer.raw_offset,
+                                                   writer.dst};
+  auto const reader_args = orc_tz_side_kernel_args{reader_trans_ptr,
+                                                   reader_offsets_ptr,
+                                                   reader_trans_count,
+                                                   reader.initial_offset,
+                                                   reader.raw_offset,
+                                                   reader.dst};
 
   auto const launch_config = cuda::make_config(cuda::grid_dims(num_blocks),
                                                cuda::block_dims<CONVERT_TZ_BLOCK_SIZE>(),
@@ -688,19 +789,9 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
                input.null_mask(),
                results->mutable_view().begin<cudf::timestamp_us>(),
                input.size(),
-               base_offset_us,
-               writer_trans_ptr,
-               writer_offsets_ptr,
-               writer_trans_count,
-               writer.initial_offset,
-               writer.raw_offset,
-               writer.dst,
-               reader_trans_ptr,
-               reader_offsets_ptr,
-               reader_trans_count,
-               reader.initial_offset,
-               reader.raw_offset,
-               reader.dst);
+               writer_2015_year_base_offset,
+               writer_args,
+               reader_args);
   CUDF_CHECK_CUDA(stream.value());
 
   return results;
@@ -780,39 +871,41 @@ std::unique_ptr<column> convert_timestamp_to_utc(column_view const& input_second
                                                 mr);
 }
 
-std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(cudf::column_view const& input,
-                                                                  int64_t base_offset_us,
-                                                                  orc_tz_side writer,
-                                                                  orc_tz_side reader,
-                                                                  rmm::cuda_stream_view stream,
-                                                                  rmm::device_async_resource_ref mr)
+std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
+  cudf::column_view const& input,
+  int64_t writer_2015_year_base_offset_us,
+  orc_tz_side writer,
+  orc_tz_side reader,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
 {
-  return convert_timezones(input, base_offset_us, writer, reader, stream, mr);
+  return convert_timezones(input, writer_2015_year_base_offset_us, writer, reader, stream, mr);
 }
 
 std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
   cudf::column_view const& input,
   cudf::table_view const* writer_tz_info_table,
   int32_t writer_raw_offset,
+  int64_t writer_2015_year_base_offset_us,
   cudf::table_view const* reader_tz_info_table,
   int32_t reader_raw_offset,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  // Non-DST path: no base-offset fusion, no DST rule. Passing
-  // initial_offset == raw_offset makes the DST-capable kernel's
-  // before-first-transition branch return raw_offset, matching the legacy
-  // kernel exactly.
-  return convert_orc_writer_reader_timezones(input,
-                                             /*base_offset_us=*/int64_t{0},
-                                             orc_tz_side{writer_tz_info_table,
-                                                         /*initial_offset=*/writer_raw_offset,
-                                                         writer_raw_offset},
-                                             orc_tz_side{reader_tz_info_table,
-                                                         /*initial_offset=*/reader_raw_offset,
-                                                         reader_raw_offset},
-                                             stream,
-                                             mr);
+  // Java passes the exact ORC 2015 writer base offset, so this path does not infer it from
+  // raw_offset. Passing initial_offset == raw_offset preserves the previous before-first-transition
+  // behavior for raw-offset-only callers; full DST fallback uses the orc_tz_side overload.
+  return convert_orc_writer_reader_timezones(
+    input,
+    writer_2015_year_base_offset_us,
+    spark_rapids_jni::orc_tz_side{writer_tz_info_table,
+                                  /*initial_offset=*/writer_raw_offset,
+                                  writer_raw_offset},
+    spark_rapids_jni::orc_tz_side{reader_tz_info_table,
+                                  /*initial_offset=*/reader_raw_offset,
+                                  reader_raw_offset},
+    stream,
+    mr);
 }
 
 }  // namespace spark_rapids_jni

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -151,9 +151,11 @@ struct orc_tz_side {
  * recurring DST rules derived from JVM timezone APIs for dates beyond the table.
  *
  * @param input The input timestamp column in microseconds.
- * @param base_offset_us Fixed microsecond offset to apply before timezone conversion.
- *        Fuses ORC's base-timestamp adjustment (writer TZ offset at 2015-01-01) into
- *        the kernel, eliminating a separate pass. Pass 0 for no adjustment.
+ * @param writer_2015_year_base_offset_us Writer timezone offset at ORC's 2015-01-01 base instant.
+ *        ORC applies this base-timestamp adjustment, including any DST savings in effect at that
+ *        instant, before running SerializationUtils.convertBetweenTimezones. The native path
+ *        applies the same adjustment first so the negative-timestamp nanos borrow is decided in
+ *        the same frame as Apache ORC. Pass 0 for no adjustment.
  * @param writer writer timezone transition data, offsets, and DST rule.
  * @param reader reader timezone transition data, offsets, and DST rule.
  * @param stream CUDA stream.
@@ -162,26 +164,27 @@ struct orc_tz_side {
  */
 [[nodiscard]] std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
   cudf::column_view const& input,
-  int64_t base_offset_us,
+  int64_t writer_2015_year_base_offset_us,
   orc_tz_side writer,
   orc_tz_side reader,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
- * @brief Backward-compatible non-DST overload of the ORC conversion.
+ * @brief JNI-compatible raw-offset overload of the ORC conversion.
  *
- * Forwards to the DST-capable overload with no base offset and no DST rule
- * (`has_dst == false`). Passing `initial_offset == raw_offset` for each side
- * reproduces the legacy behavior exactly: before the first transition the
- * DST-capable kernel returns `initial_offset`, where the legacy kernel returned
- * `raw_offset`. Retained so existing callers (the JNI binding and C++ tests)
- * compile and behave unchanged while the DST path is staged in behind
- * GpuTimeZoneDB's DST gate.
+ * Java computes and passes the writer timezone offset at ORC's 2015-01-01 base instant separately,
+ * because that value is not necessarily the raw offset: for DST zones it can include DST savings,
+ * and for historical transition zones it can come from the transition table. This overload uses
+ * that exact value for the base-timestamp/borrow adjustment, then forwards the transition tables
+ * and raw offsets to the shared conversion kernel. Callers that need recurring DST fallback beyond
+ * a transition table should use the full `orc_tz_side` overload.
  *
  * @param input The input timestamp column in microseconds.
  * @param writer_tz_info_table transition/offset table, nullptr for fixed-offset TZ.
  * @param writer_raw_offset the raw offset in milliseconds.
+ * @param writer_2015_year_base_offset_us writer timezone offset at ORC's 2015-01-01 base instant,
+ *        in microseconds.
  * @param reader_tz_info_table transition/offset table, nullptr for fixed-offset TZ.
  * @param reader_raw_offset the raw offset in milliseconds.
  * @param stream CUDA stream.
@@ -192,6 +195,7 @@ struct orc_tz_side {
   cudf::column_view const& input,
   cudf::table_view const* writer_tz_info_table,
   int32_t writer_raw_offset,
+  int64_t writer_2015_year_base_offset_us,
   cudf::table_view const* reader_tz_info_table,
   int32_t reader_raw_offset,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -26,6 +26,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/wrappers/timestamps.hpp>
 
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -402,13 +403,15 @@ spark_rapids_jni::dst_rule make_us_dst_rule()
 }
 
 [[nodiscard]] std::unique_ptr<cudf::column> convert_utc_to_dst_reader(
-  cudf::column_view const& input, spark_rapids_jni::dst_rule reader_dst, int64_t base_offset_us = 0)
+  cudf::column_view const& input,
+  spark_rapids_jni::dst_rule reader_dst,
+  int64_t writer_2015_year_base_offset_us = 0)
 {
   spark_rapids_jni::dst_rule no_dst{};
   no_dst.has_dst = 0;
   return spark_rapids_jni::convert_orc_writer_reader_timezones(
     input,
-    base_offset_us,
+    writer_2015_year_base_offset_us,
     spark_rapids_jni::orc_tz_side{/*tz_info_table=*/nullptr, 0, 0, no_dst},
     spark_rapids_jni::orc_tz_side{/*tz_info_table=*/nullptr, 0, 0, reader_dst},
     cudf::get_default_stream(),
@@ -416,15 +419,15 @@ spark_rapids_jni::dst_rule make_us_dst_rule()
 }
 }  // namespace
 
-TEST_F(TimeZoneTest, ConvertOrcTimezonesAppliesBaseOffset)
+TEST_F(TimeZoneTest, ConvertOrcTimezonesAppliesWriter2015BaseOffset)
 {
   spark_rapids_jni::dst_rule no_dst{};
   no_dst.has_dst = 0;
 
   auto const input    = micros_col{3'600'000'000L, 7'200'000'000L};
   auto const expected = micros_col{0L, 3'600'000'000L};
-  auto const actual =
-    convert_utc_to_dst_reader(input, no_dst, /*base_offset_us=*/int64_t{3'600'000'000});
+  auto const actual   = convert_utc_to_dst_reader(
+    input, no_dst, /*writer_2015_year_base_offset_us=*/int64_t{3'600'000'000});
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
 
@@ -436,13 +439,139 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesAppliesBaseOffset)
   auto const transition_expected = micros_col{-1'000L};
   auto const transition_actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
     transition_input,
-    /*base_offset_us=*/int64_t{2'000},
+    /*writer_2015_year_base_offset_us=*/int64_t{2'000},
     spark_rapids_jni::orc_tz_side{&writer_tv, 0, 0, no_dst},
     spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst},
     cudf::get_default_stream(),
     cudf::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(transition_expected, *transition_actual);
+}
+
+TEST_F(TimeZoneTest, ConvertOrcTimezonesCorrectsIgnoredWriterTimezoneEpochBorrow)
+{
+  spark_rapids_jni::dst_rule no_dst{};
+  no_dst.has_dst = 0;
+
+  // cuDF decodes this pre-epoch Asia/Shanghai ORC timestamp relative to the UTC 2015 epoch when
+  // ignoreTimezoneInStripeFooter=true. Applying the Shanghai ORC base offset moves it back before
+  // the Unix epoch, where Apache ORC applies a one-second nanos borrow.
+  auto const input    = micros_col{21'087'883'873L};
+  auto const expected = micros_col{-7'713'116'127L};
+  auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
+    input,
+    /*writer_2015_year_base_offset_us=*/int64_t{28'800'000'000},
+    spark_rapids_jni::orc_tz_side{nullptr, 28'800'000, 28'800'000, no_dst},
+    spark_rapids_jni::orc_tz_side{nullptr, 28'800'000, 28'800'000, no_dst},
+    cudf::get_default_stream(),
+    cudf::get_current_device_resource_ref());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}
+
+TEST_F(TimeZoneTest, ConvertOrcTimezonesCorrectsIgnoredWriterTimezoneEpochBorrowWithDstRule)
+{
+  auto const writer_dst = make_dst_rule(/*start_mode=*/2,
+                                        /*start_day=*/1,
+                                        /*start_dow=*/1,
+                                        /*end_mode=*/2,
+                                        /*end_day=*/1,
+                                        /*end_dow=*/1,
+                                        /*start_month=*/9,
+                                        /*end_month=*/3);
+  spark_rapids_jni::dst_rule no_dst{};
+  no_dst.has_dst = 0;
+
+  // This models the Java/JNI path for a DST writer once the Java DST gate is opened:
+  // GpuTimeZoneDB.getOrc2015YearBaseOffsetMillis calls TimeZone.getOffset at ORC's 2015-01-01
+  // base instant for transition-table timezones. The writer is a southern-hemisphere DST
+  // timezone: raw UTC+10, DST +1h. Jan 1 is inside its DST window, so that Java helper would
+  // pass UTC+11 as writer_2015_year_base_offset_us. The base-offset adjustment moves this
+  // decoded value before the Unix epoch, where Apache ORC applies the negative timestamp nanos
+  // borrow before converting between writer and reader timezones. The expected result includes
+  // both the corrected borrow and the DST writer offset when converting to UTC.
+  auto const input    = micros_col{31'887'883'873L};
+  auto const expected = micros_col{31'886'883'873L};
+  auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
+    input,
+    /*writer_2015_year_base_offset_us=*/int64_t{39'600'000'000},
+    spark_rapids_jni::orc_tz_side{nullptr, 36'000'000, 36'000'000, writer_dst},
+    spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst},
+    cudf::get_default_stream(),
+    cudf::get_current_device_resource_ref());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}
+
+TEST_F(TimeZoneTest, ConvertOrcTimezonesTableOverloadAppliesWriter2015BaseOffset)
+{
+  auto const input    = micros_col{21'087'883'873L};
+  auto const expected = micros_col{-7'713'116'127L};
+  auto const actual =
+    spark_rapids_jni::convert_orc_writer_reader_timezones(input,
+                                                          /*writer_tz_info_table=*/nullptr,
+                                                          /*writer_raw_offset=*/28'800'000,
+                                                          /*writer_2015_year_base_offset_us=*/
+                                                          int64_t{28'800'000'000},
+                                                          /*reader_tz_info_table=*/nullptr,
+                                                          /*reader_raw_offset=*/28'800'000,
+                                                          cudf::get_default_stream(),
+                                                          cudf::get_current_device_resource_ref());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}
+
+TEST_F(TimeZoneTest, ConvertOrcTimezonesTableOverloadAcceptsWriterTransitionsWithBaseOffset)
+{
+  auto const input       = micros_col{1'000L};
+  auto const expected    = micros_col{-1'000L};
+  auto const transitions = int64_col({0L, 1'000'000'000L});
+  auto const offsets     = int32_col({3'600'000, 0});
+  auto const writer_tv   = cudf::table_view({transitions, offsets});
+
+  auto const actual =
+    spark_rapids_jni::convert_orc_writer_reader_timezones(input,
+                                                          /*writer_tz_info_table=*/&writer_tv,
+                                                          /*writer_raw_offset=*/0,
+                                                          /*writer_2015_year_base_offset_us=*/2'000,
+                                                          /*reader_tz_info_table=*/nullptr,
+                                                          /*reader_raw_offset=*/0,
+                                                          cudf::get_default_stream(),
+                                                          cudf::get_current_device_resource_ref());
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}
+
+TEST_F(TimeZoneTest, ConvertOrcTimezonesRecomputesEpochBorrowAfterWriter2015BaseOffset)
+{
+  spark_rapids_jni::dst_rule no_dst{};
+  no_dst.has_dst = 0;
+
+  struct test_case {
+    int64_t decoded_us;
+    int64_t writer_2015_year_base_offset_us;
+    int64_t expected_us;
+  };
+  auto const cases = std::array<test_case, 4>{{
+    {-7'713'116'127L, 0L, -7'713'116'127L},
+    {-1'116'127L, -1'000'000L, 883'873L},
+    {9'000'999L, 10'000'000L, -999'001L},
+    {9'001'000L, 10'000'000L, -1'999'000L},
+  }};
+
+  for (auto const& test_case_data : cases) {
+    auto const input    = micros_col{test_case_data.decoded_us};
+    auto const expected = micros_col{test_case_data.expected_us};
+    auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
+      input,
+      test_case_data.writer_2015_year_base_offset_us,
+      spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst},
+      spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst},
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref());
+
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+  }
 }
 
 TEST_F(TimeZoneTest, ConvertOrcTimezonesRejectsInvalidTables)
@@ -457,13 +586,13 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesRejectsInvalidTables)
 
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::convert_orc_writer_reader_timezones(
                  input,
-                 /*base_offset_us=*/0,
+                 /*writer_2015_year_base_offset_us=*/0,
                  spark_rapids_jni::orc_tz_side{&one_column, 0, 0, no_dst},
                  spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst})),
                cudf::logic_error);
   EXPECT_THROW(static_cast<void>(spark_rapids_jni::convert_orc_writer_reader_timezones(
                  input,
-                 /*base_offset_us=*/0,
+                 /*writer_2015_year_base_offset_us=*/0,
                  spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst},
                  spark_rapids_jni::orc_tz_side{&wrong_types, 0, 0, no_dst})),
                cudf::logic_error);
@@ -484,7 +613,7 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesReaderDstBeyondTable)
   auto const expected = micros_col{1894665600000000L, 1910300400000000L};
   auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
     input,
-    /*base_offset_us=*/int64_t{0},
+    /*writer_2015_year_base_offset_us=*/int64_t{0},
     spark_rapids_jni::orc_tz_side{nullptr, 0, 0, no_dst},
     spark_rapids_jni::orc_tz_side{nullptr, 0, 0, reader_dst},
     cudf::get_default_stream(),
@@ -506,7 +635,7 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesUsesInitialOffsetBeforeFirstTransition)
   auto const expected = micros_col{1'910'304'000'000'000L};
   auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
     input,
-    /*base_offset_us=*/0,
+    /*writer_2015_year_base_offset_us=*/0,
     spark_rapids_jni::orc_tz_side{nullptr, 0, 0},
     spark_rapids_jni::orc_tz_side{&reader_tv, 0, 0, rule},
     cudf::get_default_stream(),
@@ -651,7 +780,7 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesSameDstZoneIsIdentity)
   auto const expected = micros_col{1894665600000000L, 1910304000000000L};
   auto const actual   = spark_rapids_jni::convert_orc_writer_reader_timezones(
     input,
-    /*base_offset_us=*/int64_t{0},
+    /*writer_2015_year_base_offset_us=*/int64_t{0},
     spark_rapids_jni::orc_tz_side{nullptr, 0, 0, rule},
     spark_rapids_jni::orc_tz_side{nullptr, 0, 0, rule},
     cudf::get_default_stream(),

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -342,6 +342,7 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesSubMillisBeforeGap)
     ts_col,
     nullptr,
     0,
+    /*writer_2015_year_base_offset_us=*/0,
     &reader_tv,
     7200000,
     cudf::get_default_stream(),

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -502,7 +502,7 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesEpochBorrowColumnShapes)
   {
     auto const source   = micros_col{{0L, 21'087'883'873L, 9'001'000L}, {false, true, true}};
     auto const input    = cudf::slice(source, {1, 3})[0];
-    auto const expected = micros_col{-7'713'116'127L, -28'791'999'000L};
+    auto const expected = micros_col{{-7'713'116'127L, -28'791'999'000L}, {true, true}};
     auto const actual   = convert(input);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
   }

--- a/src/main/cpp/tests/timezones.cpp
+++ b/src/main/cpp/tests/timezones.cpp
@@ -22,6 +22,7 @@
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/copying.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/wrappers/timestamps.hpp>
@@ -468,6 +469,43 @@ TEST_F(TimeZoneTest, ConvertOrcTimezonesCorrectsIgnoredWriterTimezoneEpochBorrow
     cudf::get_current_device_resource_ref());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+}
+
+TEST_F(TimeZoneTest, ConvertOrcTimezonesEpochBorrowColumnShapes)
+{
+  spark_rapids_jni::dst_rule no_dst{};
+  no_dst.has_dst     = 0;
+  auto const convert = [&](cudf::column_view const& input) {
+    return spark_rapids_jni::convert_orc_writer_reader_timezones(
+      input,
+      /*writer_2015_year_base_offset_us=*/int64_t{28'800'000'000},
+      spark_rapids_jni::orc_tz_side{nullptr, 28'800'000, 28'800'000, no_dst},
+      spark_rapids_jni::orc_tz_side{nullptr, 28'800'000, 28'800'000, no_dst},
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref());
+  };
+
+  {
+    auto const input    = micros_col{};
+    auto const expected = micros_col{};
+    auto const actual   = convert(input);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+  }
+
+  {
+    auto const input    = micros_col{{21'087'883'873L, 0L, 9'001'000L}, {true, false, true}};
+    auto const expected = micros_col{{-7'713'116'127L, 0L, -28'791'999'000L}, {true, false, true}};
+    auto const actual   = convert(input);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+  }
+
+  {
+    auto const source   = micros_col{{0L, 21'087'883'873L, 9'001'000L}, {false, true, true}};
+    auto const input    = cudf::slice(source, {1, 3})[0];
+    auto const expected = micros_col{-7'713'116'127L, -28'791'999'000L};
+    auto const actual   = convert(input);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *actual);
+  }
 }
 
 TEST_F(TimeZoneTest, ConvertOrcTimezonesCorrectsIgnoredWriterTimezoneEpochBorrowWithDstRule)

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -35,10 +35,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.concurrent.Executors;
 import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Gpu timezone utility.
@@ -517,6 +518,19 @@ public class GpuTimeZoneDB {
     return !zoneId.getRules().getTransitionRules().isEmpty();
   }
 
+  /**
+   * ORC stores timestamp seconds as a diff from 2015-01-01 00:00:00 in the writer timezone.
+   * Use the writer offset at that base timestamp so native code can reconstruct the same
+   * timestamp frame before applying ORC's negative nanos borrow and timezone conversion.
+   */
+  private static int getOrc2015YearBaseOffsetMillis(String timezoneId, OrcTimezoneInfo info) {
+    if (info.transitions == null) {
+      return info.rawOffset;
+    }
+    TimeZone tz = TimeZone.getTimeZone(getZoneId(timezoneId).getId());
+    return tz.getOffset(OrcTimezoneInfo.utcMillisForDate(2015, 1, 1));
+  }
+
   private static ColumnVector getTransitionsForUtilTZ(OrcTimezoneInfo info) {
     try (HostColumnVector hcv = HostColumnVector.fromLongs(info.transitions)) {
       return hcv.copyToDevice();
@@ -562,12 +576,14 @@ public class GpuTimeZoneDB {
 
   /**
    * Convert timestamps between writer/reader timezones for ORC reading.
-   * Similar to `org.apache.orc.impl.SerializationUtils.convertBetweenTimezones`.
-   * `SerializationUtils.convertBetweenTimezones` gets offset between timezones.
-   * This function does the same thing and then apply the offset to get the
-   * final timestamps.
+   * Similar to Apache ORC, this first reconstructs the timestamp from ORC's
+   * writer-timezone 2015 base instant and applies the negative nanos borrow,
+   * then applies the offset from
+   * `org.apache.orc.impl.SerializationUtils.convertBetweenTimezones`.
    * For more details, refer to:
-   * <a href="https://github.com/apache/orc/blob/rel/release-1.9.1/java/core/src/java/org/apache/orc/impl/SerializationUtils.java#L1440">link</a>
+   * <a href="https://github.com/apache/orc/blob/rel/release-1.9.1/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java#L1284-L1286">borrow logic</a>
+   * and
+   * <a href="https://github.com/apache/orc/blob/rel/release-1.9.1/java/core/src/java/org/apache/orc/impl/SerializationUtils.java#L1440">timezone conversion logic</a>
    *
    * @param input          input timestamp column in microseconds.
    * @param writerTimezone writer timezone, it's from ORC stripe metadata.
@@ -591,11 +607,17 @@ public class GpuTimeZoneDB {
     try (Table writerTzInfoTable = getTableForUtilTZ(writerTzInfo);
         Table readerTzInfoTable = getTableForUtilTZ(readerTzInfo)) {
 
-      // convert between timezones
+      // ORC first reconstructs the timestamp using the writer timezone's 2015 base instant,
+      // including any DST offset in effect at that instant, then applies the negative nanos borrow.
+      // The native path applies this adjustment before matching ORC's writer/reader timezone
+      // conversion.
+      long writer2015YearBaseOffsetUs = TimeUnit.MILLISECONDS.toMicros(
+          getOrc2015YearBaseOffsetMillis(writerTimezone, writerTzInfo));
       return new ColumnVector(convertOrcTimezones(
           input.getNativeView(),
           writerTzInfoTable != null ? writerTzInfoTable.getNativeView() : 0L,
           writerTzInfo.rawOffset,
+          writer2015YearBaseOffsetUs,
           readerTzInfoTable != null ? readerTzInfoTable.getNativeView() : 0L,
           readerTzInfo.rawOffset));
     } catch (Exception e) {
@@ -615,6 +637,7 @@ public class GpuTimeZoneDB {
       long input,
       long writerTzInfoTable,
       int writerTzRawOffset,
+      long writer2015YearBaseOffsetUs,
       long readerTzInfoTable,
       int readerTzRawOffset);
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -25,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +39,44 @@ import java.util.concurrent.TimeUnit;
 public class GpuTimeZoneDBTest {
 
   private static final long microsPerMillis = TimeUnit.MILLISECONDS.toMicros(1);
+  private static final long MICROS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
+
+  private static TimeZone getTimeZoneForOrc(String timezoneId) {
+    return TimeZone.getTimeZone(GpuTimeZoneDB.getZoneId(timezoneId).getId());
+  }
+
+  private static long orc2015YearBaseOffsetUs(String timezoneId) {
+    ZoneId zoneId = GpuTimeZoneDB.getZoneId(timezoneId);
+    if (zoneId.getRules().isFixedOffset()) {
+      int offsetSeconds = zoneId.getRules().getOffset(Instant.EPOCH).getTotalSeconds();
+      return TimeUnit.SECONDS.toMicros(offsetSeconds);
+    }
+    TimeZone tz = TimeZone.getTimeZone(zoneId.getId());
+    return TimeUnit.MILLISECONDS.toMicros(
+        tz.getOffset(OrcTimezoneInfo.utcMillisForDate(2015, 1, 1)));
+  }
+
+  private static long applyOrcBaseOffsetOnCPU(long decodedUs, long baseOffsetUs) {
+    if (baseOffsetUs == 0) {
+      return decodedUs;
+    }
+
+    // ORC timezone base offsets are second-aligned. For an arbitrary microsecond offset, the
+    // original nanos field cannot be reconstructed reliably, so retain the plain offset behavior.
+    if (baseOffsetUs % MICROS_PER_SECOND != 0) {
+      return decodedUs - baseOffsetUs;
+    }
+
+    long fractionalUs = Math.floorMod(decodedUs, MICROS_PER_SECOND);
+    boolean hasBorrowableFraction = fractionalUs >= microsPerMillis;
+    boolean cudfAppliedBorrow = decodedUs < 0 && hasBorrowableFraction;
+
+    long unborrowedUs = decodedUs + (cudfAppliedBorrow ? MICROS_PER_SECOND : 0L);
+    long adjustedUnborrowedUs = unborrowedUs - baseOffsetUs;
+    boolean apacheAppliesBorrow = adjustedUnborrowedUs < 0 && hasBorrowableFraction;
+
+    return adjustedUnborrowedUs - (apacheAppliesBorrow ? MICROS_PER_SECOND : 0L);
+  }
 
   /**
    * Java implementation of timezone conversion to compare against the GPU
@@ -49,21 +89,24 @@ public class GpuTimeZoneDBTest {
       String writeTzId,
       String readerTzId) {
     long[] results = new long[microseconds.length];
-    TimeZone writeTz = TimeZone.getTimeZone(writeTzId);
-    TimeZone readerTz = TimeZone.getTimeZone(readerTzId);
+    TimeZone writeTz = getTimeZoneForOrc(writeTzId);
+    TimeZone readerTz = getTimeZoneForOrc(readerTzId);
+    long writer2015YearBaseOffsetUs = orc2015YearBaseOffsetUs(writeTzId);
     for (int i = 0; i < microseconds.length; ++i) {
-      // Floor-divide µs to ms (and floor-mod for the sub-ms remainder) so reconstruction round-trips
-      // for negative timestamps with a non-zero sub-millisecond component. Truncation toward zero
-      // would round such an input up by one ms; at a DST gap transition that lands on the
-      // post-transition offset, producing a 1-hour off-by-one. Must match the GPU kernel's
+      long adjustedUs = applyOrcBaseOffsetOnCPU(microseconds[i], writer2015YearBaseOffsetUs);
+      // Floor-divide µs to ms (and floor-mod for the sub-ms remainder) so reconstruction
+      // round-trips for negative timestamps with a non-zero sub-millisecond component. Truncation
+      // toward zero would round such an input up by one ms; at a DST gap transition that lands on
+      // the post-transition offset, producing a 1-hour off-by-one. Must match the GPU kernel's
       // floor-divide in convert_timestamp_between_timezones.
-      long millis = Math.floorDiv(microseconds[i], microsPerMillis);
+      long millis = Math.floorDiv(adjustedUs, microsPerMillis);
       long writerOffset = writeTz.getOffset(millis);
       long readerOffset = readerTz.getOffset(millis);
       long adjustedMillis = millis + writerOffset - readerOffset;
       long adjustedReader = readerTz.getOffset(adjustedMillis);
       long finalDiffs = writerOffset - adjustedReader;
-      results[i] = (millis + finalDiffs) * microsPerMillis + Math.floorMod(microseconds[i], microsPerMillis);
+      results[i] =
+          (millis + finalDiffs) * microsPerMillis + Math.floorMod(adjustedUs, microsPerMillis);
     }
     return ColumnVector.timestampMicroSecondsFromLongs(results);
   }
@@ -103,6 +146,21 @@ public class GpuTimeZoneDBTest {
   }
 
   @Test
+  void testConvertOrcTimezonesCorrectsIgnoredWriterTimezoneEpochBorrow() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    try (ColumnVector input =
+            ColumnVector.timestampMicroSecondsFromLongs(new long[] {21_087_883_873L});
+        ColumnVector expected =
+            ColumnVector.timestampMicroSecondsFromLongs(new long[] {-7_713_116_127L});
+        ColumnVector actual =
+            GpuTimeZoneDB.convertOrcTimezones(input, "Asia/Shanghai", "Asia/Shanghai")) {
+      assertColumnsAreEqual(expected, actual);
+    }
+  }
+
+  @Test
   void testConvertOrcTimezones() {
     GpuTimeZoneDB.cacheDatabase();
     GpuTimeZoneDB.verifyDatabaseCached();
@@ -118,6 +176,7 @@ public class GpuTimeZoneDBTest {
 
     List<String> timezones = Arrays.asList(
         "America/Los_Angeles",
+        "America/Cancun",
         "Asia/Shanghai",
         "Antarctica/DumontDUrville",
         "Etc/GMT-12",

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -25,10 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
@@ -46,12 +44,11 @@ public class GpuTimeZoneDBTest {
   }
 
   private static long orc2015YearBaseOffsetUs(String timezoneId) {
-    ZoneId zoneId = GpuTimeZoneDB.getZoneId(timezoneId);
-    if (zoneId.getRules().isFixedOffset()) {
-      int offsetSeconds = zoneId.getRules().getOffset(Instant.EPOCH).getTotalSeconds();
-      return TimeUnit.SECONDS.toMicros(offsetSeconds);
+    OrcTimezoneInfo info = OrcTimezoneInfo.get(timezoneId);
+    if (info.transitions == null) {
+      return TimeUnit.MILLISECONDS.toMicros(info.rawOffset);
     }
-    TimeZone tz = TimeZone.getTimeZone(zoneId.getId());
+    TimeZone tz = getTimeZoneForOrc(timezoneId);
     return TimeUnit.MILLISECONDS.toMicros(
         tz.getOffset(OrcTimezoneInfo.utcMillisForDate(2015, 1, 1)));
   }


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/cudf-spark/issues/13437
Related to rapidsai/cudf#21993.

### Problem to fix
CPU and GPU have 1 second diff when reading timestamps near epoch(1970-01-01 00:00:00)  when writer is non-UTC timezone(e.g.: Shanghai). 

### Root cause
In order to follow Java behaviors, cudf-spark-jni has own impementations do the timezone conversions,  jni is using  `ignoreTimezoneInStripeFooter=true` to read ORC, all the timestamps are recognized as in UTC timezone, although they are in Shanghai timezone. So JNI must adjust for some extra logic in ORC: borrow logic.

#### ORC borrow logic, aka **non-negative** nanos
ORC stores timestamps in seconds plus a **non-negative** nanos field.  So for a negative nano value, MU
ST borrow a second and make nano positive. E.g.:  value -1ns, the second part is 0, the nano part is -1. After apply non-negative nano, the second part is -1, and the nano part is 999,999,999ns.

When writer timezone is Shanghai,  for the timestamps near epoch, using UTC timezone get positive value, while using Shanghai get negative value, becuase of time diff between UTC and Shanghai is 8 hours.

[borrow logic link](https://github.com/apache/orc/blob/rel/release-1.9.1/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java#L1284-L1286)

JNI only implements `SerializationUtils.convertBetweenTimezones`, lack the borrow logic.

Please refer to the following detail example
<details>
<summary>a detail example</summary>

  Assume the ORC timestamp stores:

  ORC stored seconds = -1'420'049'313
  ORC stored nanos   =    883'873'000 ns
                      =    883'873 us

  ORC timestamp semantics are:

  timestamp = ORC base timestamp + stored seconds + stored nanos

  The key point is: the ORC base timestamp is 2015-01-01 00:00:00 in the writer timezone.

  Here the writer timezone is Asia/Shanghai.

  ### 1. Two ORC base timestamps

  If cuDF ignores the stripe footer timezone, it decodes using the UTC ORC base:

  UTC ORC base:
  2015-01-01 00:00:00 UTC
  = 1'420'070'400'000'000 us

  But Apache ORC / Spark semantics use the writer timezone ORC base:

  Asia/Shanghai ORC base:
  2015-01-01 00:00:00 Asia/Shanghai
  = 2014-12-31 16:00:00 UTC
  = 1'420'041'600'000'000 us

  The difference is:

  base_offset_us
  = UTC ORC base - Shanghai ORC base
  = 28'800'000'000 us
  = 8 hours

  ### 2. cuDF decodes with the UTC ORC base

  decoded_us
  = UTC_ORC_BASE_US + stored_seconds * 1'000'000 + stored_nanos_us

  = 1'420'070'400'000'000
    + (-1'420'049'313 * 1'000'000)
    + 883'873

  = 21'087'883'873 us

  This is positive, so cuDF does not apply the negative timestamp borrow.

  ### 3. Correct semantics switch back to the writer timezone ORC base

  Equivalent correction:

  plain_adjusted_us = decoded_us - base_offset_us

  = 21'087'883'873 - 28'800'000'000
  = -7'712'116'127 us

  This value is now negative.

  ### 4. Recompute the Apache ORC borrow

  The fractional part is:

  floor_mod(-7'712'116'127, 1'000'000)
  = 883'873 us

  Because:

  883'873 us >= 1'000 us

  Apache ORC applies the 1-second negative timestamp borrow:

  result_us
  = -7'712'116'127 - 1'000'000
  = -7'713'116'127 us

  ### 5. Wrong vs correct result

  plain offset result        = -7'712'116'127
  Apache-compatible result   = -7'713'116'127
  difference                 = -1'000'000 us
                             = -1 second

  The bug is that cuDF made the borrow decision in the UTC ORC base frame. After applying the writer timezone base offset, the value is in the writer ORC base frame and the borrow decision changes.


</details>


### Fix
Implement [borrow logic link](https://github.com/apache/orc/blob/rel/release-1.9.1/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java#L1284-L1286)

