### PR TITLE
[Part 4] [ORC-timezone]: Wire recurring DST metadata through JNI

### DIFF
--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -128,4 +128,69 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOr
   }
   JNI_CATCH(env, 0);
 }
+
+static spark_rapids_jni::dst_rule parse_dst_rule(JNIEnv* env, jintArray java_rule)
+{
+  spark_rapids_jni::dst_rule rule{};
+  if (java_rule == nullptr) { return rule; }
+
+  cudf::jni::native_jintArray const values(env, java_rule);
+  constexpr int32_t expected_rule_size = 13;
+  JNI_ARG_CHECK(
+    env, values.size() == expected_rule_size, "ORC DST rule array must contain 13 integers", rule);
+
+  // Keep this field order synchronized with GpuTimeZoneDB.dstRuleToArray.
+  rule.has_dst         = true;
+  rule.dst_savings     = values[0];
+  rule.start_month     = values[1];
+  rule.start_day       = values[2];
+  rule.start_dow       = values[3];
+  rule.start_time      = values[4];
+  rule.start_time_mode = values[5];
+  rule.start_mode      = values[6];
+  rule.end_month       = values[7];
+  rule.end_day         = values[8];
+  rule.end_dow         = values[9];
+  rule.end_time        = values[10];
+  rule.end_time_mode   = values[11];
+  rule.end_mode        = values[12];
+  return rule;
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOrcTimezonesWithRules(
+  JNIEnv* env,
+  jclass,
+  jlong input_handle,
+  jlong writer_tz_offset_at_orc_2015_base_us,
+  jlong writer_tz_info_table,
+  jint writer_tz_initial_offset,
+  jint writer_tz_raw_offset,
+  jintArray writer_dst_rule,
+  jlong reader_tz_info_table,
+  jint reader_tz_initial_offset,
+  jint reader_tz_raw_offset,
+  jintArray reader_dst_rule)
+{
+  JNI_NULL_CHECK(env, input_handle, "input column is null", 0);
+
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const input              = reinterpret_cast<cudf::column_view const*>(input_handle);
+    auto const writer_tz_info_tab = reinterpret_cast<cudf::table_view const*>(writer_tz_info_table);
+    auto const reader_tz_info_tab = reinterpret_cast<cudf::table_view const*>(reader_tz_info_table);
+    auto const writer_dst         = parse_dst_rule(env, writer_dst_rule);
+    cudf::jni::check_java_exception(env);
+    auto const reader_dst = parse_dst_rule(env, reader_dst_rule);
+    cudf::jni::check_java_exception(env);
+
+    auto const writer = spark_rapids_jni::orc_tz_side{
+      writer_tz_info_tab, writer_tz_initial_offset, writer_tz_raw_offset, writer_dst};
+    auto const reader = spark_rapids_jni::orc_tz_side{
+      reader_tz_info_tab, reader_tz_initial_offset, reader_tz_raw_offset, reader_dst};
+    return cudf::jni::release_as_jlong(spark_rapids_jni::convert_orc_writer_reader_timezones(
+      *input, static_cast<int64_t>(writer_tz_offset_at_orc_2015_base_us), writer, reader));
+  }
+  JNI_CATCH(env, 0);
+}
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -568,7 +568,8 @@ public class GpuTimeZoneDB {
 
   /**
    * Reusable device-side metadata for converting ORC timestamps between one writer/reader
-   * timezone pair.
+   * timezone pair. This context is not thread-safe. Callers must not use it concurrently from
+   * multiple threads or call {@link #close()} while a conversion is in progress.
    */
   public static final class OrcTimezoneContext implements AutoCloseable {
     private Table writerTzInfoTable;
@@ -649,7 +650,8 @@ public class GpuTimeZoneDB {
    * DST-enabled dispatch path so callers can reuse transition tables across timestamp columns.
    *
    * @param input input timestamp column in microseconds
-   * @param context writer/reader timezone metadata
+   * @param context writer/reader timezone metadata; must not be used concurrently or closed while
+   *                this method is running
    * @return converted timestamp column
    */
   public static ColumnVector convertOrcTimezones(

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -524,7 +524,7 @@ public class GpuTimeZoneDB {
    * timestamp frame before applying ORC's negative nanos borrow and timezone conversion.
    */
   private static int getOrc2015YearBaseOffsetMillis(String timezoneId, OrcTimezoneInfo info) {
-    if (info.transitions == null) {
+    if (info.transitions == null && info.dstRule == null) {
       return info.rawOffset;
     }
     TimeZone tz = TimeZone.getTimeZone(getZoneId(timezoneId).getId());
@@ -564,6 +564,130 @@ public class GpuTimeZoneDB {
    */
   static List<String> getOrcSupportedTimezones() {
     return OrcTimezoneInfo.getAllTimezoneIds();
+  }
+
+  /**
+   * Reusable device-side metadata for converting ORC timestamps between one writer/reader
+   * timezone pair.
+   */
+  public static final class OrcTimezoneContext implements AutoCloseable {
+    private Table writerTzInfoTable;
+    private Table readerTzInfoTable;
+    private final long writerTzOffsetAtOrc2015BaseUs;
+    private final int writerInitialOffset;
+    private final int writerRawOffset;
+    private final int[] writerDstRule;
+    private final int readerInitialOffset;
+    private final int readerRawOffset;
+    private final int[] readerDstRule;
+    private boolean closed;
+
+    private OrcTimezoneContext(Table writerTzInfoTable, Table readerTzInfoTable,
+        String writerTimezone, OrcTimezoneInfo writerTzInfo, OrcTimezoneInfo readerTzInfo) {
+      this.writerTzInfoTable = writerTzInfoTable;
+      this.readerTzInfoTable = readerTzInfoTable;
+      this.writerTzOffsetAtOrc2015BaseUs = TimeUnit.MILLISECONDS.toMicros(
+          getOrc2015YearBaseOffsetMillis(writerTimezone, writerTzInfo));
+      this.writerInitialOffset = writerTzInfo.initialOffset;
+      this.writerRawOffset = writerTzInfo.rawOffset;
+      this.writerDstRule = dstRuleToArray(writerTzInfo.dstRule);
+      this.readerInitialOffset = readerTzInfo.initialOffset;
+      this.readerRawOffset = readerTzInfo.rawOffset;
+      this.readerDstRule = dstRuleToArray(readerTzInfo.dstRule);
+    }
+
+    private void ensureOpen() {
+      if (closed) {
+        throw new IllegalStateException("ORC timezone context is closed");
+      }
+    }
+
+    @Override
+    public void close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      Table writerTable = writerTzInfoTable;
+      Table readerTable = readerTzInfoTable;
+      writerTzInfoTable = null;
+      readerTzInfoTable = null;
+      Arms.closeAll(writerTable, readerTable);
+    }
+  }
+
+  /**
+   * Build reusable GPU metadata for one ORC writer/reader timezone pair.
+   *
+   * @param writerTimezone writer timezone from ORC stripe metadata
+   * @param readerTimezone reader timezone from the current JVM default timezone
+   * @return a context owned by the caller
+   */
+  public static OrcTimezoneContext buildOrcTimezoneContext(
+      String writerTimezone, String readerTimezone) {
+    OrcTimezoneInfo writerTzInfo = OrcTimezoneInfo.get(writerTimezone);
+    OrcTimezoneInfo readerTzInfo = OrcTimezoneInfo.get(readerTimezone);
+    Table writerTzInfoTable = null;
+    Table readerTzInfoTable = null;
+    try {
+      writerTzInfoTable = getTableForUtilTZ(writerTzInfo);
+      readerTzInfoTable = getTableForUtilTZ(readerTzInfo);
+      return new OrcTimezoneContext(writerTzInfoTable, readerTzInfoTable,
+          writerTimezone, writerTzInfo, readerTzInfo);
+    } catch (RuntimeException | Error e) {
+      try {
+        Arms.closeAll(writerTzInfoTable, readerTzInfoTable);
+      } catch (RuntimeException closeError) {
+        e.addSuppressed(closeError);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Convert timestamps using a pre-built ORC timezone context. This entry point is staged for the
+   * DST-enabled dispatch path so callers can reuse transition tables across timestamp columns.
+   *
+   * @param input input timestamp column in microseconds
+   * @param context writer/reader timezone metadata
+   * @return converted timestamp column
+   */
+  public static ColumnVector convertOrcTimezones(
+      ColumnView input, OrcTimezoneContext context) {
+    context.ensureOpen();
+    return new ColumnVector(convertOrcTimezonesWithRules(
+        input.getNativeView(),
+        context.writerTzOffsetAtOrc2015BaseUs,
+        context.writerTzInfoTable != null ? context.writerTzInfoTable.getNativeView() : 0L,
+        context.writerInitialOffset,
+        context.writerRawOffset,
+        context.writerDstRule,
+        context.readerTzInfoTable != null ? context.readerTzInfoTable.getNativeView() : 0L,
+        context.readerInitialOffset,
+        context.readerRawOffset,
+        context.readerDstRule));
+  }
+
+  private static int[] dstRuleToArray(OrcDstRuleExtractor.DstRule rule) {
+    if (rule == null) {
+      return null;
+    }
+    // Keep this field order synchronized with parse_dst_rule in GpuTimeZoneDBJni.cpp.
+    return new int[]{
+        rule.dstSavings,
+        rule.startMonth,
+        rule.startDay,
+        rule.startDayOfWeek,
+        rule.startTime,
+        rule.startTimeMode,
+        rule.startMode,
+        rule.endMonth,
+        rule.endDay,
+        rule.endDayOfWeek,
+        rule.endTime,
+        rule.endTimeMode,
+        rule.endMode
+    };
   }
 
   /**
@@ -640,4 +764,16 @@ public class GpuTimeZoneDB {
       long writer2015YearBaseOffsetUs,
       long readerTzInfoTable,
       int readerTzRawOffset);
+
+  private static native long convertOrcTimezonesWithRules(
+      long input,
+      long writerTzOffsetAtOrc2015BaseUs,
+      long writerTzInfoTable,
+      int writerTzInitialOffset,
+      int writerTzRawOffset,
+      int[] writerDstRule,
+      long readerTzInfoTable,
+      int readerTzInitialOffset,
+      int readerTzRawOffset,
+      int[] readerDstRule);
 }

--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
@@ -31,8 +31,8 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * Holds ORC timezone metadata generated at runtime from public java.time/java.util APIs.
- * Historical transitions come from ZoneRules, while offsets before the first transition are
- * derived from java.util.TimeZone so ORC rebasing matches
+ * Historical transitions come from ZoneRules, while offsets before the first transition and
+ * future recurring DST behavior are derived from java.util.TimeZone so ORC rebasing matches
  * SerializationUtils.convertBetweenTimezones semantics without relying on non-public ZoneInfo APIs.
  *
  * <p><b>Runtime dependency:</b> because the metadata is generated on the fly from
@@ -43,11 +43,17 @@ import java.util.concurrent.ConcurrentMap;
  * debugging cross-environment differences should first check the JVM's {@code tzdata} version.
  */
 class OrcTimezoneInfo {
-  public OrcTimezoneInfo(int rawOffset, long[] transitions, int[] offsets) {
+  public OrcTimezoneInfo(int initialOffset, int rawOffset, long[] transitions, int[] offsets,
+      OrcDstRuleExtractor.DstRule dstRule) {
+    this.initialOffset = initialOffset;
     this.rawOffset = rawOffset;
     this.transitions = transitions;
     this.offsets = offsets;
+    this.dstRule = dstRule;
   }
+
+  // Historical offset before the first transition, in milliseconds.
+  final int initialOffset;
 
   // in milliseconds
   final int rawOffset;
@@ -57,6 +63,9 @@ class OrcTimezoneInfo {
 
   // in milliseconds
   final int[] offsets;
+
+  // Recurring rule used after the historical transition table, or null for no DST.
+  final OrcDstRuleExtractor.DstRule dstRule;
 
   // Lower bound of the range ORC supports (year 0001-01-01 UTC). Computed via
   // java.time.LocalDate, which uses the proleptic Gregorian calendar, whereas
@@ -86,9 +95,11 @@ class OrcTimezoneInfo {
   @Override
   public String toString() {
     return "OrcTimezoneInfo{" +
-        "rawOffset=" + rawOffset +
+        "initialOffset=" + initialOffset +
+        ", rawOffset=" + rawOffset +
         ", transitions=" + Arrays.toString(transitions) +
         ", offsets=" + Arrays.toString(offsets) +
+        ", dstRule=" + dstRule +
         '}';
   }
 
@@ -134,7 +145,7 @@ class OrcTimezoneInfo {
       // maps them to GMT (offset 0). Derive the offset from ZoneRules instead so
       // the GPU path doesn't treat them as UTC.
       int fixedOffsetMs = rules.getOffset(Instant.EPOCH).getTotalSeconds() * 1000;
-      return new OrcTimezoneInfo(fixedOffsetMs, null, null);
+      return new OrcTimezoneInfo(fixedOffsetMs, fixedOffsetMs, null, null, null);
     }
     // Use the canonical ID from the resolved ZoneId (e.g. "Asia/Kolkata" for
     // input "IST") so that TimeZone and ZoneRules always refer to the same
@@ -144,13 +155,17 @@ class OrcTimezoneInfo {
     // zone on some JVM distributions, which would silently produce mixed
     // offset data with no exception.
     TimeZone tz = TimeZone.getTimeZone(zoneId.getId());
+    int initialOffset = getInitialOffset(tz);
+    OrcDstRuleExtractor.DstRule dstRule =
+        OrcDstRuleExtractor.extractDstRule(timezoneId, tz, rules);
     List<ZoneOffsetTransition> transitionList = rules.getTransitions();
     HistoricalTransitions historicalTransitions = buildHistoricalTransitions(tz, transitionList);
     if (historicalTransitions.transitions == null) {
-      return new OrcTimezoneInfo(tz.getRawOffset(), null, null);
+      return new OrcTimezoneInfo(initialOffset, tz.getRawOffset(), null, null, dstRule);
     }
-    return new OrcTimezoneInfo(tz.getRawOffset(),
-        historicalTransitions.transitions, historicalTransitions.offsets);
+    return new OrcTimezoneInfo(initialOffset,
+        tz.getRawOffset(), historicalTransitions.transitions, historicalTransitions.offsets,
+        dstRule);
   }
 
   /**

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -76,9 +76,11 @@ public class OrcTimezoneInfoTest {
     // would silently map "+05:30" to GMT). +05:30 == 19_800_000 ms.
     OrcTimezoneInfo info = OrcTimezoneInfo.get("+05:30");
     assertNotNull(info);
+    assertEquals(19_800_000, info.initialOffset);
     assertEquals(19_800_000, info.rawOffset);
     assertNull(info.transitions);
     assertNull(info.offsets);
+    assertNull(info.dstRule);
   }
 
   @Test
@@ -89,9 +91,11 @@ public class OrcTimezoneInfoTest {
     // TimeZone.getTimeZone — is caught. rawOffset must be 0.
     OrcTimezoneInfo info = OrcTimezoneInfo.get("UTC");
     assertNotNull(info);
+    assertEquals(0, info.initialOffset);
     assertEquals(0, info.rawOffset);
     assertNull(info.transitions);
     assertNull(info.offsets);
+    assertNull(info.dstRule);
   }
 
   @Test
@@ -147,6 +151,7 @@ public class OrcTimezoneInfoTest {
     assertNotNull(info);
     assertNotNull(info.transitions, "Asia/Shanghai should have historical transitions");
     assertNotNull(info.offsets);
+    assertNull(info.dstRule);
     assertEquals(info.transitions.length, info.offsets.length,
         "transitions and offsets must be the same length");
     // Transitions must be strictly increasing so the GPU binary search is well-defined.
@@ -156,7 +161,20 @@ public class OrcTimezoneInfoTest {
     }
   }
 
-  // ---- DST rule extraction (Part 2 — not wired into production yet) ----
+  @Test
+  void testGetDstZoneIncludesKernelMetadata() {
+    String timezoneId = "America/New_York";
+    OrcTimezoneInfo info = OrcTimezoneInfo.get(timezoneId);
+    TimeZone tz = TimeZone.getTimeZone(GpuTimeZoneDB.getZoneId(timezoneId).getId());
+
+    assertEquals(tz.getOffset(OrcTimezoneInfo.utcMillisForDate(1, 1, 1)), info.initialOffset);
+    assertEquals(tz.getRawOffset(), info.rawOffset);
+    assertNotNull(info.transitions);
+    assertNotNull(info.offsets);
+    assertNotNull(info.dstRule);
+  }
+
+  // ---- DST rule extraction ----
 
   @Test
   void testExtractDstRuleNorthernHemisphere() {


### PR DESCRIPTION
## Context

Part 4 of the split of #4432.

Merged prerequisites:
- Part 1: #4539
- Part 2: #4635
- Part 3: #4733

Additional prerequisite:
- ORC 2015 base-offset borrow correction: #4809

The end-to-end cudf-spark consumer remains tracked by NVIDIA/cudf-spark#14544.

## Changes

- Extend runtime `OrcTimezoneInfo` metadata with the historical initial offset and the recurring
  `OrcDstRuleExtractor.DstRule` produced by Part 2.
- Add a reusable `GpuTimeZoneDB.OrcTimezoneContext` that owns writer/reader transition tables on
  the GPU and stores the writer timezone offset at ORC's 2015 base timestamp.
- Serialize the 13 recurring-rule fields in a stable Java/JNI order.
- Add `convertOrcTimezonesWithRules` JNI plumbing that invokes the DST-capable native API added in
  Part 3.
- Add focused metadata tests for fixed, historical non-DST, and recurring-DST zones.

## Behavior

Production behavior is unchanged in this part. The existing public conversion path retains its DST
gate and continues to use the existing non-DST JNI entry point. The new full-path context API is
staged for Part 5.

## Verification

- Repository-pinned clang-format 20.1.8
- `git diff --check`
- Pre-commit hooks
- Build and tests were not run locally; CI will run them.

Signed-off-by: Chong Gao <chongg@nvidia.com>
