### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.08 to release/26.08 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -57,7 +57,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "7351c59e68468478811a4988bebef46ff0c0acba",
+      "git_tag" : "72c3cff44cee25b0ef3e7f34ec7ff10d18227950",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
       "version" : "26.08"
@@ -89,7 +89,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "16536f935be084429c0fdcecca788656d2b881c2",
+      "git_tag" : "374bf81ff1345316b584b00372d733aaab60398c",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.08"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: 4055fd9ab991f1248bb4d253359d22fbc8105b6e, cudf commit SHA: https://github.com/rapidsai/cudf/commit/9a6de5926b852369aaac97a3300b61deb0faf3ba

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.