### PR TITLE
Fix profile converter crash on markers with missing strings

### DIFF
--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -687,7 +687,12 @@ void convert_to_nvtxt(std::ifstream& in, std::ostream& out, program_options cons
               category = it->second->category();
             }
             marker_start ms{
-              m->timestamp(), process_id, thread_id, color, category, m->name()->str()};
+              m->timestamp(),
+              process_id,
+              thread_id,
+              color,
+              category,
+              m->name() ? m->name()->str() : ""};
             auto [ignored, inserted] = marker_start_map.insert({m->id(), ms});
             if (not inserted) {
               std::ostringstream oss;
@@ -970,8 +975,8 @@ int convert_to_nvtxw(std::ifstream& in,
                             thread_id,
                             color,
                             category,
-                            m->name()->str(),
-                            m->domain()->str()};
+                            m->name() ? m->name()->str() : "",
+                            m->domain() ? m->domain()->str() : ""};
             auto [ignored, inserted] = marker_start_map.insert({m->id(), ms});
             if (not inserted) {
               std::ostringstream oss;

--- a/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
+++ b/src/main/cpp/profiler/spark_rapids_profile_converter.cpp
@@ -686,13 +686,12 @@ void convert_to_nvtxt(std::ifstream& in, std::ostream& out, program_options cons
               color    = it->second->color();
               category = it->second->category();
             }
-            marker_start ms{
-              m->timestamp(),
-              process_id,
-              thread_id,
-              color,
-              category,
-              m->name() ? m->name()->str() : ""};
+            marker_start ms{m->timestamp(),
+                            process_id,
+                            thread_id,
+                            color,
+                            category,
+                            m->name() ? m->name()->str() : ""};
             auto [ignored, inserted] = marker_start_map.insert({m->id(), ms});
             if (not inserted) {
               std::ostringstream oss;


### PR DESCRIPTION
## Summary

- treat absent NVTX marker names as empty strings during NVTXT conversion
- treat absent marker names and domains as empty strings during direct NVTXW conversion
- prevent valid profiler output from crashing the offline converter

Fixes #4895.

## Test plan

- [x] `git diff --check`
- [x] built `spark_rapids_profile_converter` from current `main`
- [x] reproduced the pre-fix SIGSEGV under GDB at the unchecked `m->domain()->str()` dereference
- [x] rebuilt with the fix and processed the affected customer profile beyond the marker that previously crashed
- [ ] complete conversion of the 15 GB decompressed profile is still running; the PR will be updated with the final result