### PR TITLE
[CI] Use dedicated Apache mirror for Thrift

### DIFF
--- a/ci/Jenkinsfile.premerge
+++ b/ci/Jenkinsfile.premerge
@@ -313,12 +313,17 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
 } // end of pipeline
 
 void runPremergeBuild() {
+    // CMake uses ~/.netrc to authenticate to the Apache mirror. Redact credentials
+    // from failed downloads via cuDF CMake/libcurl CLI before Jenkins logs them.
     common.prepareArtNetrc(this)
     withEnv([
-        "ARROW_THRIFT_MIRROR_URL=https://${env.ARTIFACTORY_NAME}/artifactory/sw-spark-maven/apache-remote",
+        "ARROW_THRIFT_MIRROR_URL=https://${env.ARTIFACTORY_NAME}/artifactory/sw-spark-apache-remote",
         "CMAKE_NETRC=OPTIONAL",
     ]) {
-        sh 'source build/env.sh && ${sclCMD} "ci/premerge-build.sh"'
+        common.shWithRedactedAuthorization(
+            this,
+            'source build/env.sh && ${sclCMD} "ci/premerge-build.sh"'
+        )
     }
 }
 


### PR DESCRIPTION
To fix https://github.com/NVIDIA/cudf-spark-jni/issues/4942

Update the premerge build to download Arrow's Apache Thrift tarball through sw-spark-apache-remote instead of sw-spark-maven/apache-remote.

The dedicated Generic Artifactory remote is backed by archive.apache.org and automatically caches Apache tarballs, avoiding the manual uploads required by the Maven repository path.

Continue authenticating through ~/.netrc with CMAKE_NETRC=OPTIONAL, and run the cuDF build through common.shWithRedactedAuthorization so CMake/libcurl failures cannot expose credentials in the Jenkins console while pipefail preserves the original command failure.

