### PR TITLE
Fix includes of cudf-spark generate_input.hpp

### DIFF
--- a/src/main/cpp/benchmarks/bloom_filter.cu
+++ b/src/main/cpp/benchmarks/bloom_filter.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/bloom_filter.cu
+++ b/src/main/cpp/benchmarks/bloom_filter.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <benchmarks/common/generate_input.hpp>
+#include "common/generate_input.hpp"
 
 #include <cudf_test/column_utilities.hpp>
 

--- a/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
+++ b/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
+++ b/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
+++ b/src/main/cpp/benchmarks/cast_long_to_binary_string.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <benchmarks/common/generate_input.hpp>
+#include "common/generate_input.hpp"
 
 #include <cudf_test/column_utilities.hpp>
 

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/cast_string_to_float.cpp
+++ b/src/main/cpp/benchmarks/cast_string_to_float.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <benchmarks/common/generate_input.hpp>
+#include "common/generate_input.hpp"
 
 #include <cudf_test/column_wrapper.hpp>
 

--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -1117,7 +1117,7 @@ std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
 
 std::unique_ptr<cudf::column> create_ascii_string_column(data_profile const& profile,
                                                          cudf::size_type num_rows,
-                                                         unsigned seed = 1)
+                                                         unsigned seed)
 {
   auto engine = deterministic_engine(seed);
   return create_random_utf8_string_column<string_encoding::ASCII>(profile, engine, num_rows);

--- a/src/main/cpp/benchmarks/common/generate_input.cu
+++ b/src/main/cpp/benchmarks/common/generate_input.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,76 +17,132 @@
 #include "generate_input.hpp"
 #include "random_distribution_factory.cuh"
 
+#include <cudf_test/column_wrapper.hpp>
+
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/filling.hpp>
+#include <cudf/lists/combine.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/strings/combine.hpp>
+#include <cudf/strings/convert/convert_integers.hpp>
+#include <cudf/strings/detail/strings_children.cuh>
 #include <cudf/table/table.hpp>
+#include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
 #include <thrust/binary_search.h>
-#include <thrust/device_ptr.h>
+#include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 #include <thrust/gather.h>
-#include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/random/linear_congruential_engine.h>
 #include <thrust/random/uniform_int_distribution.h>
 #include <thrust/random/uniform_real_distribution.h>
 #include <thrust/scan.h>
+#include <thrust/shuffle.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <random>
 #include <utility>
 #include <vector>
 
+namespace {
 /**
  * @brief Mersenne Twister pseudo-random engine.
  */
 auto deterministic_engine(unsigned seed) { return thrust::minstd_rand{seed}; }
 
+// standard deviation such that most samples fall within the given range
+template <typename T>
+constexpr double std_dev_from_range(T lower_bound, T upper_bound)
+{
+  // 99.7% samples are within 3 standard deviations of the mean
+  constexpr double k    = 6.0;
+  auto const range_size = std::abs(static_cast<double>(upper_bound) - lower_bound);
+  return range_size / k;
+}
+
 /**
  *  Computes the mean value for a distribution of given type and value bounds.
  */
 template <typename T>
-T get_distribution_mean(distribution_params<T> const& dist)
+double get_distribution_mean(distribution_params<T> const& dist)
 {
   switch (dist.id) {
     case distribution_id::NORMAL:
     case distribution_id::UNIFORM: return (dist.lower_bound / 2.) + (dist.upper_bound / 2.);
     case distribution_id::GEOMETRIC: {
-      auto const range_size = dist.lower_bound < dist.upper_bound
-                                ? dist.upper_bound - dist.lower_bound
-                                : dist.lower_bound - dist.upper_bound;
-      auto const p          = geometric_dist_p(range_size);
+      // Geometric distribution is approximated by a half-normal distribution
+      // Doubling the standard deviation because the dist range only includes half of the (unfolded)
+      // normal distribution
+      auto const gauss_std_dev   = std_dev_from_range(dist.lower_bound, dist.upper_bound) * 2;
+      auto const half_gauss_mean = gauss_std_dev * sqrt(2. / M_PI);
       if (dist.lower_bound < dist.upper_bound)
-        return dist.lower_bound + (1. / p);
+        return dist.lower_bound + half_gauss_mean;
       else
-        return dist.lower_bound - (1. / p);
+        return dist.lower_bound - half_gauss_mean;
     }
     default: CUDF_FAIL("Unsupported distribution type.");
   }
+}
+
+/**
+ * @brief Calculates the number of direct parents needed to generate a struct column hierarchy with
+ * lowest maximum number of children in any nested column.
+ *
+ * Used to generate an "evenly distributed" struct column hierarchy with the given number of leaf
+ * columns and nesting levels. The column tree is considered evenly distributed if all columns have
+ * nearly the same number of child columns (difference not larger than one).
+ */
+int num_direct_parents(int num_lvls, int num_leaf_columns)
+{
+  // Estimated average number of children in the hierarchy;
+  auto const num_children_avg = std::pow(num_leaf_columns, 1. / num_lvls);
+  // Minimum number of children columns for any column in the hierarchy
+  int const num_children_min = std::floor(num_children_avg);
+  // Maximum number of children columns for any column in the hierarchy
+  int const num_children_max = num_children_min + 1;
+
+  // Minimum number of columns needed so that their number of children does not exceed the maximum
+  int const min_for_current_nesting =
+    std::ceil(static_cast<double>(num_leaf_columns) / num_children_max);
+  // Minimum number of columns needed so that columns at the higher levels have at least the minimum
+  // number of children
+  int const min_for_upper_nesting = std::pow(num_children_min, num_lvls - 1);
+  // Both conditions need to be satisfied
+  return std::max(min_for_current_nesting, min_for_upper_nesting);
+}
+
+// Size of the null mask for each row, in bytes
+[[nodiscard]] double row_null_mask_size(data_profile const& profile)
+{
+  return profile.get_null_probability().has_value() ? 1. / 8 : 0.;
 }
 
 /**
@@ -96,60 +152,95 @@ T get_distribution_mean(distribution_params<T> const& dist)
  * the element size of non-fixed-width columns. For lists and structs, `avg_element_size` is called
  * recursively to determine the size of nested columns.
  */
-size_t avg_element_size(data_profile const& profile, cudf::data_type dtype);
+double avg_element_size(data_profile const& profile, cudf::data_type dtype);
 
 // Utilities to determine the mean size of an element, given the data profile
 template <typename T, CUDF_ENABLE_IF(cudf::is_fixed_width<T>())>
-size_t non_fixed_width_size(data_profile const& profile)
+double non_fixed_width_size(data_profile const& profile)
 {
   CUDF_FAIL("Should not be called, use `size_of` for this type instead");
 }
 
 template <typename T, CUDF_ENABLE_IF(!cudf::is_fixed_width<T>())>
-size_t non_fixed_width_size(data_profile const& profile)
+double non_fixed_width_size(data_profile const& profile)
 {
   CUDF_FAIL("not implemented!");
 }
 
 template <>
-size_t non_fixed_width_size<cudf::string_view>(data_profile const& profile)
+double non_fixed_width_size<cudf::string_view>(data_profile const& profile)
 {
   auto const dist = profile.get_distribution_params<cudf::string_view>().length_params;
-  return get_distribution_mean(dist);
+  return get_distribution_mean(dist) * profile.get_valid_probability() + sizeof(cudf::size_type) +
+         row_null_mask_size(profile);
 }
 
-template <>
-size_t non_fixed_width_size<cudf::list_view>(data_profile const& profile)
+double geometric_sum(size_t n, double p)
 {
-  auto const dist_params       = profile.get_distribution_params<cudf::list_view>();
-  auto const single_level_mean = get_distribution_mean(dist_params.length_params);
-  auto const element_size = avg_element_size(profile, cudf::data_type{dist_params.element_type});
-  return element_size * pow(single_level_mean, dist_params.max_depth);
+  if (p == 1) { return n; }
+  return (1 - std::pow(p, n)) / (1 - p);
 }
 
 template <>
-size_t non_fixed_width_size<cudf::struct_view>(data_profile const& profile)
+double non_fixed_width_size<cudf::list_view>(data_profile const& profile)
+{
+  auto const dist_params = profile.get_distribution_params<cudf::list_view>();
+  auto const single_level_mean =
+    get_distribution_mean(dist_params.length_params) * profile.get_valid_probability();
+
+  // Leaf column size
+  auto const element_size  = avg_element_size(profile, cudf::data_type{dist_params.element_type});
+  auto const element_count = std::pow(single_level_mean, dist_params.max_depth);
+
+  auto const offset_size = avg_element_size(profile, cudf::data_type{cudf::type_id::INT32});
+  // Each nesting level includes offsets, this is the sum of all levels
+  auto const total_offset_count = geometric_sum(dist_params.max_depth, single_level_mean);
+
+  return element_size * element_count + offset_size * total_offset_count;
+}
+
+[[nodiscard]] cudf::size_type num_struct_columns(data_profile const& profile)
 {
   auto const dist_params = profile.get_distribution_params<cudf::struct_view>();
-  return std::accumulate(dist_params.leaf_types.cbegin(),
-                         dist_params.leaf_types.cend(),
-                         0ul,
-                         [&](auto sum, auto type_id) {
-                           return sum + avg_element_size(profile, cudf::data_type{type_id});
-                         });
+
+  cudf::size_type children_count     = dist_params.leaf_types.size();
+  cudf::size_type total_parent_count = 0;
+  for (cudf::size_type lvl = dist_params.max_depth; lvl > 0; --lvl) {
+    children_count = num_direct_parents(lvl, children_count);
+    total_parent_count += children_count;
+  }
+  return total_parent_count;
+}
+
+template <>
+double non_fixed_width_size<cudf::struct_view>(data_profile const& profile)
+{
+  auto const dist_params = profile.get_distribution_params<cudf::struct_view>();
+  auto const total_children_size =
+    std::accumulate(dist_params.leaf_types.cbegin(),
+                    dist_params.leaf_types.cend(),
+                    0ul,
+                    [&](auto sum, auto type_id) {
+                      return sum + avg_element_size(profile, cudf::data_type{type_id});
+                    });
+
+  // struct columns have a null mask for each row
+  auto const structs_null_mask_size = num_struct_columns(profile) * row_null_mask_size(profile);
+
+  return total_children_size + structs_null_mask_size;
 }
 
 struct non_fixed_width_size_fn {
   template <typename T>
-  size_t operator()(data_profile const& profile)
+  double operator()(data_profile const& profile)
   {
     return non_fixed_width_size<T>(profile);
   }
 };
 
-size_t avg_element_size(data_profile const& profile, cudf::data_type dtype)
+double avg_element_size(data_profile const& profile, cudf::data_type dtype)
 {
-  if (cudf::is_fixed_width(dtype)) { return cudf::size_of(dtype); }
+  if (cudf::is_fixed_width(dtype)) { return cudf::size_of(dtype) + row_null_mask_size(profile); }
   return cudf::type_dispatcher(dtype, non_fixed_width_size_fn{}, profile);
 }
 
@@ -209,7 +300,8 @@ struct random_value_fn<T, std::enable_if_t<cudf::is_chrono<T>()>> {
       // Don't need a random seconds generator for sub-second intervals
       seconds_gen = [range_s](thrust::minstd_rand&, size_t size) {
         rmm::device_uvector<int64_t> result(size, cudf::get_default_stream());
-        thrust::fill(thrust::device, result.begin(), result.end(), range_s.second.count());
+        thrust::uninitialized_fill(
+          thrust::device, result.begin(), result.end(), range_s.second.count());
         return result;
       };
 
@@ -233,12 +325,12 @@ struct random_value_fn<T, std::enable_if_t<cudf::is_chrono<T>()>> {
       sec.end(),
       ns.begin(),
       result.begin(),
-      [] __device__(int64_t sec_value, int64_t nanoseconds_value) {
+      cuda::proclaim_return_type<T>([] __device__(int64_t sec_value, int64_t nanoseconds_value) {
         auto const timestamp_ns =
           cudf::duration_s{sec_value} + cudf::duration_ns{nanoseconds_value};
         // Return value in the type's precision
         return T(cuda::std::chrono::duration_cast<typename T::duration>(timestamp_ns));
-      });
+      }));
     return result;
   }
 };
