### PR TITLE
Move `NativeDepsLoaderTest` to run on a forked JVM

### DIFF
--- a/ci/nightly-build.sh
+++ b/ci/nightly-build.sh
@@ -56,7 +56,7 @@ ${MVN} clean package ${MVN_MIRROR}  \
   -P${profiles} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
+  -DUSE_GDS=${USE_GDS} -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest,!NativeDepsLoaderTest \
   -DBUILD_TESTS=ON \
   -DBUILD_BENCHMARKS=ON \
   -DBUILD_FAULTINJ=${BUILD_FAULTINJ} \

--- a/ci/premerge-build.sh
+++ b/ci/premerge-build.sh
@@ -39,7 +39,7 @@ ${MVN} verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
   -DUSE_GDS=ON \
-  -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
+  -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest,!NativeDepsLoaderTest \
   -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON \
   -DBUILD_FAULTINJ=${BUILD_FAULTINJ} \
   -DBUILD_PROFILER=${BUILD_PROFILER}

--- a/ci/submodule-sync.sh
+++ b/ci/submodule-sync.sh
@@ -116,7 +116,7 @@ set +e
 ${MVN} clean verify ${MVN_MIRROR} \
   -DCPP_PARALLEL_LEVEL=${PARALLEL_LEVEL} \
   -Dlibcudf.build.configure=true \
-  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest \
+  -DUSE_GDS=ON -Dtest=*,!CuFileTest,!CudaFatalTest,!ColumnViewNonEmptyNullsTest,!NativeDepsLoaderTest \
   -DBUILD_TESTS=ON \
   -DUSE_SANITIZER=ON
 verify_status=$?

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
                     <exclude>**/CuFileTest.java</exclude>
                     <exclude>**/CudaFatalTest.java</exclude>
                     <exclude>**/ColumnViewNonEmptyNullsTest.java</exclude>
+                    <exclude>**/NativeDepsLoaderTest.java</exclude>
                   </excludes>
                 </configuration>
               </execution>
@@ -256,6 +257,9 @@
                 <configuration>
                   <groups>!noSanitizer</groups>
                   <jvm>${project.basedir}/build/sanitizer-java/bin/java</jvm>
+                  <excludes>
+                    <exclude>**/NativeDepsLoaderTest.java</exclude>
+                  </excludes>
                 </configuration>
               </execution>
               <execution>
@@ -617,6 +621,18 @@
           </dependency>
         </dependencies>
         <executions>
+          <!-- NativeDepsLoaderTest sets lib-native-dir before NativeDepsLoader initializes. -->
+          <execution>
+            <id>native-deps-loader-test</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <reuseForks>false</reuseForks>
+              <test>NativeDepsLoaderTest</test>
+            </configuration>
+          </execution>
           <execution>
             <id>default-test</id>
             <goals>
@@ -626,6 +642,7 @@
               <excludes>
                 <exclude>**/CudaFatalTest.java</exclude>
                 <exclude>**/ColumnViewNonEmptyNullsTest.java</exclude>
+                <exclude>**/NativeDepsLoaderTest.java</exclude>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
Fixes #4810.

This commit moves `NativeDepsLoaderTest` to a forked JVM.

Per #4810, this test began failing after https://github.com/rapidsai/cudf/pull/22592 was merged in cuDF.  This is because `NativeDepsLoaderTest` expects that the native libraries aren't loaded before the test starts.  When the test is run from `spark-rapids-jni`, it currently reuses the JVM instead of forking a new one.

cuDF-java's pom addresses this for cuDF via the changes seen [here](https://github.com/rapidsai/cudf/blame/4526245bca583f897773805b659c56b6821f7f66/java/pom.xml#L274).

This commit makes a similar change in `spark-rapids-jni`'s pom, so as to stop reusing forked JVMs.
Some additional changes had to be made to the CI scripts, to ensure that this test is still run when `mvn test` is invoked.

The `thirdparty/cudf` submodule has been update to latest.
