### PR TITLE
Fix ORC timezone conversion semantics

### DIFF
--- a/src/main/cpp/src/GpuTimeZoneDBJni.cpp
+++ b/src/main/cpp/src/GpuTimeZoneDBJni.cpp
@@ -140,7 +140,8 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOr
   jlong reader_tz_info_table,
   jint reader_tz_initial_offset,
   jint reader_tz_raw_offset,
-  jintArray reader_dst_rule)
+  jintArray reader_dst_rule,
+  jboolean writer_reader_rules_differ)
 {
   JNI_NULL_CHECK(env, input_handle, "input column is null", 0);
 
@@ -160,7 +161,38 @@ JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOr
     auto const reader = spark_rapids_jni::orc_tz_side{
       reader_tz_info_tab, reader_tz_initial_offset, reader_tz_raw_offset, reader_dst};
     return cudf::jni::release_as_jlong(spark_rapids_jni::convert_orc_writer_reader_timezones(
-      *input, static_cast<int64_t>(writer_tz_offset_at_orc_2015_base_us), writer, reader));
+      *input,
+      static_cast<int64_t>(writer_tz_offset_at_orc_2015_base_us),
+      writer,
+      reader,
+      cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref(),
+      writer_reader_rules_differ));
+  }
+  JNI_CATCH(env, 0);
+}
+
+JNIEXPORT jlong JNICALL Java_com_nvidia_spark_rapids_jni_GpuTimeZoneDB_convertOrcFromUtcWithRules(
+  JNIEnv* env,
+  jclass,
+  jlong input_handle,
+  jlong reader_tz_info_table,
+  jint reader_tz_initial_offset,
+  jint reader_tz_raw_offset,
+  jintArray reader_dst_rule)
+{
+  JNI_NULL_CHECK(env, input_handle, "input column is null", 0);
+
+  JNI_TRY
+  {
+    cudf::jni::auto_set_device(env);
+    auto const input              = reinterpret_cast<cudf::column_view const*>(input_handle);
+    auto const reader_tz_info_tab = reinterpret_cast<cudf::table_view const*>(reader_tz_info_table);
+    auto const reader_dst         = parse_dst_rule(env, reader_dst_rule);
+    cudf::jni::check_java_exception(env);
+    auto const reader = spark_rapids_jni::orc_tz_side{
+      reader_tz_info_tab, reader_tz_initial_offset, reader_tz_raw_offset, reader_dst};
+    return cudf::jni::release_as_jlong(spark_rapids_jni::convert_orc_from_utc(*input, reader));
   }
   JNI_CATCH(env, 0);
 }

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -817,9 +817,12 @@ __device__ cudf::timestamp_us convert_orc_from_utc_value(cudf::timestamp_us valu
                                                          tz_side_info const& reader)
 {
   auto const value_us = value.time_since_epoch().count();
-  auto const value_ms = spark_rapids_jni::integer_utils::floor_div(value_us, MICROS_PER_MILLI);
-  auto const offset_lookup_ms = wrapping_subtract(value_ms, reader.raw_offset);
-  auto const offset_ms        = get_transition_index(offset_lookup_ms, reader);
+  auto offset_ms      = reader.raw_offset;
+  if (!reader.is_fixed) {
+    auto const value_ms = spark_rapids_jni::integer_utils::floor_div(value_us, MICROS_PER_MILLI);
+    auto const offset_lookup_ms = wrapping_subtract(value_ms, reader.raw_offset);
+    offset_ms                   = get_transition_index(offset_lookup_ms, reader);
+  }
   auto const result_us =
     wrapping_subtract(value_us, static_cast<int64_t>(offset_ms) * MICROS_PER_MILLI);
   return cudf::timestamp_us{cudf::duration_us{result_us}};
@@ -835,17 +838,19 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
                               orc_tz_side_kernel_args reader_args)
 {
   extern __shared__ char smem[];
-  char* ptr = smem;
-  int64_t const *rt_begin, *rt_end;
-  int32_t const* ro_begin;
-  stage_side_transitions(reader_args.trans,
-                         reader_args.offsets,
-                         reader_args.trans_count,
-                         ptr,
-                         rt_begin,
-                         rt_end,
-                         ro_begin);
-  __syncthreads();
+  char* ptr               = smem;
+  int64_t const *rt_begin = nullptr, *rt_end = nullptr;
+  int32_t const* ro_begin = nullptr;
+  if (!reader_args.is_fixed) {
+    stage_side_transitions(reader_args.trans,
+                           reader_args.offsets,
+                           reader_args.trans_count,
+                           ptr,
+                           rt_begin,
+                           rt_end,
+                           ro_begin);
+    __syncthreads();
+  }
 
   cudf::size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_rows) {
@@ -855,7 +860,8 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
                               ro_begin,
                               reader_args.initial_offset,
                               reader_args.raw_offset,
-                              reader_args.dst};
+                              reader_args.dst,
+                              reader_args.is_fixed};
     output[idx] = convert_orc_from_utc_value(input[idx], reader);
   }
 }
