### PR TITLE
[submodule-sync] bot-submodule-sync-release/26.08 to release/26.08 [skip ci] [bot]

### DIFF
--- a/thirdparty/cudf-pins/versions.json
+++ b/thirdparty/cudf-pins/versions.json
@@ -89,7 +89,7 @@
     {
       "always_download" : true,
       "git_shallow" : false,
-      "git_tag" : "374bf81ff1345316b584b00372d733aaab60398c",
+      "git_tag" : "1a39f9e81c467b1a9522a4dcec8b5581ae165fef",
       "git_url" : "https://github.com/rapidsai/rmm.git",
       "source_subdir" : "cpp",
       "version" : "26.08"


### PR DESCRIPTION
submodule-sync to create a PR keeping thirdparty/cudf up-to-date.
HEAD commit SHA: 91d7a0ad46eb68b00e09bbe95414d29a7c42e22f, cudf commit SHA: https://github.com/rapidsai/cudf/commit/9b00d888c77f2cfb6c2f67b810d1047e4d4a7f1c

This PR will be auto-merged if test passed. If failed, it will remain open until test pass or manually fix.