### PR TITLE
26.08: Fix nvCOMP native dependency loading (cherry-pick #4881)

### DIFF
--- a/patches/0001-use-static-nvcomp-from-libcudf.patch
+++ b/patches/0001-use-static-nvcomp-from-libcudf.patch
@@ -1,0 +1,14 @@
+diff --git a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+index 0ab9ec79d1..3d42449128 100755
+--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
++++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+@@ -69,9 +69,6 @@ public class NativeDepsLoader {
+    * subsequent stages are loaded.
+    */
+   private static final String[][] loadOrder = new String[][]{
+-      new String[]{
+-          "nvcomp"
+-      },
+       new String[]{
+           "cudf"
+       },

--- a/pom.xml
+++ b/pom.xml
@@ -570,14 +570,6 @@
                     <include>libprofilerjni.so</include>
                   </includes>
                 </resource>
-                <resource>
-                  <directory>${libcudfjni.build.path}</directory>
-                  <includes>
-                    <include>libnvcomp.so</include>
-                    <include>libnvcomp_gdeflate.so</include>
-                    <include>libnvcomp_bitcomp.so</include>
-                  </includes>
-                </resource>
               </resources>
             </configuration>
           </execution>

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -62,6 +62,7 @@ option(BUILD_TESTS "Configure CMake to build tests" OFF)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 option(BUILD_FAULTINJ "Configure CMake to build fault injection" ON)
 option(BUILD_PROFILER "Configure CMake to build profiler" ON)
+option(HIDE_PRIVATE_CUDA_SYMBOLS "Hide private symbols from static CUDA compiler libraries" ON)
 
 message(
   VERBOSE "SPARK_RAPIDS_JNI: Build with per-thread default stream:
@@ -70,6 +71,9 @@ message(
 message(VERBOSE "SPARK_RAPIDS_JNI: Configure CMake to build tests: ${BUILD_TESTS}")
 message(VERBOSE "SPARK_RAPIDS_JNI: Configure CMake to build (nvbench) benchmarks: ${BUILD_BENCHMARKS}")
 message(VERBOSE "SPARK_RAPIDS_JNI: Configure CMake to build fault injection: ${BUILD_FAULTINJ}")
+message(VERBOSE
+        "SPARK_RAPIDS_JNI: Hide private static CUDA compiler symbols: ${HIDE_PRIVATE_CUDA_SYMBOLS}"
+)
 
 set(SPARK_RAPIDS_JNI_BUILD_TESTS ${BUILD_TESTS})
 set(SPARK_RAPIDS_JNI_BUILD_BENCHMARKS ${BUILD_BENCHMARKS})
@@ -349,6 +353,18 @@ target_link_libraries(
     ${PARQUET_LIB}
     ${THRIFT_LIB}
 )
+if(HIDE_PRIVATE_CUDA_SYMBOLS)
+  # These toolkit implementation symbols are not part of the cuDF or JNI ABI. Localizing them keeps
+  # the regular ELF symbol table for diagnostics while removing them from the dynamic export table.
+  target_link_options(
+    spark_rapids_jni
+    PRIVATE "LINKER:--exclude-libs,libnvrtc_static.a"
+            "LINKER:--exclude-libs,libnvrtc-builtins_static.a"
+            "LINKER:--exclude-libs,libnvptxcompiler_static.a"
+            "LINKER:--exclude-libs,libnvJitLink_static.a"
+            "LINKER:--exclude-libs,libnvcomp_static.a"
+  )
+endif()
 rapids_cuda_set_runtime(spark_rapids_jni USE_STATIC ON)
 set_target_properties(spark_rapids_jni PROPERTIES LINK_LANGUAGE "CXX")
 # For backwards-compatibility with the cudf Java bindings and RAPIDS accelerated UDFs,


### PR DESCRIPTION
Fixes NVIDIA/cudf-spark#15427. Cherry-picks #4881 into `release/26.08`.

### Description

The `release/26.08` submodule-sync to cuDF `4a902a20dd` fails pre-merge with `Tests run: 2038, Failures: 4, Errors: 1949`, nearly all of them `UnsatisfiedLinkError` / `NoClassDefFoundError` on `ai.rapids.cudf` native methods.

cuDF's JNI `CMakeLists.txt` used to copy `libnvcomp.so` into the JNI build directory unconditionally for Maven to package it into `amd64/Linux`. rapidsai/cudf#23456 made that copy conditional on nvCOMP being linked dynamically. This build uses `CUDF_BUILD_STATIC_DEPS=FORCE`, under which cuDF links `nvcomp_static` into `libcudf.so` and never produces a `libnvcomp.so`. cuDF's `NativeDepsLoader` still lists `nvcomp` as the first stage of its `loadOrder`, so it fails with `FileNotFoundException: Could not locate native dependency amd64/Linux/libnvcomp.so` and aborts before loading `libcudf` at all — after which every native call throws. See analysis in https://github.com/NVIDIA/cudf-spark/issues/15427#issuecomment-5153553604.

#4881 already fixed this on `main` by patching the `nvcomp` entry out of `loadOrder` and dropping the nvCOMP shared libraries from the packaged resources, so what is loaded matches what is actually linked. This cherry-picks that commit unchanged, including the `--exclude-libs` symbol localization it carries.

The commit does not touch the `thirdparty/cudf` pointer, so it can merge ahead of the blocked submodule-sync.

### Testing

Built and tested `release/26.08` with `thirdparty/cudf` bumped to `4a902a20dd` — the state the failing submodule-sync produced — plus this commit:

- Full `mvn verify`: BUILD SUCCESS, `Tests run: 2171, Failures: 0, Errors: 0, Skipped: 5`
- `ai.rapids.cudf.nvcomp.NvcompTest`: 2 passed; `ai.rapids.cudf.NativeDepsLoaderTest`: 4 passed
- No `UnsatisfiedLinkError` or `Could not locate native dependency` anywhere in the log
- Packaged jar contains `libcudf.so`, `libcudfjni.so`, `libcufilejni.so`, `libnvmljni.so`, and `libprofilerjni.so`, with no nvCOMP shared library