### PR TITLE
[Part 5] [ORC-timezone]: Enable DST-aware ORC timezone conversion

### DIFF
--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -100,35 +100,6 @@ Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertTimestampColumnToUTCWithTz
   JNI_CATCH(env, 0);
 }
 
-JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOrcTimezones(
-  JNIEnv* env,
-  jclass,
-  jlong input_handle,
-  jlong writer_tz_info_table,
-  jint writer_tz_raw_offset,
-  jlong writer_2015_year_base_offset_us,
-  jlong reader_tz_info_table,
-  jint reader_tz_raw_offset)
-{
-  JNI_NULL_CHECK(env, input_handle, "input column is null", 0);
-
-  JNI_TRY
-  {
-    cudf::jni::auto_set_device(env);
-    auto const input              = reinterpret_cast<cudf::column_view const*>(input_handle);
-    auto const writer_tz_info_tab = reinterpret_cast<cudf::table_view const*>(writer_tz_info_table);
-    auto const reader_tz_info_tab = reinterpret_cast<cudf::table_view const*>(reader_tz_info_table);
-    return cudf::jni::release_as_jlong(spark_rapids_jni::convert_orc_writer_reader_timezones(
-      *input,
-      writer_tz_info_tab,
-      writer_tz_raw_offset,
-      static_cast<int64_t>(writer_2015_year_base_offset_us),
-      reader_tz_info_tab,
-      reader_tz_raw_offset));
-  }
-  JNI_CATCH(env, 0);
-}
-
 static spark_rapids_jni::dst_rule parse_dst_rule(JNIEnv* env, jintArray java_rule)
 {
   spark_rapids_jni::dst_rule rule{};

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -693,14 +693,6 @@ public class GpuTimeZoneDB {
   }
 
   /**
-   * Does the given timezone have Daylight Saving Time(DST) rules.
-   */
-  private static boolean hasDaylightSavingTime(String timezoneId) {
-    ZoneId zoneId = ZoneId.of(timezoneId, ZoneId.SHORT_IDS);
-    return !zoneId.getRules().getTransitionRules().isEmpty();
-  }
-
-  /**
    * Convert timestamps between writer/reader timezones for ORC reading.
    * Similar to Apache ORC, this first reconstructs the timestamp from ORC's
    * writer-timezone 2015 base instant and applies the negative nanos borrow,
@@ -721,33 +713,9 @@ public class GpuTimeZoneDB {
       ColumnVector input,
       String writerTimezone,
       String readerTimezone) {
-    // Does not support DST timezone now, just throw exception.
-    if (hasDaylightSavingTime(writerTimezone) ||
-        hasDaylightSavingTime(readerTimezone)) {
-      throw new UnsupportedOperationException("Daylight Saving Time is not supported now.");
-    }
-
-    // get timezone info from `java.util.TimeZone`
-    OrcTimezoneInfo writerTzInfo = OrcTimezoneInfo.get(writerTimezone);
-    OrcTimezoneInfo readerTzInfo = OrcTimezoneInfo.get(readerTimezone);
-    try (Table writerTzInfoTable = getTableForUtilTZ(writerTzInfo);
-        Table readerTzInfoTable = getTableForUtilTZ(readerTzInfo)) {
-
-      // ORC first reconstructs the timestamp using the writer timezone's 2015 base instant,
-      // including any DST offset in effect at that instant, then applies the negative nanos borrow.
-      // The native path applies this adjustment before matching ORC's writer/reader timezone
-      // conversion.
-      long writer2015YearBaseOffsetUs = TimeUnit.MILLISECONDS.toMicros(
-          getOrc2015YearBaseOffsetMillis(writerTimezone, writerTzInfo));
-      return new ColumnVector(convertOrcTimezones(
-          input.getNativeView(),
-          writerTzInfoTable != null ? writerTzInfoTable.getNativeView() : 0L,
-          writerTzInfo.rawOffset,
-          writer2015YearBaseOffsetUs,
-          readerTzInfoTable != null ? readerTzInfoTable.getNativeView() : 0L,
-          readerTzInfo.rawOffset));
-    } catch (Exception e) {
-      throw new IllegalStateException("convert between timezones failed!", e);
+    try (OrcTimezoneContext context =
+        buildOrcTimezoneContext(writerTimezone, readerTimezone)) {
+      return convertOrcTimezones(input, context);
     }
   }
 
@@ -758,14 +726,6 @@ public class GpuTimeZoneDB {
   private static native long convertTimestampColumnToUTCWithTzCv(
       long input_seconds, long input_microseconds, long invalid, long tzType,
       long tzOffset, long timezoneInfo, long tzIndex);
-
-  private static native long convertOrcTimezones(
-      long input,
-      long writerTzInfoTable,
-      int writerTzRawOffset,
-      long writer2015YearBaseOffsetUs,
-      long readerTzInfoTable,
-      int readerTzRawOffset);
 
   private static native long convertOrcTimezonesWithRules(
       long input,

--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcDstRuleExtractor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcDstRuleExtractor.java
@@ -120,16 +120,19 @@ final class OrcDstRuleExtractor {
     // Sanity-check that tz and rules describe the same zone. Both Path A and
     // Path B assume this, but the two-argument signature lets a caller pass
     // mismatched objects (the silent-GMT trap above is one way this can
-    // happen). Compare standard offsets at a recent reference instant -- the
+    // happen). Compare actual offsets at a recent reference instant -- the
     // epoch is unsafe because some zones (e.g. Europe/London) were on a
-    // different standard offset in 1970 (British Standard Time experiment).
+    // different standard offset in 1970 (British Standard Time experiment),
+    // while the current raw offset is unsafe because a zone's standard offset
+    // may have changed after the reference instant.
     Instant ref = Instant.parse("2024-01-15T00:00:00Z");
-    int rulesStandardOffsetMillis = rules.getStandardOffset(ref).getTotalSeconds() * 1000;
-    if (tz.getRawOffset() != rulesStandardOffsetMillis) {
+    int timeZoneOffsetMillis = tz.getOffset(ref.toEpochMilli());
+    int rulesOffsetMillis = rules.getOffset(ref).getTotalSeconds() * 1000;
+    if (timeZoneOffsetMillis != rulesOffsetMillis) {
       throw new IllegalStateException(
           "TimeZone and ZoneRules describe different zones for timezone: " + timezoneId
-              + " (tz.rawOffset=" + tz.getRawOffset()
-              + ", rules.standardOffset=" + rulesStandardOffsetMillis + ")");
+              + " (tz.offset=" + timeZoneOffsetMillis
+              + ", rules.offset=" + rulesOffsetMillis + ")");
     }
     DstRule rule = extractDstRuleByProbing(tz);
     if (rule != null) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
@@ -212,6 +212,7 @@ class OrcTimezoneInfo {
     List<Integer> offsets = new ArrayList<>();
     long scanCursor = MIN_SUPPORTED_ORC_UTC_MILLIS;
     int currentOffset = getInitialOffset(tz);
+    boolean hasPreviousCandidate = false;
 
     for (ZoneOffsetTransition transition : transitionList) {
       long transitionMs = transition.getInstant().toEpochMilli();
@@ -221,18 +222,19 @@ class OrcTimezoneInfo {
 
       long beforeTransitionMs = transitionMs - 1;
       int offsetBeforeTransition = tz.getOffset(beforeTransitionMs);
-      // Invariant: between two consecutive entries returned by
-      // ZoneRules.getTransitions(), the wall offset is constant — no hidden
-      // paired round-trips (e.g. A->B->A) net to zero between entries. If
-      // that ever breaks (DST zones, future tzdata revisions), the guard
-      // below will not fire and both transitions in the pair will be
-      // silently dropped. ZoneRules enumerates every transition for this zone,
-      // while the TimeZone gap scan below reconciles any offset differences
-      // between the two APIs using a six-hour base probe that is shorter than
-      // the minimum spacing between real IANA transitions.
-      if (beforeTransitionMs >= scanCursor && offsetBeforeTransition != currentOffset) {
-        currentOffset = collectTimeZoneTransitionsByScanning(
-            tz, scanCursor, beforeTransitionMs, currentOffset, transitions, offsets);
+      if (beforeTransitionMs >= scanCursor) {
+        if (hasPreviousCandidate) {
+          // Reconcile every interval between ZoneRules candidates. Endpoints with the same
+          // offset do not prove that the interval is transition-free: TimeZone may contain an
+          // A -> B -> A round trip that ZoneRules does not expose.
+          currentOffset = collectTimeZoneTransitionsByScanning(
+              tz, scanCursor, beforeTransitionMs, currentOffset, transitions, offsets);
+        } else if (offsetBeforeTransition != currentOffset) {
+          // Keep the year-0001-to-first-candidate path logarithmic. ZoneRules has no candidate
+          // in this interval, which is typically about 1,900 years long.
+          currentOffset = collectInitialTimeZoneTransitions(
+              tz, scanCursor, beforeTransitionMs, currentOffset, transitions, offsets);
+        }
       }
 
       int offsetAtTransition = tz.getOffset(transitionMs);
@@ -241,7 +243,19 @@ class OrcTimezoneInfo {
         offsets.add(offsetAtTransition);
         currentOffset = offsetAtTransition;
       }
-      scanCursor = transitionMs;
+
+      // Some JDK tzdata versions expose a ZoneRules candidate that TimeZone observes for only
+      // one millisecond. Sampling T+1 catches that immediate return and anchors the following
+      // bounded scan with the correct running offset.
+      long afterTransitionMs = transitionMs + 1;
+      int offsetAfterTransition = tz.getOffset(afterTransitionMs);
+      if (offsetAfterTransition != currentOffset) {
+        transitions.add(afterTransitionMs);
+        offsets.add(offsetAfterTransition);
+        currentOffset = offsetAfterTransition;
+      }
+      scanCursor = afterTransitionMs;
+      hasPreviousCandidate = true;
     }
 
     if (transitions.isEmpty()) {
@@ -250,7 +264,7 @@ class OrcTimezoneInfo {
     return new HistoricalTransitions(toLongArray(transitions), toIntArray(offsets));
   }
 
-  private static int collectTimeZoneTransitionsByScanning(
+  static int collectTimeZoneTransitionsByScanning(
       TimeZone tz,
       long scanStartMs,
       long scanEndMs,
@@ -260,15 +274,34 @@ class OrcTimezoneInfo {
     long cursor = scanStartMs;
     int currentOffset = startOffset;
     while (cursor < scanEndMs) {
-      // Exponentially expand the probe step while the offset stays equal to
-      // currentOffset. This collapses long no-transition stretches (e.g. the
-      // year-0001-to-first-historical-transition gap, ~1880 years for typical
-      // IANA zones) from O(N) day probes to O(log N). Once the probe lands on
-      // a different offset, the [lo, hi] bracket contains a transition and we
-      // hand it to binarySearchTransition. The bracket may be wider than the
-      // base 6h step, so this assumes at most one offset transition lives in
-      // the expanded window — which holds for real IANA data; A->B->A pairs
-      // narrower than the base step are addressed separately by the step size.
+      long lo = cursor;
+      long hi = Math.min(lo + HISTORICAL_TRANSITION_SCAN_STEP_MILLIS, scanEndMs);
+      int hiOffset = tz.getOffset(hi);
+      if (hiOffset == currentOffset) {
+        cursor = hi;
+        continue;
+      }
+
+      long exactTransition = binarySearchTransition(tz, lo, hi);
+      int offsetAfterTransition = tz.getOffset(exactTransition);
+      transitions.add(exactTransition);
+      offsets.add(offsetAfterTransition);
+      currentOffset = offsetAfterTransition;
+      cursor = exactTransition;
+    }
+    return currentOffset;
+  }
+
+  private static int collectInitialTimeZoneTransitions(
+      TimeZone tz,
+      long scanStartMs,
+      long scanEndMs,
+      int startOffset,
+      List<Long> transitions,
+      List<Integer> offsets) {
+    long cursor = scanStartMs;
+    int currentOffset = startOffset;
+    while (cursor < scanEndMs) {
       long lo = cursor;
       long step = HISTORICAL_TRANSITION_SCAN_STEP_MILLIS;
       long hi = Math.min(lo + step, scanEndMs);
@@ -280,7 +313,6 @@ class OrcTimezoneInfo {
         hiOffset = tz.getOffset(hi);
       }
       if (hiOffset == currentOffset) {
-        // Reached scanEndMs without seeing any transition.
         cursor = hi;
         continue;
       }

--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
@@ -226,9 +226,10 @@ class OrcTimezoneInfo {
       // paired round-trips (e.g. A->B->A) net to zero between entries. If
       // that ever breaks (DST zones, future tzdata revisions), the guard
       // below will not fire and both transitions in the pair will be
-      // silently dropped. The DST guard in
-      // GpuTimeZoneDB.convertOrcTimezones currently keeps this dormant;
-      // any follow-up that relaxes it must revisit this code.
+      // silently dropped. ZoneRules enumerates every transition for this zone,
+      // while the TimeZone gap scan below reconciles any offset differences
+      // between the two APIs using a six-hour base probe that is shorter than
+      // the minimum spacing between real IANA transitions.
       if (beforeTransitionMs >= scanCursor && offsetBeforeTransition != currentOffset) {
         currentOffset = collectTimeZoneTransitionsByScanning(
             tz, scanCursor, beforeTransitionMs, currentOffset, transitions, offsets);

--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfo.java
@@ -201,7 +201,7 @@ class OrcTimezoneInfo {
     return tz.getOffset(MIN_SUPPORTED_ORC_UTC_MILLIS);
   }
 
-  private static HistoricalTransitions buildHistoricalTransitions(
+  static HistoricalTransitions buildHistoricalTransitions(
       TimeZone tz,
       List<ZoneOffsetTransition> transitionList) {
     if (transitionList.isEmpty()) {
@@ -358,7 +358,7 @@ class OrcTimezoneInfo {
     return result;
   }
 
-  private static final class HistoricalTransitions {
+  static final class HistoricalTransitions {
     static final HistoricalTransitions EMPTY = new HistoricalTransitions(null, null);
 
     final long[] transitions;

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -138,6 +138,24 @@ public class GpuTimeZoneDBTest {
   }
 
   @Test
+  void testConvertOrcTimezonesPreservesEmptyAndNulls() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    try (ColumnVector input =
+            ColumnVector.timestampMicroSecondsFromBoxedLongs(new Long[] {});
+        ColumnVector actual = GpuTimeZoneDB.convertOrcTimezones(input, "UTC", "UTC")) {
+      assertColumnsAreEqual(input, actual);
+    }
+
+    try (ColumnVector input =
+            ColumnVector.timestampMicroSecondsFromBoxedLongs(null, 0L, null);
+        ColumnVector actual = GpuTimeZoneDB.convertOrcTimezones(input, "UTC", "UTC")) {
+      assertColumnsAreEqual(input, actual);
+    }
+  }
+
+  @Test
   void testConvertOrcTimezonesCorrectsIgnoredWriterTimezoneEpochBorrow() {
     GpuTimeZoneDB.cacheDatabase();
     GpuTimeZoneDB.verifyDatabaseCached();

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
@@ -45,7 +44,7 @@ public class GpuTimeZoneDBTest {
 
   private static long orc2015YearBaseOffsetUs(String timezoneId) {
     OrcTimezoneInfo info = OrcTimezoneInfo.get(timezoneId);
-    if (info.transitions == null) {
+    if (info.transitions == null && info.dstRule == null) {
       return TimeUnit.MILLISECONDS.toMicros(info.rawOffset);
     }
     TimeZone tz = getTimeZoneForOrc(timezoneId);
@@ -128,12 +127,8 @@ public class GpuTimeZoneDBTest {
   @Test
   void testConvertOrcTimezonesRejectsInvalidId() {
     // Invalid timezone IDs must surface an exception rather than silently
-    // falling back to GMT. The DST guard at the top of convertOrcTimezones
-    // calls ZoneId.of(...), so an unknown id will throw before the runtime
-    // build path or the GPU kernel ever runs. We assert the broad
-    // RuntimeException type so this stays a regression guard even if the
-    // exact wrapping (DateTimeException vs IllegalArgumentException vs
-    // IllegalStateException) is refactored later.
+    // falling back to GMT. We assert the broad RuntimeException type so this
+    // stays a regression guard even if the exact wrapping is refactored later.
     GpuTimeZoneDB.cacheDatabase();
     try (ColumnVector input =
         ColumnVector.timestampMicroSecondsFromLongs(new long[] {0L})) {
@@ -168,8 +163,8 @@ public class GpuTimeZoneDBTest {
     long max = LocalDateTime.of(9999, 12, 31, 23, 59, 59)
         .toEpochSecond(ZoneOffset.UTC) * TimeUnit.SECONDS.toMicros(1);
 
-    // use today as the random seed so we get different values each day
-    Random rng = new Random(LocalDate.now().toEpochDay());
+    // Keep the DST matrix deterministic so failures are reproducible.
+    Random rng = new Random(42L);
 
     List<String> timezones = Arrays.asList(
         "America/Los_Angeles",
@@ -182,15 +177,7 @@ public class GpuTimeZoneDBTest {
         "Asia/Tokyo");
 
     for (String writerTz : timezones) {
-      if (GpuTimeZoneDB.isDST(writerTz)) {
-        // currently do not support DST conversions
-        continue;
-      }
       for (String readerTz : timezones) {
-        if (GpuTimeZoneDB.isDST(readerTz)) {
-          // currently do not support DST conversions
-          continue;
-        }
         // Use 1024 as a reasonable batch size for testing timezone conversions.
         long[] microseconds = new long[1024];
         for (int i = 0; i < microseconds.length; ++i) {
@@ -205,6 +192,35 @@ public class GpuTimeZoneDBTest {
             ColumnVector actual = GpuTimeZoneDB.convertOrcTimezones(input, writerTz, readerTz)) {
           assertColumnsAreEqual(expected, actual);
         }
+      }
+    }
+  }
+
+  @Test
+  void testConvertOrcTimezonesFutureDstRuleFallback() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    long[] microseconds = {
+        LocalDateTime.of(9999, 1, 15, 12, 0, 0)
+            .toEpochSecond(ZoneOffset.UTC) * TimeUnit.SECONDS.toMicros(1),
+        LocalDateTime.of(9999, 7, 15, 12, 0, 0)
+            .toEpochSecond(ZoneOffset.UTC) * TimeUnit.SECONDS.toMicros(1)
+    };
+    String[][] cases = {
+        {"America/Los_Angeles", "UTC"},
+        {"UTC", "America/Los_Angeles"},
+        {"Australia/Sydney", "UTC"},
+        {"UTC", "Australia/Sydney"}
+    };
+
+    for (String[] timezones : cases) {
+      try (ColumnVector input = ColumnVector.timestampMicroSecondsFromLongs(microseconds);
+          ColumnVector expected =
+              convertOrcTimezonesOnCPU(microseconds, timezones[0], timezones[1]);
+          ColumnVector actual =
+              GpuTimeZoneDB.convertOrcTimezones(input, timezones[0], timezones[1])) {
+        assertColumnsAreEqual(expected, actual);
       }
     }
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -242,4 +242,29 @@ public class GpuTimeZoneDBTest {
       }
     }
   }
+
+  @Test
+  void testConvertOrcTimezonesAsiaGazaPairedTransitions() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    long[] microseconds = {
+        LocalDateTime.of(2037, 10, 15, 0, 0)
+            .toEpochSecond(ZoneOffset.UTC) * TimeUnit.SECONDS.toMicros(1)
+    };
+    String[][] cases = {
+        {"Asia/Gaza", "UTC"},
+        {"UTC", "Asia/Gaza"}
+    };
+
+    for (String[] timezones : cases) {
+      try (ColumnVector input = ColumnVector.timestampMicroSecondsFromLongs(microseconds);
+          ColumnVector expected =
+              convertOrcTimezonesOnCPU(microseconds, timezones[0], timezones[1]);
+          ColumnVector actual =
+              GpuTimeZoneDB.convertOrcTimezones(input, timezones[0], timezones[1])) {
+        assertColumnsAreEqual(expected, actual);
+      }
+    }
+  }
 }

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -21,12 +21,16 @@ import ai.rapids.cudf.*;
 import org.junit.jupiter.api.Test;
 
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneOffsetTransitionRule;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -72,6 +76,22 @@ public class GpuTimeZoneDBTest {
     boolean apacheAppliesBorrow = adjustedUnborrowedUs < 0 && hasBorrowableFraction;
 
     return adjustedUnborrowedUs - (apacheAppliesBorrow ? MICROS_PER_SECOND : 0L);
+  }
+
+  private static long[] getFutureDstBoundaryMicros(String timezoneId) {
+    List<ZoneOffsetTransitionRule> rules =
+        ZoneId.of(timezoneId).getRules().getTransitionRules();
+    assertEquals(2, rules.size(), "expected two recurring DST rules for " + timezoneId);
+    long[] microseconds = new long[rules.size() * 3];
+    int index = 0;
+    for (ZoneOffsetTransitionRule rule : rules) {
+      ZoneOffsetTransition transition = rule.createTransition(9999);
+      long transitionMillis = transition.getInstant().toEpochMilli();
+      microseconds[index++] = (transitionMillis - 1) * microsPerMillis;
+      microseconds[index++] = transitionMillis * microsPerMillis;
+      microseconds[index++] = (transitionMillis + 1) * microsPerMillis;
+    }
+    return microseconds;
   }
 
   /**
@@ -219,26 +239,21 @@ public class GpuTimeZoneDBTest {
     GpuTimeZoneDB.cacheDatabase();
     GpuTimeZoneDB.verifyDatabaseCached();
 
-    long[] microseconds = {
-        LocalDateTime.of(9999, 1, 15, 12, 0, 0)
-            .toEpochSecond(ZoneOffset.UTC) * TimeUnit.SECONDS.toMicros(1),
-        LocalDateTime.of(9999, 7, 15, 12, 0, 0)
-            .toEpochSecond(ZoneOffset.UTC) * TimeUnit.SECONDS.toMicros(1)
-    };
-    String[][] cases = {
-        {"America/Los_Angeles", "UTC"},
-        {"UTC", "America/Los_Angeles"},
-        {"Australia/Sydney", "UTC"},
-        {"UTC", "Australia/Sydney"}
-    };
+    for (String timezoneId : Arrays.asList("America/Los_Angeles", "Australia/Sydney")) {
+      long[] microseconds = getFutureDstBoundaryMicros(timezoneId);
+      String[][] cases = {
+          {timezoneId, "UTC"},
+          {"UTC", timezoneId}
+      };
 
-    for (String[] timezones : cases) {
-      try (ColumnVector input = ColumnVector.timestampMicroSecondsFromLongs(microseconds);
-          ColumnVector expected =
-              convertOrcTimezonesOnCPU(microseconds, timezones[0], timezones[1]);
-          ColumnVector actual =
-              GpuTimeZoneDB.convertOrcTimezones(input, timezones[0], timezones[1])) {
-        assertColumnsAreEqual(expected, actual);
+      for (String[] timezones : cases) {
+        try (ColumnVector input = ColumnVector.timestampMicroSecondsFromLongs(microseconds);
+            ColumnVector expected =
+                convertOrcTimezonesOnCPU(microseconds, timezones[0], timezones[1]);
+            ColumnVector actual =
+                GpuTimeZoneDB.convertOrcTimezones(input, timezones[0], timezones[1])) {
+          assertColumnsAreEqual(expected, actual);
+        }
       }
     }
   }

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -295,6 +295,14 @@ public class OrcTimezoneInfoTest {
   }
 
   @Test
+  void testExtractDstRuleAfterHistoricalStandardOffsetChange() {
+    // America/Scoresbysund changed its standard offset after the validation reference instant.
+    // TimeZone.getRawOffset() reports the current standard offset, so it cannot be compared with
+    // ZoneRules at that historical instant. The two APIs' actual offsets still agree there.
+    assertNotNull(extractDstRuleFor("America/Scoresbysund"));
+  }
+
+  @Test
   void testExtractDstRuleSouthernHemisphere() {
     // Australia/Sydney: DST starts 1st Sunday of October, ends 1st Sunday of April.
     // Southern hemisphere — start month numerically > end month.
@@ -445,12 +453,16 @@ public class OrcTimezoneInfoTest {
   // across any anchor year and returns null, so extractDstRuleFromZoneRules is
   // invoked with the hand-crafted ZoneRules in each test below.
   private static TimeZone newConstantOffsetWithDstFlag(String id) {
+    return newConstantOffsetWithDstFlag(id, 0);
+  }
+
+  private static TimeZone newConstantOffsetWithDstFlag(String id, int offset) {
     TimeZone tz = new TimeZone() {
-      @Override public int getOffset(long instant) { return 0; }
+      @Override public int getOffset(long instant) { return offset; }
       @Override public int getOffset(int era, int year, int month, int day, int dow, int ms) {
-        return 0;
+        return offset;
       }
-      @Override public int getRawOffset() { return 0; }
+      @Override public int getRawOffset() { return offset; }
       @Override public void setRawOffset(int offsetMillis) {}
       @Override public boolean useDaylightTime() { return true; }
       @Override public boolean inDaylightTime(Date date) { return false; }
@@ -510,9 +522,9 @@ public class OrcTimezoneInfoTest {
 
   @Test
   void testExtractDstRuleThrowsWhenTzAndRulesDescribeDifferentZones() {
-    // The sanity-check in extractDstRule compares tz.getRawOffset() against
-    // rules.getStandardOffset(ref). Pair a constant-zero TimeZone with
-    // ZoneRules for America/New_York (rawOffset = -18_000_000 ms at the
+    // The sanity-check in extractDstRule compares actual offsets at the same
+    // reference instant. Pair a constant-zero TimeZone with ZoneRules for
+    // America/New_York (offset = -18_000_000 ms at the
     // 2024 reference instant) so the check fires before either extraction
     // path runs.
     TimeZone zeroOffsetTz = newConstantOffsetWithDstFlag("Synthetic/OffsetMismatch");
@@ -530,7 +542,8 @@ public class OrcTimezoneInfoTest {
     // both with negative delta — startTransitionRule stays null. Pins the
     // startTransitionRule == null sub-case of the || at line 157 so a future
     // change from || to && cannot slip through.
-    TimeZone tz = newConstantOffsetWithDstFlag("Synthetic/BothNegative");
+    // These malformed rules leave the recurring period at +1h at the validation instant.
+    TimeZone tz = newConstantOffsetWithDstFlag("Synthetic/BothNegative", 3_600_000);
     ZoneOffset base = ZoneOffset.UTC;
     ZoneOffset plus1 = ZoneOffset.ofHours(1);
     ZoneOffsetTransitionRule ruleA = ZoneOffsetTransitionRule.of(

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -232,11 +232,16 @@ public class OrcTimezoneInfoTest {
         ZoneOffset.ofHours(3),
         ZoneOffset.ofHours(2)).getInstant().toEpochMilli();
     int index = Arrays.binarySearch(info.transitions, transition);
+    TimeZone tz = TimeZone.getTimeZone(GpuTimeZoneDB.getZoneId("Asia/Gaza").getId());
+    int offsetAtTransition = tz.getOffset(transition);
+    int offsetAfterTransition = tz.getOffset(transition + 1);
 
     assertTrue(index >= 0, "expected the ZoneRules candidate in the transition table");
-    assertEquals(7_200_000, info.offsets[index]);
-    assertEquals(transition + 1, info.transitions[index + 1]);
-    assertEquals(10_800_000, info.offsets[index + 1]);
+    assertEquals(offsetAtTransition, info.offsets[index]);
+    if (offsetAfterTransition != offsetAtTransition) {
+      assertEquals(transition + 1, info.transitions[index + 1]);
+      assertEquals(offsetAfterTransition, info.offsets[index + 1]);
+    }
   }
 
   // ---- DST rule extraction ----

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -29,6 +29,7 @@ import java.time.ZoneOffset;
 import java.time.zone.ZoneOffsetTransition;
 import java.time.zone.ZoneOffsetTransitionRule;
 import java.time.zone.ZoneRules;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -172,6 +173,70 @@ public class OrcTimezoneInfoTest {
     assertNotNull(info.transitions);
     assertNotNull(info.offsets);
     assertNotNull(info.dstRule);
+  }
+
+  @Test
+  void testScannerRetainsPairedTransitionsBetweenEqualEndpoints() {
+    long firstTransition = 8L * 3_600_000L;
+    long secondTransition = 16L * 3_600_000L;
+    TimeZone pairedTransitions = new TimeZone() {
+      private int rawOffset;
+
+      @Override
+      public int getOffset(long date) {
+        return date >= firstTransition && date < secondTransition ? 3_600_000 : 0;
+      }
+
+      @Override
+      public int getOffset(int era, int year, int month, int day,
+          int dayOfWeek, int milliseconds) {
+        return rawOffset;
+      }
+
+      @Override
+      public void setRawOffset(int offsetMillis) {
+        rawOffset = offsetMillis;
+      }
+
+      @Override
+      public int getRawOffset() {
+        return rawOffset;
+      }
+
+      @Override
+      public boolean useDaylightTime() {
+        return true;
+      }
+
+      @Override
+      public boolean inDaylightTime(Date date) {
+        return getOffset(date.getTime()) != rawOffset;
+      }
+    };
+
+    List<Long> transitions = new ArrayList<>();
+    List<Integer> offsets = new ArrayList<>();
+    int finalOffset = OrcTimezoneInfo.collectTimeZoneTransitionsByScanning(
+        pairedTransitions, 0L, 24L * 3_600_000L, 0, transitions, offsets);
+
+    assertEquals(Arrays.asList(firstTransition, secondTransition), transitions);
+    assertEquals(Arrays.asList(3_600_000, 0), offsets);
+    assertEquals(0, finalOffset);
+  }
+
+  @Test
+  void testAsiaGazaRetainsImmediateOffsetReturn() {
+    OrcTimezoneInfo info = OrcTimezoneInfo.get("Asia/Gaza");
+    long transition = ZoneOffsetTransition.of(
+        LocalDateTime.of(2037, 10, 10, 2, 0),
+        ZoneOffset.ofHours(3),
+        ZoneOffset.ofHours(2)).getInstant().toEpochMilli();
+    int index = Arrays.binarySearch(info.transitions, transition);
+
+    assertTrue(index >= 0, "expected the ZoneRules candidate in the transition table");
+    assertEquals(7_200_000, info.offsets[index]);
+    assertEquals(transition + 1, info.transitions[index + 1]);
+    assertEquals(10_800_000, info.offsets[index + 1]);
   }
 
   // ---- DST rule extraction ----

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -222,6 +223,58 @@ public class OrcTimezoneInfoTest {
     assertEquals(Arrays.asList(firstTransition, secondTransition), transitions);
     assertEquals(Arrays.asList(3_600_000, 0), offsets);
     assertEquals(0, finalOffset);
+  }
+
+  @Test
+  void testBuilderScansPairedTransitionsBetweenEqualCandidateEndpoints() {
+    long firstHiddenTransition = 8L * 3_600_000L;
+    long secondHiddenTransition = 16L * 3_600_000L;
+    TimeZone pairedTransitions = new TimeZone() {
+      private int rawOffset;
+
+      @Override
+      public int getOffset(long date) {
+        return date >= firstHiddenTransition && date < secondHiddenTransition ? 3_600_000 : 0;
+      }
+
+      @Override
+      public int getOffset(int era, int year, int month, int day,
+          int dayOfWeek, int milliseconds) {
+        return rawOffset;
+      }
+
+      @Override
+      public void setRawOffset(int offsetMillis) {
+        rawOffset = offsetMillis;
+      }
+
+      @Override
+      public int getRawOffset() {
+        return rawOffset;
+      }
+
+      @Override
+      public boolean useDaylightTime() {
+        return true;
+      }
+
+      @Override
+      public boolean inDaylightTime(Date date) {
+        return getOffset(date.getTime()) != rawOffset;
+      }
+    };
+    List<ZoneOffsetTransition> candidates = Arrays.asList(
+        ZoneOffsetTransition.of(LocalDateTime.of(1970, 1, 1, 4, 0),
+            ZoneOffset.UTC, ZoneOffset.ofHours(1)),
+        ZoneOffsetTransition.of(LocalDateTime.of(1970, 1, 1, 20, 0),
+            ZoneOffset.UTC, ZoneOffset.ofHours(1)));
+
+    OrcTimezoneInfo.HistoricalTransitions actual =
+        OrcTimezoneInfo.buildHistoricalTransitions(pairedTransitions, candidates);
+
+    assertArrayEquals(new long[] {firstHiddenTransition, secondHiddenTransition},
+        actual.transitions);
+    assertArrayEquals(new int[] {3_600_000, 0}, actual.offsets);
   }
 
   @Test


### PR DESCRIPTION
## Context

Part 5 of the split of #4432 and the only split part that enables recurring-DST conversion in the
existing public dispatch path.

Prerequisites:
- Part 1: #4539
- Part 2: #4635
- Part 3: #4733
- ORC 2015 base-offset borrow correction: #4809
- Part 4: #4812

The end-to-end cudf-spark consumer remains tracked by NVIDIA/cudf-spark#14544.

## Changes

- Remove the Java DST gate from `GpuTimeZoneDB.convertOrcTimezones`.
- Route fixed, historical, and recurring-DST zones through the reusable full-path timezone context.
- Remove the superseded raw JNI entry point.
- Enable DST writer/reader pairs in the deterministic Java conversion matrix.
- Add a focused year-9999 test for northern- and southern-hemisphere recurring-rule fallback.
- Keep the ORC 2015 base-offset borrow regression from #4809 active for same-timezone conversion.

## Behavior

This part changes runtime behavior: ORC writer/reader timezone conversion now supports recurring DST
rules instead of rejecting DST zones.

## Verification

- Repository-pinned clang-format 20.1.8
- `git diff --check`
- Pre-commit hooks
- Build and tests were not run locally; CI will run them.

Signed-off-by: Chong Gao <chongg@nvidia.com>