@@ -879,6 +885,7 @@ std::unique_ptr<column> convert_orc_from_utc_typed(cudf::column_view const& inpu
   int32_t const* reader_offsets_ptr =
     reader.tz_info_table ? reader.tz_info_table->column(1).begin<int32_t>() : nullptr;
   int32_t reader_trans_count = reader.tz_info_table ? reader.tz_info_table->column(0).size() : 0;
+  auto const is_reader_fixed = reader_trans_count == 0 && !reader.dst.has_dst;
   size_t smem_bytes          = 0;
   if (reader_trans_count > 0 && reader_trans_count <= MAX_SMEM_TRANSITIONS) {
     smem_bytes = reader_trans_count * (sizeof(int64_t) + sizeof(int32_t));
@@ -889,7 +896,8 @@ std::unique_ptr<column> convert_orc_from_utc_typed(cudf::column_view const& inpu
                                                    reader_trans_count,
                                                    reader.initial_offset,
                                                    reader.raw_offset,
-                                                   reader.dst};
+                                                   reader.dst,
+                                                   is_reader_fixed};
   int32_t num_blocks       = cudf::util::div_rounding_up_safe(input.size(), CONVERT_TZ_BLOCK_SIZE);
   auto const launch_config = cuda::make_config(cuda::grid_dims(num_blocks),
                                                cuda::block_dims<CONVERT_TZ_BLOCK_SIZE>(),

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -673,24 +673,26 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
   // Shared memory layout: writer transitions, writer offsets, reader transitions, reader offsets
   extern __shared__ char smem[];
 
-  char* ptr = smem;
-  int64_t const *wt_begin, *wt_end, *rt_begin, *rt_end;
-  int32_t const *wo_begin, *ro_begin;
-  stage_side_transitions(writer_args.trans,
-                         writer_args.offsets,
-                         writer_args.trans_count,
-                         ptr,
-                         wt_begin,
-                         wt_end,
-                         wo_begin);
-  stage_side_transitions(reader_args.trans,
-                         reader_args.offsets,
-                         reader_args.trans_count,
-                         ptr,
-                         rt_begin,
-                         rt_end,
-                         ro_begin);
-  __syncthreads();
+  char* ptr               = smem;
+  int64_t const *wt_begin = nullptr, *wt_end = nullptr, *rt_begin = nullptr, *rt_end = nullptr;
+  int32_t const *wo_begin = nullptr, *ro_begin = nullptr;
+  if (writer_reader_rules_differ) {
+    stage_side_transitions(writer_args.trans,
+                           writer_args.offsets,
+                           writer_args.trans_count,
+                           ptr,
+                           wt_begin,
+                           wt_end,
+                           wo_begin);
+    stage_side_transitions(reader_args.trans,
+                           reader_args.offsets,
+                           reader_args.trans_count,
+                           ptr,
+                           rt_begin,
+                           rt_end,
+                           ro_begin);
+    __syncthreads();
+  }
 
   cudf::size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_rows) {
@@ -751,13 +753,15 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
   int32_t reader_trans_count = reader.tz_info_table ? reader.tz_info_table->column(0).size() : 0;
 
   size_t smem_bytes = 0;
-  if (writer_trans_count > 0 && writer_trans_count <= MAX_SMEM_TRANSITIONS) {
-    smem_bytes += writer_trans_count * (sizeof(int64_t) + sizeof(int32_t));
-  }
-  if (reader_trans_count > 0 && reader_trans_count <= MAX_SMEM_TRANSITIONS) {
-    // Alignment padding between writer offsets (int32_t) and reader transitions (int64_t)
-    smem_bytes = align_up(smem_bytes, alignof(int64_t));
-    smem_bytes += reader_trans_count * (sizeof(int64_t) + sizeof(int32_t));
+  if (writer_reader_rules_differ) {
+    if (writer_trans_count > 0 && writer_trans_count <= MAX_SMEM_TRANSITIONS) {
+      smem_bytes += writer_trans_count * (sizeof(int64_t) + sizeof(int32_t));
+    }
+    if (reader_trans_count > 0 && reader_trans_count <= MAX_SMEM_TRANSITIONS) {
+      // Alignment padding between writer offsets (int32_t) and reader transitions (int64_t)
+      smem_bytes = align_up(smem_bytes, alignof(int64_t));
+      smem_bytes += reader_trans_count * (sizeof(int64_t) + sizeof(int32_t));
+    }
   }
 
   int32_t num_blocks = cudf::util::div_rounding_up_safe(input.size(), CONVERT_TZ_BLOCK_SIZE);

--- a/src/main/cpp/src/timezones.cu
+++ b/src/main/cpp/src/timezones.cu
@@ -582,11 +582,13 @@ __device__ static cudf::timestamp_us convert_timestamp_between_timezones(
   cudf::timestamp_us ts,
   orc_base_offset_info writer_2015_year_base_offset,
   tz_side_info const& writer,
-  tz_side_info const& reader)
+  tz_side_info const& reader,
+  bool writer_reader_rules_differ)
 {
   int64_t const decoded_us = static_cast<int64_t>(
     cuda::std::chrono::duration_cast<cudf::duration_us>(ts.time_since_epoch()).count());
   int64_t const adjusted_us = apply_orc_base_offset(decoded_us, writer_2015_year_base_offset);
+  if (!writer_reader_rules_differ) { return cudf::timestamp_us{cudf::duration_us{adjusted_us}}; }
 
   // Floor-divide to get epoch millis (handles negative timestamps correctly)
   int64_t const epoch_millis =
@@ -665,7 +667,8 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
                            cudf::size_type input_offset,
                            orc_base_offset_info writer_2015_year_base_offset,
                            orc_tz_side_kernel_args writer_args,
-                           orc_tz_side_kernel_args reader_args)
+                           orc_tz_side_kernel_args reader_args,
+                           bool writer_reader_rules_differ)
 {
   // Shared memory layout: writer transitions, writer offsets, reader transitions, reader offsets
   extern __shared__ char smem[];
@@ -706,8 +709,8 @@ CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
                               reader_args.raw_offset,
                               reader_args.dst,
                               reader_args.is_fixed};
-    output[idx] =
-      convert_timestamp_between_timezones(input[idx], writer_2015_year_base_offset, writer, reader);
+    output[idx] = convert_timestamp_between_timezones(
+      input[idx], writer_2015_year_base_offset, writer, reader, writer_reader_rules_differ);
   }
 }
 
@@ -716,7 +719,8 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
                                           spark_rapids_jni::orc_tz_side writer,
                                           spark_rapids_jni::orc_tz_side reader,
                                           rmm::cuda_stream_view stream,
