### PR TITLE
[26.08] Route premerge Thrift downloads through sw-spark-maven

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -315,7 +315,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
 void runPremergeBuild() {
     common.prepareArtNetrc(this)
     withEnv([
-        "ARROW_THRIFT_MIRROR_URL=https://${env.ARTIFACTORY_NAME}/artifactory/apache-remote",
+        "ARROW_THRIFT_MIRROR_URL=https://${env.ARTIFACTORY_NAME}/artifactory/sw-spark-maven/apache-remote",
         "CMAKE_NETRC=OPTIONAL",
     ]) {
         sh 'source build/env.sh && ${sclCMD} "ci/premerge-build.sh"'


### PR DESCRIPTION

- Point the premerge ARROW_THRIFT_MIRROR_URL at the sw-spark-maven Apache remote, as CI only have the permission to the mirror dir under artifactory/sw-spark-maven/.
- Continue using the Artifactory host configured by Jenkins.


Newer cuDF builds require the Arrow Thrift dependency. The repository-specific path allows Jenkins to resolve that dependency through the internal mirror instead of the incorrect root apache-remote path.


Related issue: https://github.com/NVIDIA/cudf-spark-jni/issues/4923