### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.08 to release/26.08 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -57,7 +57,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "72c3cff44cee25b0ef3e7f34ec7ff10d18227950",
+      "git_tag" : "93606c074f3d863a7052af25afae569f72cb3304",
       "git_url" : "https://github.com/rapidsai/kvikio.git",
       "source_subdir" : "cpp",
       "version" : "26.08"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: fdf81a34ecaa4751a9020ee9248d866213636fbb, cudf commit SHA: https://github.com/rapidsai/cudf/commit/9b00d888c77f2cfb6c2f67b810d1047e4d4a7f1c

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.