@@ -248,40 +340,34 @@ struct random_value_fn<T, std::enable_if_t<cudf::is_chrono<T>()>> {
  */
 template <typename T>
 struct random_value_fn<T, std::enable_if_t<cudf::is_fixed_point<T>()>> {
-  using rep = typename T::rep;
-  rep const lower_bound;
-  rep const upper_bound;
-  distribution_fn<rep> dist;
+  using DeviceType = cudf::device_storage_type_t<T>;
+  DeviceType const lower_bound;
+  DeviceType const upper_bound;
+  distribution_fn<DeviceType> dist;
   std::optional<numeric::scale_type> scale;
 
-  random_value_fn(distribution_params<rep> const& desc)
+  random_value_fn(distribution_params<T> const& desc)
     : lower_bound{desc.lower_bound},
       upper_bound{desc.upper_bound},
-      dist{make_distribution<rep>(desc.id, desc.lower_bound, desc.upper_bound)}
+      dist{make_distribution<DeviceType>(desc.id, lower_bound, upper_bound)},
+      scale{desc.scale}
   {
   }
 
-  rmm::device_uvector<T> operator()(thrust::minstd_rand& engine, unsigned size)
+  [[nodiscard]] numeric::scale_type get_scale(thrust::minstd_rand& engine)
   {
     if (not scale.has_value()) {
-      int const max_scale = std::numeric_limits<rep>::digits10;
+      constexpr int max_scale = std::numeric_limits<DeviceType>::digits10;
       std::uniform_int_distribution<int> scale_dist{-max_scale, max_scale};
       std::mt19937 engine_scale(engine());
       scale = numeric::scale_type{scale_dist(engine_scale)};
     }
-    auto const ints = dist(engine, size);
-    rmm::device_uvector<T> result(size, cudf::get_default_stream());
-    // Clamp the generated random value to the specified range
-    thrust::transform(thrust::device,
-                      ints.begin(),
-                      ints.end(),
-                      result.begin(),
-                      [scale       = *(this->scale),
-                       upper_bound = this->upper_bound,
-                       lower_bound = this->lower_bound] __device__(auto int_value) {
-                        return T{cuda::std::clamp(int_value, lower_bound, upper_bound), scale};
-                      });
-    return result;
+    return scale.value_or(numeric::scale_type{0});
+  }
+
+  rmm::device_uvector<DeviceType> operator()(thrust::minstd_rand& engine, unsigned size)
+  {
+    return dist(engine, size);
   }
 };
 
@@ -325,13 +411,6 @@ struct random_value_fn<T, typename std::enable_if_t<std::is_same_v<T, bool>>> {
   auto operator()(thrust::minstd_rand& engine, unsigned size) { return dist(engine, size); }
 };
 
-auto create_run_length_dist(cudf::size_type avg_run_len)
-{
-  // Distribution with low probability of generating 0-1 even with a low `avg_run_len` value
-  static constexpr float alpha = 4.f;
-  return std::gamma_distribution<float>{alpha, avg_run_len / alpha};
-}
-
 /**
  * @brief Generate indices within range [0 , cardinality) repeating with average run length
  * `avg_run_len`
@@ -359,7 +438,7 @@ rmm::device_uvector<cudf::size_type> sample_indices_with_run_length(cudf::size_t
     auto const samples_indices = sample_dist(engine, approx_run_len + 1);
     // This is gather.
     auto avg_repeated_sample_indices_iterator = thrust::make_transform_iterator(
-      thrust::make_counting_iterator(0),
+      cuda::counting_iterator<cudf::size_type>{0},
       cuda::proclaim_return_type<cudf::size_type>(
         [rb              = run_lens.begin(),
          re              = run_lens.end(),
@@ -380,6 +459,138 @@ rmm::device_uvector<cudf::size_type> sample_indices_with_run_length(cudf::size_t
   }
 }
 
+struct valid_or_zero {
+  template <typename T>
+  __device__ T operator()(cuda::std::tuple<T, bool> len_valid) const
+  {
+    return cuda::std::get<1>(len_valid) ? cuda::std::get<0>(len_valid) : T{0};
+  }
+};
+
+enum class string_encoding {
+  ASCII,
+  UTF8,
+};
+
+template <string_encoding Encoding = string_encoding::UTF8>
+struct string_generator {
+  char* chars;
+  thrust::minstd_rand engine;
+  thrust::uniform_int_distribution<unsigned char> char_dist;
+  string_generator(char* c, thrust::minstd_rand& engine)
+    : chars(c), engine(engine), char_dist(32, Encoding == string_encoding::ASCII ? 126 : 137)
+  // ~90% ASCII, ~10% UTF-8.
+  // ~80% not-space, ~20% space.
+  // range 32-127 is ASCII; 127-136 will be multi-byte UTF-8
+  {
+  }
+  __device__ void operator()(cuda::std::tuple<int64_t, int64_t> str_begin_end)
+  {
+    auto begin = cuda::std::get<0>(str_begin_end);
+    auto end   = cuda::std::get<1>(str_begin_end);
+    engine.discard(begin);
+    for (auto i = begin; i < end; ++i) {
+      auto ch = char_dist(engine);
+      if constexpr (Encoding == string_encoding::UTF8) {
+        if (i == end - 1 && ch >= '\x7F') ch = ' ';  // last element ASCII only.
+        if (ch >= '\x7F') {                          // x7F is at the top edge of ASCII
+          chars[i++] = '\xC4';                       // these characters are assigned two bytes
+          ch         = (ch >> 2) | 0x80;
+        }
+      }
+      chars[i] = static_cast<char>(ch);
+    }
+  }
+};
+
+/**
+ * @brief Create a UTF-8 string column with the average length.
+ *
+ */
+template <string_encoding Encoding = string_encoding::UTF8>
+std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile const& profile,
+                                                               thrust::minstd_rand& engine,
+                                                               cudf::size_type num_rows)
+{
+  auto len_dist =
+    random_value_fn<uint32_t>{profile.get_distribution_params<cudf::string_view>().length_params};
+  auto valid_dist = random_value_fn<bool>(
+    distribution_params<bool>{1. - profile.get_null_probability().value_or(0)});
+  auto lengths   = len_dist(engine, num_rows + 1);
+  auto null_mask = valid_dist(engine, num_rows + 1);
+  auto stream    = cudf::get_default_stream();
+  auto mr        = cudf::get_current_device_resource_ref();
+
+  thrust::transform_if(
+    thrust::device,
+    lengths.begin(),
+    lengths.end(),
+    null_mask.begin(),
+    lengths.begin(),
+    cuda::proclaim_return_type<cudf::size_type>([] __device__(auto) { return 0; }),
+    cuda::std::logical_not<bool>{});
+  auto valid_lengths = thrust::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::std::make_tuple(lengths.begin(), null_mask.begin())),
+    valid_or_zero{});
+
+  // offsets are created as INT32 or INT64 as appropriate
+  auto [offsets, chars_length] = cudf::strings::detail::make_offsets_child_column(
+    valid_lengths, valid_lengths + num_rows, stream, mr);
+  // use the offsetalator to normalize the offset values for use by the string_generator
+  auto offsets_itr = cudf::detail::offsetalator_factory::make_input_iterator(offsets->view());
+  rmm::device_uvector<char> chars(chars_length, cudf::get_default_stream());
+  thrust::for_each_n(thrust::device,
+                     thrust::make_zip_iterator(cuda::std::make_tuple(offsets_itr, offsets_itr + 1)),
+                     num_rows,
+                     string_generator<Encoding>{chars.data(), engine});
+
+  auto [result_bitmask, null_count] =
+    profile.get_null_probability().has_value()
+      ? cudf::bools_to_mask(cudf::device_span<bool const>(null_mask), stream)
+      : std::pair{std::make_unique<rmm::device_buffer>(), 0};
+
+  return cudf::make_strings_column(num_rows,
+                                   std::move(offsets),
+                                   chars.release(),
+                                   null_count,
+                                   std::move(*result_bitmask.release()));
+}
+
+// Forward declarations for create_rand_col_fn
+template <typename T>
+std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
+                                                   thrust::minstd_rand& engine,
+                                                   cudf::size_type num_rows);
+
+template <typename T>
+  requires(cudf::is_numeric_not_bool<T>())
+std::unique_ptr<cudf::column> create_distinct_rows_column(data_profile const& profile,
+                                                          thrust::minstd_rand& engine,
+                                                          cudf::size_type num_rows);
+
+template <typename T>
+  requires(!cudf::is_numeric_not_bool<T>())
+std::unique_ptr<cudf::column> create_distinct_rows_column(data_profile const& profile,
+                                                          thrust::minstd_rand& engine,
+                                                          cudf::size_type num_rows);
+
+/**
+ * @brief Functor to dispatch create_random_column calls.
+ */
+struct create_rand_col_fn {
+ public:
+  template <typename T>
+  std::unique_ptr<cudf::column> operator()(data_profile const& profile,
+                                           thrust::minstd_rand& engine,
+                                           cudf::size_type num_rows)
+  {
+    if (profile.get_cardinality() >= num_rows) {
+      return create_distinct_rows_column<T>(profile, engine, num_rows);
+    }
+    return create_random_column<T>(profile, engine, num_rows);
+  }
+};
+
 /**
  * @brief Creates a column with random content of type @ref T.
  *
@@ -396,13 +607,21 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
                                                    cudf::size_type num_rows)
 {
   // Bernoulli distribution
-  auto valid_dist =
-    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+  auto valid_dist = random_value_fn<bool>(
+    distribution_params<bool>{1. - profile.get_null_probability().value_or(0)});
   auto value_dist = random_value_fn<T>{profile.get_distribution_params<T>()};
+
+  using DeviceType            = cudf::device_storage_type_t<T>;
+  cudf::data_type const dtype = [&]() {
+    if constexpr (cudf::is_fixed_point<T>())
+      return cudf::data_type{cudf::type_to_id<T>(), value_dist.get_scale(engine)};
+    else
+      return cudf::data_type{cudf::type_to_id<T>()};
+  }();
 
   // Distribution for picking elements from the array of samples
   auto const avg_run_len = profile.get_avg_run_length();
-  rmm::device_uvector<T> data(0, cudf::get_default_stream());
+  rmm::device_uvector<DeviceType> data(0, cudf::get_default_stream());
   rmm::device_uvector<bool> null_mask(0, cudf::get_default_stream());
 
   if (profile.get_cardinality() == 0 and avg_run_len == 1) {
@@ -414,11 +633,12 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
                                                                           : profile_cardinality;
     }();
     rmm::device_uvector<bool> samples_null_mask = valid_dist(engine, cardinality);
-    rmm::device_uvector<T> samples              = value_dist(engine, cardinality);
+    rmm::device_uvector<DeviceType> samples     = value_dist(engine, cardinality);
+
     // generate n samples and gather.
     auto const sample_indices =
       sample_indices_with_run_length(avg_run_len, cardinality, num_rows, engine);
-    data      = rmm::device_uvector<T>(num_rows, cudf::get_default_stream());
+    data      = rmm::device_uvector<DeviceType>(num_rows, cudf::get_default_stream());
     null_mask = rmm::device_uvector<bool>(num_rows, cudf::get_default_stream());
     thrust::gather(
       thrust::device, sample_indices.begin(), sample_indices.end(), samples.begin(), data.begin());
@@ -430,101 +650,12 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
   }
 
   auto [result_bitmask, null_count] =
-    cudf::detail::valid_if(null_mask.begin(),
-                           null_mask.end(),
-                           cuda::std::identity{},
-                           cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource_ref());
+    profile.get_null_probability().has_value()
+      ? cudf::bools_to_mask(cudf::device_span<bool const>(null_mask))
+      : std::pair{std::make_unique<rmm::device_buffer>(), 0};
 
   return std::make_unique<cudf::column>(
-    cudf::data_type{cudf::type_to_id<T>()},
-    num_rows,
-    data.release(),
-    profile.get_null_frequency().has_value() ? std::move(result_bitmask) : rmm::device_buffer{},
-    null_count);
-}
-
-struct valid_or_zero {
-  template <typename T>
-  __device__ T operator()(cuda::std::tuple<T, bool> len_valid) const
-  {
-    return cuda::std::get<1>(len_valid) ? cuda::std::get<0>(len_valid) : T{0};
-  }
-};
-
-struct string_generator {
-  char* chars;
-  thrust::minstd_rand engine;
-  thrust::uniform_int_distribution<unsigned char> char_dist;
-  string_generator(char* c, thrust::minstd_rand& engine)
-    : chars(c), engine(engine), char_dist(32, 137)
-  // ~90% ASCII, ~10% UTF-8.
-  // ~80% not-space, ~20% space.
-  // range 32-127 is ASCII; 127-136 will be multi-byte UTF-8
-  {
-  }
-  __device__ void operator()(cuda::std::tuple<cudf::size_type, cudf::size_type> str_begin_end)
-  {
-    auto begin = cuda::std::get<0>(str_begin_end);
-    auto end   = cuda::std::get<1>(str_begin_end);
-    engine.discard(begin);
-    for (auto i = begin; i < end; ++i) {
-      auto ch = char_dist(engine);
-      if (i == end - 1 && ch >= '\x7F') ch = ' ';  // last element ASCII only.
-      if (ch >= '\x7F')                            // x7F is at the top edge of ASCII
-        chars[i++] = '\xC4';                       // these characters are assigned two bytes
-      chars[i] = static_cast<char>(ch + (ch >= '\x7F'));
-    }
-  }
-};
-
-/**
- * @brief Create a UTF-8 string column with the average length.
- *
- */
-std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile const& profile,
-                                                               thrust::minstd_rand& engine,
-                                                               cudf::size_type num_rows)
-{
-  auto len_dist =
-    random_value_fn<uint32_t>{profile.get_distribution_params<cudf::string_view>().length_params};
-  auto valid_dist =
-    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
-  auto lengths   = len_dist(engine, num_rows + 1);
-  auto null_mask = valid_dist(engine, num_rows + 1);
-  thrust::transform_if(
-    thrust::device,
-    lengths.begin(),
-    lengths.end(),
-    null_mask.begin(),
-    lengths.begin(),
-    [] __device__(auto) { return 0; },
-    thrust::logical_not<bool>{});
-  auto valid_lengths = thrust::make_transform_iterator(
-    thrust::make_zip_iterator(lengths.begin(), null_mask.begin()), valid_or_zero{});
-  rmm::device_uvector<cudf::size_type> offsets(num_rows + 1, cudf::get_default_stream());
-  thrust::exclusive_scan(
-    thrust::device, valid_lengths, valid_lengths + lengths.size(), offsets.begin());
-  // offfsets are ready.
-  auto chars_length = *thrust::device_pointer_cast(offsets.end() - 1);
-  rmm::device_uvector<char> chars(chars_length, cudf::get_default_stream());
-  thrust::for_each_n(thrust::device,
-                     thrust::make_zip_iterator(offsets.begin(), offsets.begin() + 1),
-                     num_rows,
-                     string_generator{chars.data(), engine});
-  auto [result_bitmask, null_count] =
-    cudf::detail::valid_if(null_mask.begin(),
-                           null_mask.end() - 1,
-                           cuda::std::identity{},
-                           cudf::get_default_stream(),
-                           rmm::mr::get_current_device_resource_ref());
-
-  return cudf::make_strings_column(
-    num_rows,
-    std::make_unique<cudf::column>(std::move(offsets), rmm::device_buffer{}, 0),
-    chars.release(),
-    null_count,
-    profile.get_null_frequency().has_value() ? std::move(result_bitmask) : rmm::device_buffer{});
+    dtype, num_rows, data.release(), std::move(*result_bitmask.release()), null_count);
 }
 
 /**
@@ -548,14 +679,12 @@ std::unique_ptr<cudf::column> create_random_column<cudf::string_view>(data_profi
     create_random_utf8_string_column(profile, engine, cardinality == 0 ? num_rows : cardinality);
   if (cardinality == 0) { return sample_strings; }
   auto sample_indices = sample_indices_with_run_length(avg_run_len, cardinality, num_rows, engine);
-  auto sample_indices_span =
+  auto gather_map =
     cudf::device_span<cudf::size_type const>(sample_indices.data(), sample_indices.size());
   auto str_table = cudf::gather(cudf::table_view{{sample_strings->view()}},
-                                cudf::column_view{sample_indices_span},
+                                gather_map,
                                 cudf::out_of_bounds_policy::DONT_CHECK,
-                                cudf::negative_index_policy::NOT_ALLOWED,
-                                cudf::get_default_stream(),
-                                rmm::mr::get_current_device_resource_ref());
+                                cudf::negative_index_policy::NOT_ALLOWED);
   return std::move(str_table->release()[0]);
 }
 
@@ -565,46 +694,6 @@ std::unique_ptr<cudf::column> create_random_column<cudf::dictionary32>(data_prof
                                                                        cudf::size_type num_rows)
 {
   CUDF_FAIL("not implemented yet");
-}
-
-/**
- * @brief Functor to dispatch create_random_column calls.
- */
-struct create_rand_col_fn {
- public:
-  template <typename T>
-  std::unique_ptr<cudf::column> operator()(data_profile const& profile,
-                                           thrust::minstd_rand& engine,
-                                           cudf::size_type num_rows)
-  {
-    return create_random_column<T>(profile, engine, num_rows);
-  }
-};
-
-/**
- * @brief Calculates the number of direct parents needed to generate a struct column hierarchy with
- * lowest maximum number of children in any nested column.
- *
- * Used to generate an "evenly distributed" struct column hierarchy with the given number of leaf
- * columns and nesting levels. The column tree is considered evenly distributed if all columns have
- * nearly the same number of child columns (difference not larger than one).
- */
-int num_direct_parents(int num_lvls, int num_leaf_columns)
-{
-  // Estimated average number of children in the hierarchy;
-  auto const num_children_avg = std::pow(num_leaf_columns, 1. / num_lvls);
-  // Minimum number of children columns for any column in the hierarchy
-  int const num_children_min = std::floor(num_children_avg);
-  // Maximum number of children columns for any column in the hierarchy
-  int const num_children_max = num_children_min + 1;
-
-  // Minimum number of columns needed so that their number of children does not exceed the maximum
-  int const min_for_current_nesting = std::ceil((double)num_leaf_columns / num_children_max);
-  // Minimum number of columns needed so that columns at the higher levels have at least the minimum
-  // number of children
-  int const min_for_upper_nesting = std::pow(num_children_min, num_lvls - 1);
-  // Both conditions need to be satisfied
-  return std::max(min_for_current_nesting, min_for_upper_nesting);
 }
 
 template <>