-                                          rmm::device_async_resource_ref mr)
+                                          rmm::device_async_resource_ref mr,
+                                          bool writer_reader_rules_differ)
 {
   SRJ_FUNC_RANGE();
 
@@ -789,9 +793,113 @@ std::unique_ptr<column> convert_timezones(cudf::column_view const& input,
                input.offset(),
                writer_2015_year_base_offset,
                writer_args,
-               reader_args);
+               reader_args,
+               writer_reader_rules_differ);
   CUDF_CHECK_CUDA(stream.value());
 
+  return results;
+}
+
+__device__ static int64_t wrapping_subtract(int64_t lhs, int64_t rhs)
+{
+  return static_cast<int64_t>(static_cast<uint64_t>(lhs) - static_cast<uint64_t>(rhs));
+}
+
+template <typename T>
+__device__ static T convert_orc_from_utc_value(T value, tz_side_info const& reader);
+
+template <>
+__device__ cudf::timestamp_us convert_orc_from_utc_value(cudf::timestamp_us value,
+                                                         tz_side_info const& reader)
+{
+  auto const value_us = value.time_since_epoch().count();
+  auto const value_ms = spark_rapids_jni::integer_utils::floor_div(value_us, MICROS_PER_MILLI);
+  auto const offset_lookup_ms = wrapping_subtract(value_ms, reader.raw_offset);
+  auto const offset_ms        = get_transition_index(offset_lookup_ms, reader);
+  auto const result_us =
+    wrapping_subtract(value_us, static_cast<int64_t>(offset_ms) * MICROS_PER_MILLI);
+  return cudf::timestamp_us{cudf::duration_us{result_us}};
+}
+
+template <typename T>
+CUDF_KERNEL void __launch_bounds__(CONVERT_TZ_BLOCK_SIZE)
+  convert_orc_from_utc_kernel(T const* __restrict__ input,
+                              cudf::bitmask_type const* __restrict__ null_mask,
+                              T* __restrict__ output,
+                              cudf::size_type num_rows,
+                              cudf::size_type input_offset,
+                              orc_tz_side_kernel_args reader_args)
+{
+  extern __shared__ char smem[];
+  char* ptr = smem;
+  int64_t const *rt_begin, *rt_end;
+  int32_t const* ro_begin;
+  stage_side_transitions(reader_args.trans,
+                         reader_args.offsets,
+                         reader_args.trans_count,
+                         ptr,
+                         rt_begin,
+                         rt_end,
+                         ro_begin);
+  __syncthreads();
+
+  cudf::size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < num_rows) {
+    if (null_mask && !cudf::bit_is_set(null_mask, idx + input_offset)) { return; }
+    tz_side_info const reader{rt_begin,
+                              rt_end,
+                              ro_begin,
+                              reader_args.initial_offset,
+                              reader_args.raw_offset,
+                              reader_args.dst};
+    output[idx] = convert_orc_from_utc_value(input[idx], reader);
+  }
+}
+
+template <typename T>
+std::unique_ptr<column> convert_orc_from_utc_typed(cudf::column_view const& input,
+                                                   spark_rapids_jni::orc_tz_side reader,
+                                                   rmm::cuda_stream_view stream,
+                                                   rmm::device_async_resource_ref mr)
+{
+  auto results = cudf::make_fixed_width_column(input.type(),
+                                               input.size(),
+                                               cudf::copy_bitmask(input, stream, mr),
+                                               input.null_count(),
+                                               stream,
+                                               mr);
+  if (input.size() == 0) { return results; }
+
+  int64_t const* reader_trans_ptr =
+    reader.tz_info_table ? reader.tz_info_table->column(0).begin<int64_t>() : nullptr;
+  int32_t const* reader_offsets_ptr =
+    reader.tz_info_table ? reader.tz_info_table->column(1).begin<int32_t>() : nullptr;
+  int32_t reader_trans_count = reader.tz_info_table ? reader.tz_info_table->column(0).size() : 0;
+  size_t smem_bytes          = 0;
+  if (reader_trans_count > 0 && reader_trans_count <= MAX_SMEM_TRANSITIONS) {
+    smem_bytes = reader_trans_count * (sizeof(int64_t) + sizeof(int32_t));
+  }
+
+  auto const reader_args   = orc_tz_side_kernel_args{reader_trans_ptr,
+                                                   reader_offsets_ptr,
+                                                   reader_trans_count,
+                                                   reader.initial_offset,
+                                                   reader.raw_offset,
+                                                   reader.dst};
+  int32_t num_blocks       = cudf::util::div_rounding_up_safe(input.size(), CONVERT_TZ_BLOCK_SIZE);
+  auto const launch_config = cuda::make_config(cuda::grid_dims(num_blocks),
+                                               cuda::block_dims<CONVERT_TZ_BLOCK_SIZE>(),
+                                               cuda::dynamic_shared_memory<char[]>(smem_bytes));
+  cuda::launch(stream.value(),
+               launch_config,
+               convert_orc_from_utc_kernel<T>,
+               input.begin<T>(),
+               input.null_mask(),
+               results->mutable_view().begin<T>(),
+               input.size(),
+               input.offset(),
+               reader_args);
+  CUDF_CHECK_CUDA(stream.value());
   return results;
 }
 