@@ -625,8 +714,8 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
                      cudf::data_type(type_id), create_rand_col_fn{}, profile, engine, num_rows);
                  });
 
-  auto valid_dist =
-    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+  auto valid_dist = random_value_fn<bool>(
+    distribution_params<bool>{1. - profile.get_null_probability().value_or(0)});
 
   // Generate the column bottom-up
   for (int lvl = dist_params.max_depth; lvl > 0; --lvl) {
@@ -637,15 +726,12 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
     auto current_child = children.begin();
     for (auto current_parent = parents.begin(); current_parent != parents.end(); ++current_parent) {
       auto [null_mask, null_count] = [&]() {
-        if (profile.get_null_frequency().has_value()) {
+        if (profile.get_null_probability().has_value()) {
           auto valids = valid_dist(engine, num_rows);
-          return cudf::detail::valid_if(valids.begin(),
-                                        valids.end(),
-                                        cuda::std::identity{},
-                                        cudf::get_default_stream(),
-                                        rmm::mr::get_current_device_resource_ref());
+          return cudf::bools_to_mask(cudf::device_span<bool const>(valids),
+                                     cudf::get_default_stream());
         }
-        return std::pair<rmm::device_buffer, cudf::size_type>{};
+        return std::pair{std::make_unique<rmm::device_buffer>(), 0};
       }();
 
       // Adopt remaining children as evenly as possible
@@ -660,7 +746,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
       current_child += children_to_adopt.size();
 
       *current_parent = cudf::make_structs_column(
-        num_rows, std::move(children_to_adopt), null_count, std::move(null_mask));
+        num_rows, std::move(children_to_adopt), null_count, std::move(*null_mask.release()));
     }
 
     if (lvl == 1) {
@@ -678,6 +764,7 @@ struct clamp_down {
   clamp_down(T max) : max(max) {}
   __host__ __device__ T operator()(T x) const { return min(x, max); }
 };
+
 /**
  * @brief Creates a list column with random content.
  *
@@ -697,24 +784,30 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
 {
   auto const dist_params       = profile.get_distribution_params<cudf::list_view>();
   auto const single_level_mean = get_distribution_mean(dist_params.length_params);
-  auto const num_elements      = num_rows * pow(single_level_mean, dist_params.max_depth);
+  auto const raw_num_elements =
+    static_cast<double>(num_rows) * std::pow(single_level_mean, dist_params.max_depth);
+  cudf::size_type const num_elements = static_cast<cudf::size_type>(
+    std::min(raw_num_elements, static_cast<double>(std::numeric_limits<cudf::size_type>::max())));
 
   auto leaf_column = cudf::type_dispatcher(
     cudf::data_type(dist_params.element_type), create_rand_col_fn{}, profile, engine, num_elements);
   auto len_dist =
     random_value_fn<uint32_t>{profile.get_distribution_params<cudf::list_view>().length_params};
-  auto valid_dist =
-    random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_frequency().value_or(0)});
+  auto valid_dist = random_value_fn<bool>(
+    distribution_params<bool>{1. - profile.get_null_probability().value_or(0)});
 
   // Generate the list column bottom-up
   auto list_column = std::move(leaf_column);
-  for (int lvl = 0; lvl < dist_params.max_depth; ++lvl) {
+  for (int lvl = dist_params.max_depth; lvl > 0; --lvl) {
     // Generating the next level - offsets point into the current list column
-    auto current_child_column      = std::move(list_column);
-    cudf::size_type const num_rows = current_child_column->size() / single_level_mean;
+    auto current_child_column = std::move(list_column);
+    // Because single_level_mean is not a whole number, rounding errors can lead to slightly
+    // different row count; top-level column needs to have exactly num_rows rows, so enforce it here
+    cudf::size_type const current_num_rows =
+      (lvl == 1) ? num_rows : std::lround(current_child_column->size() / single_level_mean);
 
-    auto offsets = len_dist(engine, num_rows + 1);
-    auto valids  = valid_dist(engine, num_rows);
+    auto offsets = len_dist(engine, current_num_rows + 1);
+    auto valids  = valid_dist(engine, current_num_rows);
     // to ensure these values <= current_child_column->size()
     auto output_offsets = thrust::make_transform_output_iterator(
       offsets.begin(), clamp_down{current_child_column->size()});
@@ -724,53 +817,133 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
       current_child_column->size();  // Always include all elements
 
     auto offsets_column = std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::INT32},
-                                                         num_rows + 1,
+                                                         current_num_rows + 1,
                                                          offsets.release(),
                                                          rmm::device_buffer{},
                                                          0);
 
-    auto [null_mask, null_count] =
-      cudf::detail::valid_if(valids.begin(),
-                             valids.end(),
-                             cuda::std::identity{},
-                             cudf::get_default_stream(),
-                             rmm::mr::get_current_device_resource_ref());
-    list_column = cudf::make_lists_column(
-      num_rows,
-      std::move(offsets_column),
-      std::move(current_child_column),
-      profile.get_null_frequency().has_value() ? null_count : 0,  // cudf::UNKNOWN_NULL_COUNT,
-      profile.get_null_frequency().has_value() ? std::move(null_mask) : rmm::device_buffer{});
+    auto [null_mask, null_count] = profile.get_null_probability().has_value()
+                                     ? cudf::bools_to_mask(cudf::device_span<bool const>(valids))
+                                     : std::pair{std::make_unique<rmm::device_buffer>(), 0};
+
+    list_column = cudf::make_lists_column(current_num_rows,
+                                          std::move(offsets_column),
+                                          std::move(current_child_column),
+                                          null_count,
+                                          std::move(*null_mask.release()));
+
+    if (auto const cv = list_column->view();
+        cudf::has_nonempty_nulls(cv, cudf::get_default_stream())) {
+      list_column = cudf::purge_nonempty_nulls(
+        cv, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
+    }
   }
   return list_column;  // return the top-level column
 }
 
-using columns_vector = std::vector<std::unique_ptr<cudf::column>>;
-
-/**
- * @brief Creates a vector of columns with random content.
- *
- * @param profile Parameters for the random generator
- * @param dtype_ids vector of data type ids, one for each output column
- * @param engine Pseudo-random engine
- * @param num_rows Size of the output columns
- *
- * @return Column filled with random lists
- */
-columns_vector create_random_columns(data_profile const& profile,
-                                     std::vector<cudf::type_id> dtype_ids,
-                                     thrust::minstd_rand engine,
-                                     cudf::size_type num_rows)
+// Numeric types: create a sequence of unique values, then shuffle
+template <typename T>
+  requires(cudf::is_numeric_not_bool<T>())
+std::unique_ptr<cudf::column> create_distinct_rows_column(data_profile const& profile,
+                                                          thrust::minstd_rand& engine,
+                                                          cudf::size_type num_rows)
 {
-  columns_vector output_columns;
-  std::transform(
-    dtype_ids.begin(), dtype_ids.end(), std::back_inserter(output_columns), [&](auto tid) {
-      engine.discard(num_rows);
-      return cudf::type_dispatcher(
-        cudf::data_type(tid), create_rand_col_fn{}, profile, engine, num_rows);
-    });
-  return output_columns;
+  auto init = cudf::make_fixed_width_scalar(T{});
+  auto col  = cudf::sequence(num_rows, *init);
+
+  // Shuffle to randomize order while preserving uniqueness
+  thrust::shuffle(thrust::device,
+                  col->mutable_view().template begin<T>(),
+                  col->mutable_view().template end<T>(),
+                  engine);
+
+  if (profile.get_null_probability().has_value()) {
+    auto valid_dist =
+      random_value_fn<bool>(distribution_params<bool>{1. - profile.get_null_probability().value()});
+    auto null_mask = valid_dist(engine, num_rows);
+    auto [result_bitmask, null_count] =
+      cudf::bools_to_mask(cudf::device_span<bool const>(null_mask), cudf::get_default_stream());
+    col->set_null_mask(std::move(*result_bitmask.release()), null_count);
+  }
+
+  return col;
 }
+
+// catch-all for all types not handled specifically above
+template <typename T>
+  requires(!cudf::is_numeric_not_bool<T>())
+std::unique_ptr<cudf::column> create_distinct_rows_column(data_profile const& profile,
+                                                          thrust::minstd_rand& engine,
+                                                          cudf::size_type num_rows)
+{
+  return create_random_column<T>(profile, engine, num_rows);
+}
+
+template <>
+std::unique_ptr<cudf::column> create_distinct_rows_column<cudf::string_view>(
+  data_profile const& profile, thrust::minstd_rand& engine, cudf::size_type num_rows)
+{
+  auto col        = create_random_column<cudf::string_view>(profile, engine, num_rows);
+  auto int_col    = cudf::sequence(num_rows, *cudf::make_fixed_width_scalar<int32_t>(0));
+  auto int2strcol = cudf::strings::from_integers(int_col->view());
+  auto concat_col = cudf::strings::concatenate(cudf::table_view({col->view(), int2strcol->view()}));
+  return std::move(cudf::sample(cudf::table_view({concat_col->view()}), num_rows)->release()[0]);
+}
+
+template <>
+std::unique_ptr<cudf::column> create_distinct_rows_column<cudf::list_view>(
+  data_profile const& profile, thrust::minstd_rand& engine, cudf::size_type num_rows)
+{
+  auto const dist_params = profile.get_distribution_params<cudf::list_view>();
+  auto col               = create_random_column<cudf::list_view>(profile, engine, num_rows);
+  auto zero              = cudf::make_fixed_width_scalar<cudf::size_type>(0);
+  auto child_column      = cudf::sequence(num_rows, *zero);
+  for (int lvl = dist_params.max_depth; lvl > 0; --lvl) {
+    auto offsets_column = cudf::sequence(num_rows + 1, *zero);
+    auto list_column    = cudf::make_lists_column(
+      num_rows, std::move(offsets_column), std::move(child_column), 0, rmm::device_buffer{});
+    if (auto const cv = list_column->view();
+        cudf::has_nonempty_nulls(cv, cudf::get_default_stream())) {
+      list_column = cudf::purge_nonempty_nulls(
+        cv, cudf::get_default_stream(), cudf::get_current_device_resource_ref());
+    }
+    std::swap(child_column, list_column);
+  }
+  auto lists_col =
+    cudf::lists::concatenate_rows(cudf::table_view({col->view(), child_column->view()}));
+  return std::move(cudf::sample(cudf::table_view({lists_col->view()}), num_rows)->release()[0]);
+}
+
+template <>
+std::unique_ptr<cudf::column> create_distinct_rows_column<cudf::dictionary32>(
+  data_profile const& profile, thrust::minstd_rand& engine, cudf::size_type num_rows)
+{
+  CUDF_FAIL("not implemented yet");
+}
+
+template <>
+std::unique_ptr<cudf::column> create_distinct_rows_column<cudf::struct_view>(
+  data_profile const& profile, thrust::minstd_rand& engine, cudf::size_type num_rows)
+{
+  auto const dist_params = profile.get_distribution_params<cudf::struct_view>();
+  auto col               = create_random_column<cudf::struct_view>(profile, engine, num_rows);
+  std::vector<std::unique_ptr<cudf::column>> children;
+  children.push_back(cudf::sequence(num_rows, *cudf::make_fixed_width_scalar<int32_t>(0)));
+  for (int lvl = dist_params.max_depth; lvl > 1; --lvl) {
+    std::vector<std::unique_ptr<cudf::column>> parents;
+    parents.push_back(
+      cudf::create_structs_hierarchy(num_rows, std::move(children), 0, rmm::device_buffer{}));
+    std::swap(parents, children);
+  }
+  auto const null_count = col->null_count();
+  auto col_contents     = col->release();
+  col_contents.children.push_back(std::move(children[0]));
+  auto structs_col = cudf::create_structs_hierarchy(
+    num_rows, std::move(col_contents.children), null_count, std::move(*col_contents.null_mask));
+  return std::move(cudf::sample(cudf::table_view({structs_col->view()}), num_rows)->release()[0]);
+}
+
+}  // namespace
 
 /**
  * @brief Repeats the input data types cyclically order to fill a vector of @ref num_cols
@@ -787,18 +960,41 @@ std::vector<cudf::type_id> cycle_dtypes(std::vector<cudf::type_id> const& dtype_
   return out_dtypes;
 }
 
+/**
+ * @brief Repeat the given two data types with a given ratio of a:b.
+ *
+ * The first dtype will have 'first_num' columns and the second will have 'num_cols - first_num'
+ * columns.
+ */
+std::vector<cudf::type_id> mix_dtypes(std::pair<cudf::type_id, cudf::type_id> const& dtype_ids,
+                                      cudf::size_type num_cols,
+                                      int first_num)
+{
+  std::vector<cudf::type_id> out_dtypes;
+  out_dtypes.reserve(num_cols);
+  for (cudf::size_type col = 0; col < first_num; ++col)
+    out_dtypes.push_back(dtype_ids.first);
+  for (cudf::size_type col = first_num; col < num_cols; ++col)
+    out_dtypes.push_back(dtype_ids.second);
+  return out_dtypes;
+}
+
 std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
                                                  table_size_bytes table_bytes,
                                                  data_profile const& profile,
                                                  unsigned seed)
 {
-  size_t const avg_row_bytes =
-    std::accumulate(dtype_ids.begin(), dtype_ids.end(), 0ul, [&](size_t sum, auto tid) {
+  auto const avg_row_bytes =
+    std::accumulate(dtype_ids.begin(), dtype_ids.end(), double{0}, [&](auto sum, auto tid) {
       return sum + avg_element_size(profile, cudf::data_type(tid));
     });
-  cudf::size_type const num_rows = table_bytes.size / avg_row_bytes;
+  std::size_t const num_rows = std::lround(table_bytes.size / avg_row_bytes);
+  CUDF_EXPECTS(num_rows > 0, "Table size is too small for the given data types");
+  CUDF_EXPECTS(num_rows < std::numeric_limits<cudf::size_type>::max(),
+               "Table size is too large for the given data types");
 
-  return create_random_table(dtype_ids, row_count{num_rows}, profile, seed);
+  return create_random_table(
+    dtype_ids, row_count{static_cast<cudf::size_type>(num_rows)}, profile, seed);
 }
 
 std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
@@ -809,14 +1005,22 @@ std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> cons
   auto seed_engine = deterministic_engine(seed);
   thrust::uniform_int_distribution<unsigned> seed_dist;
 
-  columns_vector output_columns;
+  std::vector<std::unique_ptr<cudf::column>> output_columns;
   std::transform(
     dtype_ids.begin(), dtype_ids.end(), std::back_inserter(output_columns), [&](auto tid) mutable {
-      auto engine = deterministic_engine(seed_dist(seed_engine));
-      return cudf::type_dispatcher(
-        cudf::data_type(tid), create_rand_col_fn{}, profile, engine, num_rows.count);
+      return create_random_column(tid, num_rows, profile, seed_dist(seed_engine));
     });
   return std::make_unique<cudf::table>(std::move(output_columns));
+}
+
+std::unique_ptr<cudf::column> create_random_column(cudf::type_id dtype_id,
+                                                   row_count num_rows,
+                                                   data_profile const& profile,
+                                                   unsigned seed)
+{
+  auto engine = deterministic_engine(seed);
+  return cudf::type_dispatcher(
+    cudf::data_type(dtype_id), create_rand_col_fn{}, profile, engine, num_rows.count);
 }
 
 std::unique_ptr<cudf::table> create_sequence_table(std::vector<cudf::type_id> const& dtype_ids,
@@ -830,13 +1034,66 @@ std::unique_ptr<cudf::table> create_sequence_table(std::vector<cudf::type_id> co
   auto columns = std::vector<std::unique_ptr<cudf::column>>(dtype_ids.size());
   std::transform(dtype_ids.begin(), dtype_ids.end(), columns.begin(), [&](auto dtype) mutable {
     auto init = cudf::make_default_constructed_scalar(cudf::data_type{dtype});
-    auto col  = cudf::sequence(num_rows.count, *init);
+    init->set_valid_async(true);
+    auto col = cudf::sequence(num_rows.count, *init);
     auto [mask, count] =
       create_random_null_mask(num_rows.count, null_probability, seed_dist(seed_engine));
     col->set_null_mask(std::move(mask), count);
     return col;
   });
   return std::make_unique<cudf::table>(std::move(columns));
+}
+
+std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
+                                                   cudf::size_type row_width,
+                                                   int32_t hit_rate)
+{
+  // build input table using the following data
+  auto raw_data = cudf::test::strings_column_wrapper(
+                    {
+                      "123 abc 4567890 DEFGHI 0987 5W43",  // matches both patterns;
+                      "012345 6789 01234 56789 0123 456",  // the rest do not match
+                      "abc 4567890 DEFGHI 0987 Wxyz 123",
+                      "abcdefghijklmnopqrstuvwxyz 01234",
+                      "",
+                      "AbcéDEFGHIJKLMNOPQRSTUVWXYZ 01",
+                      "9876543210,abcdefghijklmnopqrstU",
+                      "9876543210,abcdefghijklmnopqrstU",
+                      "123 édf 4567890 DéFG 0987 X5",
+                      "1",
+                    })
+                    .release();
+
+  if (row_width / 32 > 1) {
+    std::vector<cudf::column_view> columns;
+    for (int i = 0; i < row_width / 32; ++i) {
+      columns.push_back(raw_data->view());
+    }
+    raw_data = cudf::strings::concatenate(cudf::table_view(columns));
+  }
+  auto data_view = raw_data->view();
+
+  // compute number of rows in n_rows that should match
+  auto const num_matches = (static_cast<int64_t>(num_rows) * hit_rate) / 100;
+
+  // Create a randomized gather-map to build a column out of the strings in data.
+  data_profile gather_profile = data_profile_builder().cardinality(0).no_validity().distribution(
+    cudf::type_id::INT32, distribution_id::UNIFORM, 1, data_view.size() - 1);
+  auto gather_table =
+    create_random_table({cudf::type_id::INT32}, row_count{num_rows}, gather_profile);
+
+  if (num_matches > 0) {  // guard against division by zero
+    // Create scatter map by placing 0-index values throughout the gather-map
+    auto zero_scalar  = cudf::numeric_scalar<int32_t>(0);
+    auto scatter_data = cudf::sequence(
+      num_matches, zero_scalar, cudf::numeric_scalar<int32_t>(num_rows / num_matches));
+    gather_table = cudf::scatter({zero_scalar}, scatter_data->view(), gather_table->view());
+  }
+
+  auto gather_map = gather_table->view().column(0);
+  auto table      = cudf::gather(cudf::table_view({data_view}), gather_map);
+
+  return std::move(table->release().front());
 }
 
 std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
@@ -850,12 +1107,20 @@ std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(
   } else if (*null_probability == 1.0) {
     return {cudf::create_null_mask(size, cudf::mask_state::ALL_NULL), size};
   } else {
-    return cudf::detail::valid_if(thrust::make_counting_iterator<cudf::size_type>(0),
-                                  thrust::make_counting_iterator<cudf::size_type>(size),
+    return cudf::detail::valid_if(cuda::counting_iterator<cudf::size_type>{0},
+                                  cuda::counting_iterator<cudf::size_type>{size},
                                   bool_generator{seed, 1.0 - *null_probability},
                                   cudf::get_default_stream(),
-                                  rmm::mr::get_current_device_resource_ref());
+                                  cudf::get_current_device_resource_ref());
   }
+}
+
+std::unique_ptr<cudf::column> create_ascii_string_column(data_profile const& profile,
+                                                         cudf::size_type num_rows,
+                                                         unsigned seed = 1)
+{
+  auto engine = deterministic_engine(seed);
+  return create_random_utf8_string_column<string_encoding::ASCII>(profile, engine, num_rows);
 }
 
 std::vector<cudf::type_id> get_type_or_group(int32_t id)