@@ -875,9 +983,22 @@ std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(
   orc_tz_side writer,
   orc_tz_side reader,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+  rmm::device_async_resource_ref mr,
+  bool writer_reader_rules_differ)
 {
-  return convert_timezones(input, writer_2015_year_base_offset_us, writer, reader, stream, mr);
+  return convert_timezones(
+    input, writer_2015_year_base_offset_us, writer, reader, stream, mr, writer_reader_rules_differ);
+}
+
+std::unique_ptr<cudf::column> convert_orc_from_utc(cudf::column_view const& input,
+                                                   orc_tz_side reader,
+                                                   rmm::cuda_stream_view stream,
+                                                   rmm::device_async_resource_ref mr)
+{
+  validate_timezone_table(reader.tz_info_table);
+  CUDF_EXPECTS(input.type().id() == cudf::type_id::TIMESTAMP_MICROSECONDS,
+               "ORC convertFromUtc input must be TIMESTAMP_MICROSECONDS");
+  return convert_orc_from_utc_typed<cudf::timestamp_us>(input, reader, stream, mr);
 }
 
 std::unique_ptr<cudf::column> convert_orc_writer_reader_timezones(

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -158,6 +158,8 @@ struct orc_tz_side {
  *        the same frame as Apache ORC. Pass 0 for no adjustment.
  * @param writer writer timezone transition data, offsets, and DST rule.
  * @param reader reader timezone transition data, offsets, and DST rule.
+ * @param writer_reader_rules_differ whether Apache ORC would call
+ *        SerializationUtils.convertBetweenTimezones for this timezone pair.
  * @param stream CUDA stream.
  * @param mr Device memory resource.
  * @return timestamps rebased between writer and reader timezones.
@@ -166,6 +168,22 @@ struct orc_tz_side {
   cudf::column_view const& input,
   int64_t writer_2015_year_base_offset_us,
   orc_tz_side writer,
+  orc_tz_side reader,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref(),
+  bool writer_reader_rules_differ   = true);
+
+/**
+ * @brief Apply Apache ORC SerializationUtils.convertFromUtc semantics.
+ *
+ * @param input TIMESTAMP_MICROSECONDS input column.
+ * @param reader reader timezone transition data, offsets, and DST rule.
+ * @param stream CUDA stream.
+ * @param mr Device memory resource.
+ * @return converted column with the same type as input.
+ */
+[[nodiscard]] std::unique_ptr<cudf::column> convert_orc_from_utc(
+  cudf::column_view const& input,
   orc_tz_side reader,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());

--- a/src/main/cpp/src/timezones.hpp
+++ b/src/main/cpp/src/timezones.hpp
@@ -181,6 +181,7 @@ struct orc_tz_side {
  * @param stream CUDA stream.
  * @param mr Device memory resource.
  * @return converted column with the same type as input.
+ * @throws cudf::logic_error If input is not TIMESTAMP_MICROSECONDS.
  */
 [[nodiscard]] std::unique_ptr<cudf::column> convert_orc_from_utc(
   cudf::column_view const& input,

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -602,8 +602,8 @@ public class GpuTimeZoneDB {
           readerTzInfo.transitions == null || readerTzInfo.transitions.length == 0
               ? Long.MIN_VALUE
               : TimeUnit.MILLISECONDS.toMicros(readerTzInfo.transitions[0]);
-      TimeZone writerTz = TimeZone.getTimeZone(getZoneId(writerTimezone).getId());
-      TimeZone readerTz = TimeZone.getTimeZone(getZoneId(readerTimezone).getId());
+      TimeZone writerTz = TimeZone.getTimeZone(getZoneId(writerTimezone));
+      TimeZone readerTz = TimeZone.getTimeZone(getZoneId(readerTimezone));
       this.writerReaderRulesDiffer = !writerTz.hasSameRules(readerTz);
     }
 

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -631,6 +631,10 @@ public class GpuTimeZoneDB {
 
     /**
      * Returns the reader timezone's first transition in the local ORC timestamp frame.
+     *
+     * @return the first transition in microseconds, or {@link Long#MIN_VALUE} if the reader
+     *         timezone has no transitions
+     * @throws IllegalStateException if this context is closed
      */
     public long getReaderFirstTransitionUs() {
       ensureOpen();

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -581,10 +581,13 @@ public class GpuTimeZoneDB {
     private final int readerInitialOffset;
     private final int readerRawOffset;
     private final int[] readerDstRule;
+    private final long readerFirstTransitionUs;
+    private final boolean writerReaderRulesDiffer;
     private boolean closed;
 
     private OrcTimezoneContext(Table writerTzInfoTable, Table readerTzInfoTable,
-        String writerTimezone, OrcTimezoneInfo writerTzInfo, OrcTimezoneInfo readerTzInfo) {
+        String writerTimezone, String readerTimezone,
+        OrcTimezoneInfo writerTzInfo, OrcTimezoneInfo readerTzInfo) {
       this.writerTzInfoTable = writerTzInfoTable;
       this.readerTzInfoTable = readerTzInfoTable;
       this.writerTzOffsetAtOrc2015BaseUs = TimeUnit.MILLISECONDS.toMicros(
@@ -595,6 +598,18 @@ public class GpuTimeZoneDB {
       this.readerInitialOffset = readerTzInfo.initialOffset;
       this.readerRawOffset = readerTzInfo.rawOffset;
       this.readerDstRule = dstRuleToArray(readerTzInfo.dstRule);
+      this.readerFirstTransitionUs =
+          readerTzInfo.transitions == null || readerTzInfo.transitions.length == 0
+              ? Long.MIN_VALUE
+              : TimeUnit.MILLISECONDS.toMicros(readerTzInfo.transitions[0]);
+      TimeZone writerTz = TimeZone.getTimeZone(getZoneId(writerTimezone).getId());
+      TimeZone readerTz = TimeZone.getTimeZone(getZoneId(readerTimezone).getId());
+      this.writerReaderRulesDiffer = !writerTz.hasSameRules(readerTz);
+    }
+
+    public long getReaderFirstTransitionUs() {
+      ensureOpen();
+      return readerFirstTransitionUs;
     }
 
     private void ensureOpen() {
@@ -634,7 +649,7 @@ public class GpuTimeZoneDB {
       writerTzInfoTable = getTableForUtilTZ(writerTzInfo);
       readerTzInfoTable = getTableForUtilTZ(readerTzInfo);
       return new OrcTimezoneContext(writerTzInfoTable, readerTzInfoTable,
-          writerTimezone, writerTzInfo, readerTzInfo);
+          writerTimezone, readerTimezone, writerTzInfo, readerTzInfo);
     } catch (RuntimeException | Error e) {
       try {
         Arms.closeAll(writerTzInfoTable, readerTzInfoTable);
@@ -667,7 +682,42 @@ public class GpuTimeZoneDB {
         context.readerTzInfoTable != null ? context.readerTzInfoTable.getNativeView() : 0L,
         context.readerInitialOffset,
         context.readerRawOffset,
+        context.readerDstRule,
+        context.writerReaderRulesDiffer));
+  }
+
+  /**
+   * Apply Apache ORC's {@code SerializationUtils.convertFromUtc} semantics using a pre-built
+   * ORC timezone context. The input must be TIMESTAMP_MICROSECONDS.
+   *
+   * @param input values to convert
+   * @param context timezone metadata whose reader side identifies the target timezone
+   * @return converted values with the same type as {@code input}
+   */
+  public static ColumnVector convertOrcFromUtc(
+      ColumnView input, OrcTimezoneContext context) {
+    context.ensureOpen();
+    return new ColumnVector(convertOrcFromUtcWithRules(
+        input.getNativeView(),
+        context.readerTzInfoTable != null ? context.readerTzInfoTable.getNativeView() : 0L,
+        context.readerInitialOffset,
+        context.readerRawOffset,
         context.readerDstRule));
+  }
+
+  /**
+   * Apply Apache ORC's {@code SerializationUtils.convertFromUtc} semantics.
+   *
+   * @param input TIMESTAMP_MICROSECONDS values
+   * @param readerTimezone target timezone
+   * @return converted values with the same type as {@code input}
+   */
+  public static ColumnVector convertOrcFromUtc(
+      ColumnView input, String readerTimezone) {
+    try (OrcTimezoneContext context =
+        buildOrcTimezoneContext(readerTimezone, readerTimezone)) {
+      return convertOrcFromUtc(input, context);
+    }
   }
 
   private static int[] dstRuleToArray(OrcDstRuleExtractor.DstRule rule) {
@@ -734,6 +784,14 @@ public class GpuTimeZoneDB {
       int writerTzInitialOffset,
       int writerTzRawOffset,
       int[] writerDstRule,
+      long readerTzInfoTable,
+      int readerTzInitialOffset,
+      int readerTzRawOffset,
+      int[] readerDstRule,
+      boolean writerReaderRulesDiffer);
+
+  private static native long convertOrcFromUtcWithRules(
+      long input,
       long readerTzInfoTable,
       int readerTzInitialOffset,
       int readerTzRawOffset,

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -622,12 +622,16 @@ public class GpuTimeZoneDB {
       this.readerFirstTransitionUs =
           readerTzInfo.transitions == null || readerTzInfo.transitions.length == 0
               ? Long.MIN_VALUE
-              : TimeUnit.MILLISECONDS.toMicros(readerTzInfo.transitions[0]);
+              : TimeUnit.MILLISECONDS.toMicros(
+                  readerTzInfo.transitions[0] + readerTzInfo.rawOffset);
       TimeZone writerTz = TimeZone.getTimeZone(getZoneId(writerTimezone));
       TimeZone readerTz = TimeZone.getTimeZone(getZoneId(readerTimezone));
       this.writerReaderRulesDiffer = !writerTz.hasSameRules(readerTz);
     }
 
+    /**
+     * Returns the reader timezone's first transition in the local ORC timestamp frame.
+     */
     public long getReaderFirstTransitionUs() {
       ensureOpen();
       return readerFirstTransitionUs;

--- a/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDB.java
@@ -532,15 +532,36 @@ public class GpuTimeZoneDB {
   }
 
   private static ColumnVector getTransitionsForUtilTZ(OrcTimezoneInfo info) {
-    try (HostColumnVector hcv = HostColumnVector.fromLongs(info.transitions)) {
+    long[] transitions = info.transitions;
+    if (needsTerminalOffsetSentinel(info)) {
+      transitions = Arrays.copyOf(transitions, transitions.length + 1);
+      transitions[transitions.length - 1] = Long.MAX_VALUE;
+    }
+    try (HostColumnVector hcv = HostColumnVector.fromLongs(transitions)) {
       return hcv.copyToDevice();
     }
   }
 
   private static ColumnVector getOffsetsForUtilTZ(OrcTimezoneInfo info) {
-    try (HostColumnVector hcv = HostColumnVector.fromInts(info.offsets)) {
+    int[] offsets = info.offsets;
+    if (needsTerminalOffsetSentinel(info)) {
+      offsets = Arrays.copyOf(offsets, offsets.length + 1);
+      offsets[offsets.length - 1] = offsets[offsets.length - 2];
+    }
+    try (HostColumnVector hcv = HostColumnVector.fromInts(offsets)) {
       return hcv.copyToDevice();
     }
+  }
+
+  private static boolean needsTerminalOffsetSentinel(OrcTimezoneInfo info) {
+    // Native lookup normally falls back to rawOffset beyond the last historical
+    // transition. Some JDK TimeZone implementations instead retain the final
+    // wall offset indefinitely. Keep every timestamp_us lookup inside the table
+    // with a Long.MAX_VALUE-millisecond sentinel when those offsets differ.
+    return info.dstRule == null
+        && info.offsets != null
+        && info.offsets.length > 0
+        && info.offsets[info.offsets.length - 1] != info.rawOffset;
   }
 
   private static Table getTableForUtilTZ(OrcTimezoneInfo info) {

--- a/src/main/java/com/nvidia/spark/rapids/jni/OrcDstRuleExtractor.java
+++ b/src/main/java/com/nvidia/spark/rapids/jni/OrcDstRuleExtractor.java
@@ -135,7 +135,6 @@ final class OrcDstRuleExtractor {
    *     {@code rules}
    * @param rules {@link ZoneRules} for the zone
    * @return the recurring DST rule, or {@code null} if the zone has no DST
-   *     ({@code rules.isFixedOffset()} or {@code !tz.useDaylightTime()})
    * @throws IllegalStateException if the zone reports DST but neither
    *     extraction path produces a usable rule — for example, an unsupported
    *     {@link ZoneRules#getTransitionRules()} count (not 0 and not 2), a
@@ -149,7 +148,7 @@ final class OrcDstRuleExtractor {
     // TimeZone.getTimeZone(zoneId) silently returns GMT for such ids on most
     // JVMs, which would leave `tz` describing a different zone than `rules`.
     // Mirrors the guard in OrcTimezoneInfo.buildRuntimeOrcTimezoneInfo.
-    if (rules.isFixedOffset() || !tz.useDaylightTime()) {
+    if (rules.isFixedOffset()) {
       return null;
     }
     // Sanity-check that tz and rules describe the same zone. Both Path A and
@@ -172,6 +171,12 @@ final class OrcDstRuleExtractor {
     DstRule rule = extractDstRuleByProbing(tz);
     if (rule != null) {
       return rule;
+    }
+    // Some JDK timezone implementations report useDaylightTime() == false even
+    // though getOffset() still applies a recurring DST rule in future years.
+    // ORC conversion follows getOffset(), so only trust this flag after probing.
+    if (!tz.useDaylightTime()) {
+      return null;
     }
     rule = extractDstRuleFromZoneRules(timezoneId, tz, rules);
     if (rule != null) {
@@ -351,7 +356,10 @@ final class OrcDstRuleExtractor {
   private static DstRule buildDstRuleFromProbedTransitions(TimeZone tz,
       DstTransitions transitions) {
     DstRule rule = new DstRule();
-    rule.dstSavings = tz.getDSTSavings();
+    rule.dstSavings = tz.useDaylightTime()
+        ? tz.getDSTSavings()
+        : tz.getOffset(transitions.dstOnTransition)
+            - tz.getOffset(transitions.dstOnTransition - 1);
 
     int[] startFields = decodeTransition(transitions.dstOnTransition, tz.getRawOffset());
     rule.startMonth = startFields[0];

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -323,6 +323,31 @@ public class GpuTimeZoneDBTest {
   }
 
   @Test
+  void testOrcTimezoneContextConversionFailures() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    try (ColumnVector input = ColumnVector.timestampMicroSecondsFromLongs(0L)) {
+      GpuTimeZoneDB.OrcTimezoneContext closed =
+          GpuTimeZoneDB.buildOrcTimezoneContext("UTC", "UTC");
+      closed.close();
+      assertThrows(IllegalStateException.class,
+          () -> GpuTimeZoneDB.convertOrcTimezones(input, closed));
+      assertThrows(IllegalStateException.class,
+          () -> GpuTimeZoneDB.convertOrcFromUtc(input, closed));
+    }
+
+    try (ColumnVector input = ColumnVector.timestampSecondsFromLongs(0L);
+        GpuTimeZoneDB.OrcTimezoneContext context =
+            GpuTimeZoneDB.buildOrcTimezoneContext("UTC", "UTC")) {
+      assertThrows(CudfException.class,
+          () -> GpuTimeZoneDB.convertOrcTimezones(input, context));
+      assertThrows(CudfException.class,
+          () -> GpuTimeZoneDB.convertOrcFromUtc(input, context));
+    }
+  }
+
+  @Test
   void testReaderFirstTransitionUs() {
     String transitionTzId = "Europe/Paris";
     OrcTimezoneInfo transitionInfo = OrcTimezoneInfo.get(transitionTzId);

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -324,11 +324,13 @@ public class GpuTimeZoneDBTest {
 
   @Test
   void testReaderFirstTransitionUs() {
-    String transitionTzId = "America/Los_Angeles";
+    String transitionTzId = "Europe/Paris";
     OrcTimezoneInfo transitionInfo = OrcTimezoneInfo.get(transitionTzId);
+    assertTrue(transitionInfo.rawOffset > 0);
     try (GpuTimeZoneDB.OrcTimezoneContext context =
         GpuTimeZoneDB.buildOrcTimezoneContext("UTC", transitionTzId)) {
-      assertEquals(TimeUnit.MILLISECONDS.toMicros(transitionInfo.transitions[0]),
+      assertEquals(TimeUnit.MILLISECONDS.toMicros(
+              transitionInfo.transitions[0] + transitionInfo.rawOffset),
           context.getReaderFirstTransitionUs());
     }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -43,7 +43,7 @@ public class GpuTimeZoneDBTest {
   private static final long MICROS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
 
   private static TimeZone getTimeZoneForOrc(String timezoneId) {
-    return TimeZone.getTimeZone(GpuTimeZoneDB.getZoneId(timezoneId).getId());
+    return TimeZone.getTimeZone(GpuTimeZoneDB.getZoneId(timezoneId));
   }
 
   private static long orc2015YearBaseOffsetUs(String timezoneId) {
@@ -187,6 +187,30 @@ public class GpuTimeZoneDBTest {
         ColumnVector actual =
             GpuTimeZoneDB.convertOrcTimezones(input, "Asia/Shanghai", "Asia/Shanghai")) {
       assertColumnsAreEqual(expected, actual);
+    }
+  }
+
+  @Test
+  void testConvertOrcTimezonesFixedOffsetIds() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    long[] microseconds = {0L, -1L, 1L, -2_957_649_381_472_612L};
+    String[][] cases = {
+        {"UTC", "+05:30"},
+        {"+05:30", "UTC"},
+        {"UTC", "EST"},
+        {"EST", "UTC"}
+    };
+
+    for (String[] timezones : cases) {
+      try (ColumnVector input = ColumnVector.timestampMicroSecondsFromLongs(microseconds);
+          ColumnVector expected =
+              convertOrcTimezonesOnCPU(microseconds, timezones[0], timezones[1]);
+          ColumnVector actual =
+              GpuTimeZoneDB.convertOrcTimezones(input, timezones[0], timezones[1])) {
+        assertColumnsAreEqual(expected, actual);
+      }
     }
   }
 

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -31,6 +31,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.zone.ZoneOffsetTransition;
 import java.time.zone.ZoneOffsetTransitionRule;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -127,6 +128,65 @@ public class GpuTimeZoneDBTest {
     return ColumnVector.timestampMicroSecondsFromLongs(results);
   }
 
+  private static ColumnVector convertOrcFromUtcOnCPU(
+      Long[] microseconds,
+      String readerTzId) {
+    Long[] results = new Long[microseconds.length];
+    TimeZone readerTz = getTimeZoneForOrc(readerTzId);
+    for (int i = 0; i < microseconds.length; ++i) {
+      Long valueUs = microseconds[i];
+      if (valueUs != null) {
+        long valueMillis = Math.floorDiv(valueUs, microsPerMillis);
+        int offsetMillis = readerTz.getOffset(valueMillis - readerTz.getRawOffset());
+        results[i] = (valueMillis - offsetMillis) * microsPerMillis
+            + Math.floorMod(valueUs, microsPerMillis);
+      }
+    }
+    return ColumnVector.timestampMicroSecondsFromBoxedLongs(results);
+  }
+
+  private static Long[] getOrcFromUtcBoundaryMicros(String readerTzId) {
+    List<Long> values = new ArrayList<>(Arrays.asList(
+        null,
+        Long.MIN_VALUE,
+        Long.MIN_VALUE + 1,
+        -3_649_379_812_521_628L,
+        -2_957_649_381_472_612L,
+        -1_501L,
+        -1_001L,
+        -999L,
+        -1L,
+        0L,
+        1L,
+        999L,
+        1_001L,
+        514_952_012L,
+        Long.MAX_VALUE - 1,
+        Long.MAX_VALUE));
+
+    OrcTimezoneInfo readerInfo = OrcTimezoneInfo.get(readerTzId);
+    if (readerInfo.transitions != null) {
+      for (long transitionMillis : readerInfo.transitions) {
+        long localTransitionUs =
+            TimeUnit.MILLISECONDS.toMicros(transitionMillis + readerInfo.rawOffset);
+        values.add(localTransitionUs - 1);
+        values.add(localTransitionUs);
+        values.add(localTransitionUs + 1);
+      }
+    }
+
+    for (ZoneOffsetTransitionRule rule :
+        GpuTimeZoneDB.getZoneId(readerTzId).getRules().getTransitionRules()) {
+      long transitionMillis = rule.createTransition(2099).getInstant().toEpochMilli();
+      long localTransitionUs =
+          TimeUnit.MILLISECONDS.toMicros(transitionMillis + readerInfo.rawOffset);
+      values.add(localTransitionUs - 1);
+      values.add(localTransitionUs);
+      values.add(localTransitionUs + 1);
+    }
+    return values.toArray(new Long[0]);
+  }
+
   @Test
   void testIsSupportedTimeZone() {
     // Named zones with ZoneRules.
@@ -212,6 +272,70 @@ public class GpuTimeZoneDBTest {
         assertColumnsAreEqual(expected, actual);
       }
     }
+  }
+
+  @Test
+  void testConvertOrcFromUtcAllTimezones() {
+    GpuTimeZoneDB.cacheDatabase();
+    GpuTimeZoneDB.verifyDatabaseCached();
+
+    List<String> timezones = Arrays.asList(
+        "UTC",
+        "America/New_York",
+        "America/Los_Angeles",
+        "Europe/Paris",
+        "Asia/Shanghai",
+        "Australia/Sydney",
+        "US/Pacific",
+        "PST",
+        "EST",
+        "+05:30");
+
+    for (String readerTzId : timezones) {
+      Long[] values = getOrcFromUtcBoundaryMicros(readerTzId);
+      Long[] padded = new Long[values.length + 2];
+      padded[0] = 123L;
+      System.arraycopy(values, 0, padded, 1, values.length);
+      padded[padded.length - 1] = 456L;
+
+      try (ColumnVector full = ColumnVector.timestampMicroSecondsFromBoxedLongs(padded);
+          ColumnVector input = full.subVector(1, values.length + 1);
+          ColumnVector expected = convertOrcFromUtcOnCPU(values, readerTzId);
+          GpuTimeZoneDB.OrcTimezoneContext context =
+              GpuTimeZoneDB.buildOrcTimezoneContext("UTC", readerTzId);
+          ColumnVector fromContext = GpuTimeZoneDB.convertOrcFromUtc(input, context);
+          ColumnVector fromTimezone = GpuTimeZoneDB.convertOrcFromUtc(input, readerTzId)) {
+        assertColumnsAreEqual(expected, fromContext);
+        assertColumnsAreEqual(expected, fromTimezone);
+      }
+    }
+
+    try (ColumnVector empty =
+            ColumnVector.timestampMicroSecondsFromBoxedLongs(new Long[] {});
+        ColumnVector actual = GpuTimeZoneDB.convertOrcFromUtc(empty, "UTC")) {
+      assertColumnsAreEqual(empty, actual);
+    }
+  }
+
+  @Test
+  void testReaderFirstTransitionUs() {
+    String transitionTzId = "America/Los_Angeles";
+    OrcTimezoneInfo transitionInfo = OrcTimezoneInfo.get(transitionTzId);
+    try (GpuTimeZoneDB.OrcTimezoneContext context =
+        GpuTimeZoneDB.buildOrcTimezoneContext("UTC", transitionTzId)) {
+      assertEquals(TimeUnit.MILLISECONDS.toMicros(transitionInfo.transitions[0]),
+          context.getReaderFirstTransitionUs());
+    }
+
+    try (GpuTimeZoneDB.OrcTimezoneContext context =
+        GpuTimeZoneDB.buildOrcTimezoneContext("UTC", "+05:30")) {
+      assertEquals(Long.MIN_VALUE, context.getReaderFirstTransitionUs());
+    }
+
+    GpuTimeZoneDB.OrcTimezoneContext closed =
+        GpuTimeZoneDB.buildOrcTimezoneContext("UTC", "UTC");
+    closed.close();
+    assertThrows(IllegalStateException.class, closed::getReaderFirstTransitionUs);
   }
 
   @Test

--- a/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/GpuTimeZoneDBTest.java
@@ -146,10 +146,14 @@ public class GpuTimeZoneDBTest {
   }
 
   private static Long[] getOrcFromUtcBoundaryMicros(String readerTzId) {
+    long minSupportedUs = LocalDateTime.of(1, 1, 1, 0, 0)
+        .toEpochSecond(ZoneOffset.UTC) * MICROS_PER_SECOND;
+    long maxSupportedUs = LocalDateTime.of(9999, 12, 31, 23, 59, 59)
+        .toEpochSecond(ZoneOffset.UTC) * MICROS_PER_SECOND + 999_999L;
     List<Long> values = new ArrayList<>(Arrays.asList(
         null,
-        Long.MIN_VALUE,
-        Long.MIN_VALUE + 1,
+        minSupportedUs,
+        minSupportedUs + 1,
         -3_649_379_812_521_628L,
         -2_957_649_381_472_612L,
         -1_501L,
@@ -161,8 +165,8 @@ public class GpuTimeZoneDBTest {
         999L,
         1_001L,
         514_952_012L,
-        Long.MAX_VALUE - 1,
-        Long.MAX_VALUE));
+        maxSupportedUs - 1,
+        maxSupportedUs));
 
     OrcTimezoneInfo readerInfo = OrcTimezoneInfo.get(readerTzId);
     if (readerInfo.transitions != null) {
@@ -282,6 +286,7 @@ public class GpuTimeZoneDBTest {
     List<String> timezones = Arrays.asList(
         "UTC",
         "America/New_York",
+        "America/Vancouver",
         "America/Los_Angeles",
         "Europe/Paris",
         "Asia/Shanghai",
@@ -354,6 +359,7 @@ public class GpuTimeZoneDBTest {
 
     List<String> timezones = Arrays.asList(
         "America/Los_Angeles",
+        "America/Vancouver",
         "America/Cancun",
         "Asia/Shanghai",
         "Antarctica/DumontDUrville",

--- a/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
+++ b/src/test/java/com/nvidia/spark/rapids/jni/OrcTimezoneInfoTest.java
@@ -31,9 +31,11 @@ import java.time.zone.ZoneOffsetTransitionRule;
 import java.time.zone.ZoneRules;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -400,8 +402,48 @@ public class OrcTimezoneInfoTest {
   @Test
   void testExtractDstRuleNoDstReturnsNull() {
     // Asia/Shanghai had DST historically (1940s, 1986-1991) but no current rule.
-    // tz.useDaylightTime() must be false → extractDstRule returns null.
+    // Probing finds no recurring transitions and useDaylightTime() is false.
     assertNull(extractDstRuleFor("Asia/Shanghai"));
+  }
+
+  @Test
+  void testExtractDstRuleProbesBeforeUsingDaylightFlag() {
+    TimeZone tz = new SimpleTimeZone(
+        -8 * 3_600_000,
+        "Synthetic/FalseDaylightFlag",
+        Calendar.MARCH,
+        2,
+        Calendar.SUNDAY,
+        2 * 3_600_000,
+        Calendar.NOVEMBER,
+        1,
+        Calendar.SUNDAY,
+        2 * 3_600_000,
+        3_600_000) {
+      @Override
+      public boolean useDaylightTime() {
+        return false;
+      }
+    };
+    ZoneOffset baseOffset = ZoneOffset.ofHours(-8);
+    ZoneOffsetTransition historical = ZoneOffsetTransition.of(
+        LocalDateTime.of(1900, 1, 1, 0, 0),
+        ZoneOffset.ofHours(-9),
+        baseOffset);
+    ZoneRules rules = ZoneRules.of(
+        baseOffset,
+        baseOffset,
+        Collections.emptyList(),
+        Collections.singletonList(historical),
+        Collections.emptyList());
+
+    assertFalse(tz.useDaylightTime());
+    OrcDstRuleExtractor.DstRule rule = OrcDstRuleExtractor.extractDstRule(
+        tz.getID(), tz, rules);
+    assertNotNull(rule);
+    assertEquals(3_600_000, rule.dstSavings);
+    assertEquals(Calendar.MARCH, rule.startMonth);
+    assertEquals(Calendar.NOVEMBER, rule.endMonth);
   }
 
   @Test


### PR DESCRIPTION
Contributes to NVIDIA/cudf-spark#15449.

### Description

GPU ORC timestamp conversion needs to match Apache ORC's
`java.util.TimeZone` semantics for writer and reader timezones.

This change:

- preserves ORC's `TimeZone.hasSameRules` behavior so same-rule writer/reader
  pairs skip cross-timezone conversion;
- preserves fixed-offset and short timezone IDs by resolving
  `TimeZone` directly from `ZoneId`;
- adds an ORC-compatible `convertFromUtc` path for timestamp columns;
- exposes the reader timezone's first transition so the plugin can limit
  historical rule correction to values before that transition;
- preserves Java/ORC overflow, negative timestamp, null-mask, sliced-column,
  CUDA stream, and memory-resource behavior.

Without the direct `ZoneId` overload, values such as `+05:30` and short IDs
such as `EST` were silently interpreted as GMT when checking
`hasSameRules`. That could incorrectly skip conversion and produce a constant
timezone offset error.

### Testing

- `GpuTimeZoneDBTest`: `8 passed`, including `UTC` in both directions with
  `+05:30` and `EST`.
- `pre-commit` checks passed; no C/C++/CUDA files were changed by the follow-up
  fixed-offset commit.
- CUDA 12 container build: `BUILD SUCCESS`.
- Dependent cuDF Spark A/B:
  - baseline reproduced all 7 fixed-seed failures;
  - fixed build passed the same 7 cases.