--- a/src/main/cpp/benchmarks/common/generate_input.hpp
+++ b/src/main/cpp/benchmarks/common/generate_input.hpp
@@ -712,12 +712,12 @@ std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
 /**
  * @brief Generates an string column filled with ASCII characters only
  *
- * @param num_rows Number of rows in the output column
  * @param profile Data profile for the output column
+ * @param num_rows Number of rows in the output column
  * @param seed Optional, seed for the pseudo-random engine
  */
-std::unique_ptr<cudf::column> create_ascii_string_column(cudf::size_type num_rows,
-                                                         data_profile const& profile,
+std::unique_ptr<cudf::column> create_ascii_string_column(data_profile const& profile,
+                                                         cudf::size_type num_rows,
                                                          unsigned seed = 1);
 
 /**

--- a/src/main/cpp/benchmarks/common/generate_input.hpp
+++ b/src/main/cpp/benchmarks/common/generate_input.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <map>
@@ -63,7 +64,6 @@ enum class distribution_id : int8_t {
 };
 
 // Default distribution types for each type
-namespace {
 template <typename T, std::enable_if_t<cudf::is_chrono<T>()>* = nullptr>
 distribution_id default_distribution_id()
 {
@@ -117,7 +117,6 @@ std::pair<T, T> default_range()
   // Limits need to be such that `upper - lower` does not overflow
   return {std::numeric_limits<T>::lowest() / 2, std::numeric_limits<T>::max() / 2};
 }
-}  // namespace
 
 /**
  * @brief Enables partial specializations with SFINAE.
@@ -154,11 +153,14 @@ struct distribution_params<T, std::enable_if_t<cudf::is_chrono<T>()>> {
 };
 
 /**
- * @brief Strings are parameterized by the distribution of their length, as an integral value.
+ * @brief Strings are parameterized by the distribution of their length and character range.
  */
 template <typename T>
 struct distribution_params<T, std::enable_if_t<std::is_same_v<T, cudf::string_view>>> {
   distribution_params<uint32_t> length_params;
+  unsigned char char_lower = 32;   ///< Lower bound of character range (inclusive)
+  unsigned char char_upper = 137;  ///< Upper bound of character range (inclusive), >126 produces
+                                   ///< UTF-8
 };
 
 /**
@@ -181,9 +183,17 @@ struct distribution_params<T, std::enable_if_t<std::is_same_v<T, cudf::struct_vi
   cudf::size_type max_depth;
 };
 
-// Present for compilation only. To be implemented once reader/writers support the fixed width type.
+/**
+ * @brief Fixed-point values are parameterized with a distribution type, scale, and bounds of the
+ * same type.
+ */
 template <typename T>
-struct distribution_params<T, std::enable_if_t<cudf::is_fixed_point<T>()>> {};
+struct distribution_params<T, std::enable_if_t<cudf::is_fixed_point<T>()>> {
+  distribution_id id;
+  typename T::rep lower_bound;
+  typename T::rep upper_bound;
+  std::optional<numeric::scale_type> scale;
+};
 
 /**
  * @brief Returns a vector of types, corresponding to the input type or a type group.
@@ -222,15 +232,18 @@ class data_profile {
   std::map<cudf::type_id, distribution_params<double>> float_params;
   distribution_params<cudf::string_view> string_dist_desc{{distribution_id::NORMAL, 0, 32}};
   distribution_params<cudf::list_view> list_dist_desc{
-    cudf::type_id::INT32, {distribution_id::GEOMETRIC, 0, 100}, 2};
+    cudf::type_id::INT32, {distribution_id::GEOMETRIC, 0, 64}, 2};
   distribution_params<cudf::struct_view> struct_dist_desc{
     {cudf::type_id::INT32, cudf::type_id::FLOAT32, cudf::type_id::STRING}, 2};
-  std::map<cudf::type_id, distribution_params<__uint128_t>> decimal_params;
+  std::map<cudf::type_id, distribution_params<numeric::decimal128>> decimal_params;
 
-  double bool_probability              = 0.5;
-  std::optional<double> null_frequency = 0.01;
-  cudf::size_type cardinality          = 2000;
-  cudf::size_type avg_run_length       = 4;
+  double bool_probability_true           = 0.5;
+  std::optional<double> null_probability = 0.01;
+  cudf::size_type cardinality =
+    2000;  /// Upper bound on the number of unique values generated if `0 <= cardinality < n`, where
+           /// `n` is the total number of values to be generated. If `cardinality >= n`, n` unique
+           /// values of the requested data type are generated.
+  cudf::size_type avg_run_length = 4;
 
  public:
   template <typename T,
@@ -263,7 +276,7 @@ class data_profile {
   template <typename T, std::enable_if_t<std::is_same_v<T, bool>>* = nullptr>
   distribution_params<T> get_distribution_params() const
   {
-    return distribution_params<T>{bool_probability};
+    return distribution_params<T>{bool_probability_true};
   }
 
   template <typename T, std::enable_if_t<cudf::is_chrono<T>()>* = nullptr>
@@ -299,21 +312,27 @@ class data_profile {
   }
 
   template <typename T, std::enable_if_t<cudf::is_fixed_point<T>()>* = nullptr>
-  distribution_params<typename T::rep> get_distribution_params() const
+  distribution_params<T> get_distribution_params() const
   {
     using rep = typename T::rep;
     auto it   = decimal_params.find(cudf::type_to_id<T>());
     if (it == decimal_params.end()) {
       auto const range = default_range<rep>();
-      return distribution_params<rep>{default_distribution_id<rep>(), range.first, range.second};
+      auto const scale = std::optional<numeric::scale_type>{};
+      return distribution_params<T>{
+        default_distribution_id<rep>(), range.first, range.second, scale};
     } else {
       auto& desc = it->second;
-      return {desc.id, static_cast<rep>(desc.lower_bound), static_cast<rep>(desc.upper_bound)};
+      return {desc.id,
+              static_cast<rep>(desc.lower_bound),
+              static_cast<rep>(desc.upper_bound),
+              desc.scale};
     }
   }
 
-  auto get_bool_probability() const { return bool_probability; }
-  auto get_null_frequency() const { return null_frequency; };
+  [[nodiscard]] auto get_bool_probability_true() const { return bool_probability_true; }
+  [[nodiscard]] auto get_null_probability() const { return null_probability; };
+  [[nodiscard]] auto get_valid_probability() const { return 1. - null_probability.value_or(0.); };
   [[nodiscard]] auto get_cardinality() const { return cardinality; };
   [[nodiscard]] auto get_avg_run_length() const { return avg_run_length; };
 
@@ -357,6 +376,23 @@ class data_profile {
     }
   }
 
+  // Users should pass integral values for bounds when setting the parameters for fixed-point.
+  // Otherwise the call with have no effect.
+  template <typename T,
+            typename Type_enum,
+            std::enable_if_t<cuda::std::is_integral_v<T>, T>* = nullptr>
+  void set_distribution_params(Type_enum type_or_group,
+                               distribution_id dist,
+                               T lower_bound,
+                               T upper_bound,
+                               numeric::scale_type scale)
+  {
+    for (auto tid : get_type_or_group(static_cast<int32_t>(type_or_group))) {
+      decimal_params[tid] = {
+        dist, static_cast<__int128_t>(lower_bound), static_cast<__int128_t>(upper_bound), scale};
+    }
+  }
+
   template <typename T, typename Type_enum, std::enable_if_t<cudf::is_chrono<T>(), T>* = nullptr>
   void set_distribution_params(Type_enum type_or_group,
                                distribution_id dist,
@@ -369,8 +405,17 @@ class data_profile {
     }
   }
 
-  void set_bool_probability(double p) { bool_probability = p; }
-  void set_null_frequency(std::optional<double> f) { null_frequency = f; }
+  void set_bool_probability_true(double p)
+  {
+    CUDF_EXPECTS(p >= 0. and p <= 1., "probability must be in range [0...1]");
+    bool_probability_true = p;
+  }
+  void set_null_probability(std::optional<double> p)
+  {
+    CUDF_EXPECTS(p.value_or(0.) >= 0. and p.value_or(0.) <= 1.,
+                 "probability must be in range [0...1]");
+    null_probability = p;
+  }
   void set_cardinality(cudf::size_type c) { cardinality = c; }
   void set_avg_run_length(cudf::size_type avg_rl) { avg_run_length = avg_rl; }
 
@@ -388,13 +433,20 @@ class data_profile {
     struct_dist_desc.max_depth = max_depth;
   }
 
-  void set_struct_types(std::vector<cudf::type_id> const& types)
+  void set_struct_types(cudf::host_span<cudf::type_id const> types)
   {
     CUDF_EXPECTS(
       std::none_of(
-        types.cbegin(), types.cend(), [](auto& type) { return type == cudf::type_id::STRUCT; }),
+        types.begin(), types.end(), [](auto& type) { return type == cudf::type_id::STRUCT; }),
       "Cannot include STRUCT as its own subtype");
-    struct_dist_desc.leaf_types = types;
+    struct_dist_desc.leaf_types.assign(types.begin(), types.end());
+  }
+
+  void set_string_char_range(unsigned char lower, unsigned char upper)
+  {
+    CUDF_EXPECTS(lower <= upper, "Lower bound must be <= upper bound");
+    string_dist_desc.char_lower = lower;
+    string_dist_desc.char_upper = upper;
   }
 };
 
@@ -611,8 +663,8 @@ struct row_count {
  * @param dtype_ids Vector of requested column types
  * @param table_bytes Target size of the output table, in bytes. Some type may not produce columns
  * of exact size
- * @param data_params optional, set of data parameters describing the data profile for each type
- * @param seed optional, seed for the pseudo-random engine
+ * @param data_params Optional, set of data parameters describing the data profile for each type
+ * @param seed Optional, seed for the pseudo-random engine
  */
 std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
                                                  table_size_bytes table_bytes,
@@ -624,8 +676,8 @@ std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> cons
  *
  * @param dtype_ids Vector of requested column types
  * @param num_rows Number of rows in the output table
- * @param data_params optional, set of data parameters describing the data profile for each type
- * @param seed optional, seed for the pseudo-random engine
+ * @param data_params Optional, set of data parameters describing the data profile for each type
+ * @param seed Optional, seed for the pseudo-random engine
  */
 std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> const& dtype_ids,
                                                  row_count num_rows,
@@ -633,14 +685,50 @@ std::unique_ptr<cudf::table> create_random_table(std::vector<cudf::type_id> cons
                                                  unsigned seed                   = 1);
 
 /**
+ * @brief Deterministically generates a column filled with data with the given parameters.
+ *
+ * @param dtype_id Requested column type
+ * @param num_rows Number of rows in the output column
+ * @param data_params Optional, set of data parameters describing the data profile
+ * @param seed Optional, seed for the pseudo-random engine
+ */
+std::unique_ptr<cudf::column> create_random_column(cudf::type_id dtype_id,
+                                                   row_count num_rows,
+                                                   data_profile const& data_params = data_profile{},
+                                                   unsigned seed                   = 1);
+
+/**
+ * @brief Deterministically generates a large string column filled with data with the given
+ * parameters.
+ *
+ * @param num_rows Number of rows in the output column
+ * @param row_width Width of each string in the column
+ * @param hit_rate The hit rate percentage, ranging from 0 to 100
+ */
+std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
+                                                   cudf::size_type row_width,
+                                                   int32_t hit_rate);
+
+/**
+ * @brief Generates an string column filled with ASCII characters only
+ *
+ * @param num_rows Number of rows in the output column
+ * @param profile Data profile for the output column
+ * @param seed Optional, seed for the pseudo-random engine
+ */
+std::unique_ptr<cudf::column> create_ascii_string_column(cudf::size_type num_rows,
+                                                         data_profile const& profile,
+                                                         unsigned seed = 1);
+
+/**
  * @brief Generate sequence columns starting with value 0 in first row and increasing by 1 in
  * subsequent rows.
  *
  * @param dtype_ids Vector of requested column types
  * @param num_rows Number of rows in the output table
- * @param null_probability optional, probability of a null value
+ * @param null_probability Optional, probability of a null value
  *  no value implies no null mask, =0 implies all valids, >=1 implies all nulls
- * @param seed optional, seed for the pseudo-random engine
+ * @param seed Optional, seed for the pseudo-random engine
  * @return A table with the sequence columns.
  */
 std::unique_ptr<cudf::table> create_sequence_table(
@@ -659,13 +747,28 @@ std::unique_ptr<cudf::table> create_sequence_table(
  */
 std::vector<cudf::type_id> cycle_dtypes(std::vector<cudf::type_id> const& dtype_ids,
                                         cudf::size_type num_cols);
+
+/**
+ * @brief Repeat the given two data types with a given ratio of a:b.
+ *
+ * The first dtype will have 'first_num' columns and the second will have 'num_cols - first_num'
+ * columns.
+ *
+ * @param dtype_ids Pair of requested column types
+ * @param num_cols Total number of columns in the output vector
+ * @param first_num Total number of columns of type `dtype_ids.first`
+ * @return A vector of type_ids
+ */
+std::vector<cudf::type_id> mix_dtypes(std::pair<cudf::type_id, cudf::type_id> const& dtype_ids,
+                                      cudf::size_type num_cols,
+                                      int first_num);
 /**
  * @brief Create a random null mask object
  *
  * @param size number of rows
  * @param null_probability probability of a null value
  *  no value implies no null mask, =0 implies all valids, >=1 implies all nulls
- * @param seed optional, seed for the pseudo-random engine
+ * @param seed Optional, seed for the pseudo-random engine
  * @return null mask device buffer with random null mask data and null count
  */
 std::pair<rmm::device_buffer, cudf::size_type> create_random_null_mask(

--- a/src/main/cpp/benchmarks/common/generate_input.hpp
+++ b/src/main/cpp/benchmarks/common/generate_input.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -396,6 +396,198 @@ class data_profile {
       "Cannot include STRUCT as its own subtype");
     struct_dist_desc.leaf_types = types;
   }
+};
+
+/**
+ * @brief Builder to construct data profiles for the random data generator.
+ *
+ * Setters can be chained to set multiple properties in a single expression.
+ * For example, `data_profile` initialization
+ * @code{.pseudo}
+ * data_profile profile;
+ * profile.set_null_probability(0.01);
+ * profile.set_cardinality(0);
+ * profile.set_distribution_params(cudf::type_id::INT32, distribution_id::UNIFORM, 0, 100);
+ * @endcode
+ * becomes
+ * @code{.pseudo}
+ * data_profile const profile =
+ *   data_profile_builder().cardinality(0).null_probability(0.01).distribution(
+ *     cudf::type_id::INT32, distribution_id::UNIFORM, 0, 100);
+ * @endcode
+ * The builder makes it easier to have immutable `data_profile` objects even with the complex
+ * initialization. The `profile` object in the example above is initialized from
+ * `data_profile_builder` using an implicit conversion operator.
+ *
+ * The builder API also includes a few additional convenience setters:
+ * Overload of `distribution` that only takes the distribution type (not the range).
+ * `no_validity`, which is a simpler equivalent of `null_probability(std::nullopt)`.
+ */
+class data_profile_builder {
+  data_profile profile;
+
+ public:
+  /**
+   * @brief Sets random distribution type for a given set of data types.
+   *
+   * Only the distribution type is set; the distribution will use the default range.
+   *
+   * @param type_or_group  Type or group ID, depending on whether the new distribution
+   * applies to a single type or a subset of types
+   * @param dist  Random distribution type
+   * @tparam T Data type of the distribution range; does not need to match the data type
+   * @return this for chaining
+   */
+  template <typename T, typename Type_enum>
+  data_profile_builder& distribution(Type_enum type_or_group, distribution_id dist)
+  {
+    auto const range = default_range<T>();
+    profile.set_distribution_params(type_or_group, dist, range.first, range.second);
+    return *this;
+  }
+
+  /**
+   * @brief Sets random distribution type and value range for a given set of data types.
+   *
+   * @tparam T Parameters that are forwarded to set_distribution_params
+   * @return this for chaining
+   */
+  template <class... T>
+  data_profile_builder& distribution(T&&... t)
+  {
+    profile.set_distribution_params(std::forward<T>(t)...);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the probability that a randomly generated boolean element with be `true`.
+   *
+   * For example, passing `0.9` means that 90% of values in boolean columns with be `true`.
+   *
+   * @param p Probability of `true` values, in range [0..1]
+   * @return this for chaining
+   */
+  data_profile_builder& bool_probability_true(double p)
+  {
+    profile.set_bool_probability_true(p);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the probability that a randomly generated element will be `null`.
+   *
+   * @param p Probability of `null` values, in range [0..1]
+   * @return this for chaining
+   */
+  data_profile_builder& null_probability(std::optional<double> p)
+  {
+    profile.set_null_probability(p);
+    return *this;
+  }
+
+  /**
+   * @brief Disables the creation of null mask in the output columns.
+   *
+   * @return this for chaining
+   */
+  data_profile_builder& no_validity()
+  {
+    profile.set_null_probability(std::nullopt);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the maximum number of unique values in each output column.
+   *
+   * @param c Maximum number of unique values
+   * @return this for chaining
+   */
+  data_profile_builder& cardinality(cudf::size_type c)
+  {
+    profile.set_cardinality(c);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the average length of sequences of equal elements in output columns.
+   *
+   * @param avg_rl Average sequence length (run-length)
+   * @return this for chaining
+   */
+  data_profile_builder& avg_run_length(cudf::size_type avg_rl)
+  {
+    profile.set_avg_run_length(avg_rl);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the maximum nesting depth of generated list columns.
+   *
+   * @param max_depth maximum nesting depth
+   * @return this for chaining
+   */
+  data_profile_builder& list_depth(cudf::size_type max_depth)
+  {
+    profile.set_list_depth(max_depth);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the data type of list elements.
+   *
+   * @param type data type ID
+   * @return this for chaining
+   */
+  data_profile_builder& list_type(cudf::type_id type)
+  {
+    profile.set_list_type(type);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the maximum nesting depth of generated struct columns.
+   *
+   * @param max_depth maximum nesting depth
+   * @return this for chaining
+   */
+  data_profile_builder& struct_depth(cudf::size_type max_depth)
+  {
+    profile.set_struct_depth(max_depth);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the data types of struct fields.
+   *
+   * @param types data type IDs
+   * @return this for chaining
+   */
+  data_profile_builder& struct_types(cudf::host_span<cudf::type_id const> types)
+  {
+    profile.set_struct_types(types);
+    return *this;
+  }
+
+  /**
+   * @brief Sets the character range for generated strings.
+   *
+   * Characters are uniformly distributed in the range [lower, upper].
+   * Values > 126 will produce multi-byte UTF-8 characters.
+   *
+   * @param lower Lower bound of character range (inclusive, must be >= 32)
+   * @param upper Upper bound of character range (inclusive)
+   * @return this for chaining
+   */
+  data_profile_builder& string_char_range(unsigned char lower, unsigned char upper)
+  {
+    profile.set_string_char_range(lower, upper);
+    return *this;
+  }
+
+  /**
+   * @brief move data_profile member once it's built.
+   */
+  operator data_profile&&() { return std::move(profile); }
 };
 
 /**

--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/from_json.cu
+++ b/src/main/cpp/benchmarks/from_json.cu
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
+#include "common/generate_input.hpp"
 #include "json_utils.hpp"
-
-#include <benchmarks/common/generate_input.hpp>
 
 #include <cudf_test/column_wrapper.hpp>
 

--- a/src/main/cpp/benchmarks/get_json_object.cu
+++ b/src/main/cpp/benchmarks/get_json_object.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/get_json_object.cu
+++ b/src/main/cpp/benchmarks/get_json_object.cu
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <benchmarks/common/generate_input.hpp>
+#include "common/generate_input.hpp"
 
 #include <cudf_test/column_wrapper.hpp>
 

--- a/src/main/cpp/benchmarks/get_json_object.cu
+++ b/src/main/cpp/benchmarks/get_json_object.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/parse_uri.cpp
+++ b/src/main/cpp/benchmarks/parse_uri.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <benchmarks/common/generate_input.hpp>
+#include "common/generate_input.hpp"
 
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>

--- a/src/main/cpp/benchmarks/parse_uri.cpp
+++ b/src/main/cpp/benchmarks/parse_uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/parse_uri.cpp
+++ b/src/main/cpp/benchmarks/parse_uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/row_conversion.cpp
+++ b/src/main/cpp/benchmarks/row_conversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/row_conversion.cpp
+++ b/src/main/cpp/benchmarks/row_conversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/cpp/benchmarks/row_conversion.cpp
+++ b/src/main/cpp/benchmarks/row_conversion.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <benchmarks/common/generate_input.hpp>
+#include "common/generate_input.hpp"
 
 #include <cudf_test/column_utilities.hpp>
 


### PR DESCRIPTION
Fixes the include statements for the 'generate_input.hpp'.
There is a duplicate name in the libcudf library and it was being picked up by these includes and then failing to compile.
The fix here ensures the correct is included.

Example failure: https://github.com/rapidsai/cudf/actions/runs/29039260419/job/86192283985?pr=23199

Looks like cudf-spark-jni has an older copy of the generate_input.h/.cu files so this PR copies the latest from that repo.